### PR TITLE
fixed temporal quadrature formula order for higher order dG methods

### DIFF
--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -343,8 +343,8 @@ void Step1::assemble_system_on_slab ()
 {
 
     // Similar to the stationary case we start with a quadrature and FEValues objects
-    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 1 ,
-                                            fe.temporal ()->degree + 1 );
+    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 2 ,
+                                            fe.temporal ()->degree + 2 );
 
     idealii::spacetime::FEValues < 2 > fe_values_spacetime (
             fe ,

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -334,7 +334,7 @@ void Step2::setup_system_on_slab ()
 void Step2::assemble_system_on_slab ()
 {
     idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 3 ,
-                                            fe.temporal ()->degree + 1 );
+                                            fe.temporal ()->degree + 2 );
 
     idealii::spacetime::FEValues < 2 > fe_values_spacetime (
             fe ,

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -338,8 +338,8 @@ void Step3::setup_system_on_slab ()
 void Step3::assemble_system_on_slab ()
 {
 
-    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 1 ,
-                                            fe.temporal ()->degree + 1 );
+    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 2 ,
+                                            fe.temporal ()->degree + 2 );
 
     idealii::spacetime::FEValues < 2 > fe_values_spacetime (
             fe ,

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -407,8 +407,8 @@ void Step4::assemble_system_on_slab ()
 {
 
     slab_system_matrix = 0;
-    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 1 ,
-                                            fe.temporal ()->degree + 1 );
+    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 3 ,
+                                            fe.temporal ()->degree + 2 );
 
     idealii::spacetime::FEValues < 2 > fe_values_spacetime (
             fe ,
@@ -605,8 +605,8 @@ void Step4::assemble_system_on_slab ()
 void Step4::assemble_residual_on_slab ()
 {
     slab_system_rhs = 0;
-    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 1 ,
-                                            fe.temporal ()->degree + 1 );
+    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 3 ,
+                                            fe.temporal ()->degree + 2 );
 
     idealii::spacetime::FEValues < 2 > fe_values_spacetime (
             fe ,


### PR DESCRIPTION
r+1 lead to problems with dG(2) and with the nonlinear solver of the Navier-Stokes equations,
so a higher order quadrature was needed. Set to r+2 in all examples.