### PR TITLE
Added get_function_ methods to FEValues and FEJumpValues

### DIFF
--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -204,7 +204,9 @@ Step4::Step4 ( unsigned int temporal_degree )
     dof_handler ( &triangulation ),
     fe ( std::make_shared < dealii::FESystem< 2 >>
              ( dealii::FE_Q < 2 > ( 2 ) , 2 , dealii::FE_Q < 2 > ( 1 ) , 1 ) ,
-         temporal_degree ),
+         temporal_degree,
+         idealii::spacetime::DG_FiniteElement<2>::support_type::Legendre
+    ),
     slab ( 0 )
 {
 }
@@ -227,7 +229,7 @@ void Step4::make_grid ()
     static const dealii::SphericalManifold<2> boundary ( p );
     dealii::GridTools::copy_boundary_to_manifold_id ( *space_tria );
     space_tria->set_manifold ( 80 , boundary );
-    const unsigned int M = 128;
+    const unsigned int M = 256;
     triangulation.generate ( space_tria , M , 0 , 8. );
     triangulation.refine_global ( 2 , 0 );
     dof_handler.generate ();
@@ -251,13 +253,15 @@ void Step4::time_marching ()
     {
         pout << "Starting time-step ("
              << slab_its.tria->startpoint () << ","
-             << slab_its.tria->endpoint () << "]"
+             << slab_its.tria->endpoint () << ")"
              << std::endl;
 
         pout << "setup system" << std::endl;
         setup_system_on_slab ();
         solve_Newton_problem_on_slab ();
         output_results_on_slab ();
+        // As in step-3 we need to extract the solution at the final time point as the
+        // final DoF is not in the same location for Legendre support points
         idealii::slab::VectorTools::extract_subvector_at_time_point ( *slab_its.dof ,
                                                                       *slab_its.solution ,
                                                                       slab_initial_value ,
@@ -297,7 +301,6 @@ void Step4::setup_system_on_slab ()
         slab_initial_value = 0;
     }
 
-    pout << "calculating constraints" << std::endl;
     // We need two sets of constraints
     // The correct boundary conditions are prescribed on the initial Newton guess
     // and so all Dirichlet boundary conditions on the Newton update need to be
@@ -436,10 +439,10 @@ void Step4::assemble_system_on_slab ()
     dealii::TrilinosWrappers::MPI::Vector solution_extract;
     solution_extract.reinit ( space_locally_owned_dofs , space_locally_relevant_dofs , mpi_comm );
 
-    std::vector<dealii::Vector<double>> old_solution_values ( n_quad_space , dealii::Vector<double> ( 3 ) );
+    std::vector<dealii::Vector<double>> old_solution_values ( n_quad_spacetime , dealii::Vector<double> ( 3 ) );
 
-    std::vector < std::vector<dealii::Tensor<1,2> > > old_solution_grad ( n_quad_space ,
-                                                                          std::vector<dealii::Tensor<1,2>> ( 3 ) );
+    std::vector < std::vector<dealii::Tensor<1,2> > > old_solution_grads ( n_quad_spacetime ,
+                                                                           std::vector<dealii::Tensor<1,2>> ( 3 ) );
     for ( const auto &cell_space : slab_its.dof->spatial ()->active_cell_iterators () )
     {
         // We only can calculate the contributions of processor local cells
@@ -460,26 +463,20 @@ void Step4::assemble_system_on_slab ()
                 fe_jump_values_spacetime.reinit_time ( cell_time );
                 fe_values_spacetime.get_local_dof_indices ( local_spacetime_dof_index );
 
+                fe_values_spacetime.get_function_values( *slab_its.solution, old_solution_values );
+
+                fe_values_spacetime.get_function_space_gradients( *slab_its.solution , old_solution_grads );
                 for ( unsigned int q = 0 ; q < n_quad_spacetime ; ++q )
                 {
 
-                    idealii::slab::VectorTools::extract_subvector_at_time_point (
-                            *slab_its.dof , *slab_its.solution , solution_extract ,
-                            fe_values_spacetime.time_quadrature_point ( q ) );
-
-                    fe_values_spacetime.spatial ()->get_function_values ( solution_extract , old_solution_values );
-
-                    fe_values_spacetime.spatial ()->get_function_gradients ( solution_extract , old_solution_grad );
-
-                    unsigned int q_s = q % n_quad_space;
                     dealii::Tensor < 1 , 2 > v;
                     dealii::Tensor < 2 , 2 > grad_v;
                     for ( int c = 0 ; c < 2 ; c++ )
                     {
-                        v[c] = old_solution_values[q_s] ( c );
+                        v[c] = old_solution_values[q] ( c );
                         for ( int d = 0 ; d < 2 ; d++ )
                         {
-                            grad_v[c][d] = old_solution_grad[q_s][c][d];
+                            grad_v[c][d] = old_solution_grads[q][c][d];
                         }
                     }
                     for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
@@ -493,8 +490,8 @@ void Step4::assemble_system_on_slab ()
                                           j + n * dofs_per_spacetime_cell )
                             += fe_values_spacetime.vector_value ( velocity , i , q ) *
                                (
-                                       fe_values_spacetime.vector_space_grad ( velocity , j , q ) * v
-                                       + grad_v * fe_values_spacetime.vector_value ( velocity , j , q )
+                                   fe_values_spacetime.vector_space_grad ( velocity , j , q ) * v
+                                   + grad_v * fe_values_spacetime.vector_value ( velocity , j , q )
                                ) * fe_values_spacetime.JxW ( q );
 
                             // (phi, dt v)
@@ -606,14 +603,16 @@ void Step4::assemble_residual_on_slab ()
     dealii::TrilinosWrappers::MPI::Vector solution_extract;
     solution_extract.reinit ( space_locally_owned_dofs , space_locally_relevant_dofs , mpi_comm );
 
-    std::vector<dealii::Vector<double>> old_solution_values ( n_quad_space , dealii::Vector<double> ( 3 ) );
+    std::vector<dealii::Vector<double>> old_solution_values ( n_quad_spacetime , dealii::Vector<double> ( 3 ) );
 
-    std::vector < std::vector<dealii::Tensor<1,2> > > old_solution_grad (
-            n_quad_space , std::vector<dealii::Tensor<1,2>> ( 3 ) );
+    std::vector<dealii::Vector<double>> old_solution_dt ( n_quad_spacetime , dealii::Vector<double> ( 3 ) );
 
-    std::vector<dealii::Tensor<1,2>> solution_minus ( fe_values_spacetime.spatial ()->n_quadrature_points );
+    std::vector < std::vector<dealii::Tensor<1,2> > >
+        old_solution_grads ( n_quad_spacetime , std::vector<dealii::Tensor<1,2>> ( 3 ) );
 
-    std::vector<dealii::Tensor<1,2>> solution_plus ( fe_values_spacetime.spatial ()->n_quadrature_points );
+    std::vector<dealii::Tensor<1,2>> solution_minus ( n_quad_space );
+
+    std::vector<dealii::Tensor<1,2>> solution_plus ( n_quad_space );
 
     for ( const auto &cell_space : slab_its.dof->spatial ()->active_cell_iterators () )
     {
@@ -636,31 +635,28 @@ void Step4::assemble_residual_on_slab ()
                     fe_values_spacetime.spatial ()->operator[] ( velocity ).get_function_values ( slab_initial_value ,
                                                                                                   solution_minus );
                 }
+
+                fe_values_spacetime.get_function_values( *slab_its.solution, old_solution_values );
+
+                fe_values_spacetime.get_function_dt( *slab_its.solution , old_solution_dt );
+
+                fe_values_spacetime.get_function_space_gradients( *slab_its.solution , old_solution_grads );
+
                 for ( unsigned int q = 0 ; q < n_quad_spacetime ; ++q )
                 {
 
-                    // Exctract the FE solution at the temporal quadrature point
-                    // resulting in a spatial vector
-                    idealii::slab::VectorTools::extract_subvector_at_time_point (
-                            *slab_its.dof , *slab_its.solution , solution_extract ,
-                            fe_values_spacetime.time_quadrature_point ( q ) );
-
-                    //get the solution at the spatial quadrature points
-                    fe_values_spacetime.spatial ()->get_function_values ( solution_extract , old_solution_values );
-
-                    // get the spatial gradient of the solution
-                    fe_values_spacetime.spatial ()->get_function_gradients ( solution_extract , old_solution_grad );
-
-                    unsigned int q_s = q % n_quad_space;
-                    const double p = old_solution_values[q_s] ( 2 );
                     dealii::Tensor < 1 , 2 > v;
+                    dealii::Tensor < 1 , 2 > dt_v;
                     dealii::Tensor < 2 , 2 > grad_v;
+
+                    const double p = old_solution_values[q] ( 2 );
                     for ( int c = 0 ; c < 2 ; c++ )
                     {
-                        v[c] = old_solution_values[q_s] ( c );
+                        v[c] = old_solution_values[q]( c );
+                        dt_v[c] = old_solution_dt[q]( c );
                         for ( int d = 0 ; d < 2 ; d++ )
                         {
-                            grad_v[c][d] = old_solution_grad[q_s][c][d];
+                            grad_v[c][d] = old_solution_grads[q][c][d];
                         }
                     }
                     const double div_v = dealii::trace ( grad_v );
@@ -668,10 +664,12 @@ void Step4::assemble_residual_on_slab ()
                     for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
                     {
 
-                        //				// (dt u, v)
-                        //				 this can not be solved via extract value!
+                        // (dt u, v)
+                        cell_rhs ( i+ n * dofs_per_spacetime_cell )
+                           -= fe_values_spacetime.vector_value ( velocity , i , q )
+                            * dt_v * fe_values_spacetime.JxW ( q );
 
-                        //				// convection
+                        // convection
                         cell_rhs ( i + n * dofs_per_spacetime_cell )
                            -= fe_values_spacetime.vector_value ( velocity , i , q )
                             * grad_v * v * fe_values_spacetime.JxW ( q );
@@ -699,10 +697,12 @@ void Step4::assemble_residual_on_slab ()
                     } //dofs i
                 } //quad
 
+                //TODO: add FEJumpValues function for the following two calls
+
                 // solution at left element edge i.e. u_{m-1}^+
                 idealii::slab::VectorTools::extract_subvector_at_time_point ( *slab_its.dof , *slab_its.solution ,
                                                                               solution_extract ,
-                                                                              cell_time->face ( 1 )->center ()[0] );
+                                                                              cell_time->face ( 0 )->center ()[0] );
 
                 fe_values_spacetime.spatial ()->operator[] ( velocity ).get_function_values ( solution_extract ,
                                                                                               solution_plus );
@@ -864,7 +864,7 @@ int main ( int argc , char *argv[] )
     // temporal finite element order
     // WARNING do not change as evaluation of temporal derivative of a given
     // space-time fe vector is not implemented yet.
-    unsigned int r = 0;
+    unsigned int r = 1;
     Step4 problem ( r );
     problem.run ();
 }

--- a/include/ideal.II/fe/spacetime_fe_values.hh
+++ b/include/ideal.II/fe/spacetime_fe_values.hh
@@ -89,6 +89,37 @@ namespace idealii::spacetime
                                                      unsigned int point_no );
 
             /**
+             * @brief Function values of a given vector at all quadrature points
+             * @in fe_function
+             * @out values
+             */
+            template<class InputVector>
+            void get_function_values(const InputVector& fe_function,
+                                     std::vector<dealii::Vector<typename InputVector::value_type>>& values)
+            const;
+
+            /**
+             * @brief Function values of a given vector at all quadrature points
+             * @in fe_function
+             * @out values
+             */
+            template<class InputVector>
+            void get_function_dt(const InputVector& fe_function,
+                                 std::vector<dealii::Vector<typename InputVector::value_type>>& values)
+            const;
+
+            /**
+             * @brief Spatial function gradients of a given vector at all quadrature points
+             * @in fe_function
+             * @out values
+             */
+            template<class InputVector>
+            void get_function_space_gradients(const InputVector& fe_function,
+                                              std::vector<std::vector<dealii::Tensor<1,dim,typename InputVector::value_type>>>& gradients)
+            const;
+
+
+            /**
              * @brief Value of the space-time shape function of a scalar finite element component.
              *
              * This function passes the extractor to the underlying spatial FEValues object

--- a/include/ideal.II/fe/spacetime_fe_values.hh
+++ b/include/ideal.II/fe/spacetime_fe_values.hh
@@ -341,6 +341,26 @@ namespace idealii::spacetime
                                        unsigned int point_no );
 
             /**
+             * @brief Left temporal limit from below of function values of a given vector at all space quadrature points
+             * @in fe_function
+             * @out values
+             */
+            template<class InputVector>
+            void get_function_values_minus(const InputVector& fe_function,
+                                     std::vector<dealii::Vector<typename InputVector::value_type>>& values)
+            const;
+
+            /**
+             * @brief Left temporal limit from above of function values of a given vector at all space quadrature points
+             * @in fe_function
+             * @out values
+             */
+            template<class InputVector>
+            void get_function_values_plus(const InputVector& fe_function,
+                                     std::vector<dealii::Vector<typename InputVector::value_type>>& values)
+            const;
+
+            /**
              * @brief Value of the limit from above of the space-time shape function of a scalar finite element component.
              *
              * The temporal value is evaluated at the left point of the unit element i.e. 0.
@@ -403,10 +423,11 @@ namespace idealii::spacetime
             double JxW ( const unsigned int quadrature_point );
 
             /**
-             * @brief Number of spactial quadrature points per element.
+             * @brief Number of spatial quadrature points per element.
              */
             unsigned int n_quadrature_points;
             private:
+            unsigned int n_dofs_space;
             DG_FiniteElement<dim> &_fe;
             Quadrature<dim> &_quad;
 

--- a/src/fe/spacetime_fe_values.inst
+++ b/src/fe/spacetime_fe_values.inst
@@ -39,6 +39,7 @@ namespace idealii::spacetime
 
     template void FEValues<3>::get_function_space_gradients(const dealii::Vector<double> &,
                                                    std::vector<std::vector<dealii::Tensor<1,3,double>>>&) const;
+
     #ifdef DEAL_II_WITH_TRILINOS
     #ifdef DEAL_II_WITH_MPI
     template void FEValues<2>::get_function_values(const dealii::TrilinosWrappers::MPI::Vector&,
@@ -69,6 +70,37 @@ namespace idealii::spacetime
 
     template class FEJumpValues<2> ;
     template class FEJumpValues<3> ;
+
+
+    template void FEJumpValues<2>::get_function_values_plus(const dealii::Vector<double>&,
+                                                        std::vector<dealii::Vector<double>>&) const;
+
+    template void FEJumpValues<2>::get_function_values_minus(const dealii::Vector<double>&,
+                                                         std::vector<dealii::Vector<double>>&) const;
+
+    template void FEJumpValues<3>::get_function_values_plus(const dealii::Vector<double> &,
+                                                        std::vector<dealii::Vector<double>> &) const;
+
+    template void FEJumpValues<3>::get_function_values_minus(const dealii::Vector<double> &,
+                                                         std::vector<dealii::Vector<double>> &) const;
+
+#ifdef DEAL_II_WITH_TRILINOS
+#ifdef DEAL_II_WITH_MPI
+    template void FEJumpValues<2>::get_function_values_plus(const dealii::TrilinosWrappers::MPI::Vector&,
+                                                        std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+
+    template void FEJumpValues<2>::get_function_values_minus(const dealii::TrilinosWrappers::MPI::Vector&,
+                                                         std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+
+    template void FEJumpValues<3>::get_function_values_plus(const dealii::TrilinosWrappers::MPI::Vector&,
+                                                        std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+
+    template void FEJumpValues<3>::get_function_values_minus(const dealii::TrilinosWrappers::MPI::Vector&,
+                                                         std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+
+
+#endif
+#endif
 
     template class FEFaceValues<2> ;
     template class FEFaceValues<3> ;

--- a/src/fe/spacetime_fe_values.inst
+++ b/src/fe/spacetime_fe_values.inst
@@ -21,6 +21,52 @@ namespace idealii::spacetime
     template class FEValues<2> ;
     template class FEValues<3> ;
 
+
+    template void FEValues<2>::get_function_values(const dealii::Vector<double>&,
+                                                   std::vector<dealii::Vector<double>>&) const;
+
+    template void FEValues<3>::get_function_values(const dealii::Vector<double> &,
+                                                   std::vector<dealii::Vector<double>> &) const;
+
+    template void FEValues<2>::get_function_dt(const dealii::Vector<double>&,
+                                                   std::vector<dealii::Vector<double>>&) const;
+
+    template void FEValues<3>::get_function_dt(const dealii::Vector<double> &,
+                                                   std::vector<dealii::Vector<double>> &) const;
+
+    template void FEValues<2>::get_function_space_gradients(const dealii::Vector<double>&,
+                                                   std::vector<std::vector<dealii::Tensor<1,2,double>>>&) const;
+
+    template void FEValues<3>::get_function_space_gradients(const dealii::Vector<double> &,
+                                                   std::vector<std::vector<dealii::Tensor<1,3,double>>>&) const;
+    #ifdef DEAL_II_WITH_TRILINOS
+    #ifdef DEAL_II_WITH_MPI
+    template void FEValues<2>::get_function_values(const dealii::TrilinosWrappers::MPI::Vector&,
+                                                   std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+
+    template void FEValues<3>::get_function_values(const dealii::TrilinosWrappers::MPI::Vector&,
+                                                   std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+
+    template void FEValues<2>::get_function_dt(const dealii::TrilinosWrappers::MPI::Vector&,
+                                               std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+
+    template void FEValues<3>::get_function_dt(const dealii::TrilinosWrappers::MPI::Vector&,
+                                               std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+
+
+    template void FEValues<2>::get_function_space_gradients(
+        const dealii::TrilinosWrappers::MPI::Vector&,
+        std::vector<std::vector<dealii::Tensor<1,2,dealii::TrilinosScalar>>>&
+    ) const;
+
+    template void FEValues<3>::get_function_space_gradients(
+        const dealii::TrilinosWrappers::MPI::Vector&,
+        std::vector<std::vector<dealii::Tensor<1,3,dealii::TrilinosScalar>>>&
+    ) const;
+
+    #endif
+    #endif
+
     template class FEJumpValues<2> ;
     template class FEJumpValues<3> ;
 


### PR DESCRIPTION
This PR adds methods to simplify implementation of nonlinear problems.
Namely get_function_values and similar functions to extract element local 
function values and derivatives out of spacetime (solution) vectors.

With this the Navier-Stokes example is also updated to use the new functions.