### PR TITLE
Add additional flags for the FEFaceValues Object

### DIFF
--- a/include/ideal.II/fe/spacetime_fe_values.hh
+++ b/include/ideal.II/fe/spacetime_fe_values.hh
@@ -458,10 +458,13 @@ namespace idealii::spacetime
              * @param fe: The underlying space-time finite element description class.
              * @param quad: The space-time quadrature formula to be used.
              * @param uflags: The update flags to be used during the reinit calls.
+             * @param additional_flags: Additional update flags that are only appended 
+             *                          to the FEFace Object (e.g.: update_normal_vectors)
              */
             FEFaceValues ( DG_FiniteElement<dim> &fe ,
                            Quadrature<dim - 1> &quad ,
-                           const dealii::UpdateFlags uflags );
+                           const dealii::UpdateFlags uflags ,
+                           const dealii::UpdateFlags additional_flags );
 
             /**
              * @brief Reinitialize all objects of the underlying spatial FEValues object.

--- a/src/fe/spacetime_fe_values.cc
+++ b/src/fe/spacetime_fe_values.cc
@@ -567,13 +567,14 @@ namespace idealii::spacetime
     FEFaceValues<dim>::FEFaceValues (
         DG_FiniteElement<dim> &fe ,
         Quadrature<dim - 1> &quad ,
-        const dealii::UpdateFlags uflags )
+        const dealii::UpdateFlags uflags,
+        const dealii::UpdateFlags additional_flags )
         :
         _fe ( fe ),
         _quad ( quad ),
         _fev_space ( std::make_shared<dealii::FEFaceValues<dim>> ( *fe.spatial () ,
                                                                    *quad.spatial () ,
-                                                                   uflags )
+                                                                   uflags | additonal_flags )
         ),
         _fev_time ( std::make_shared<dealii::FEValues<1>> ( *fe.temporal () ,
                                                             *quad.temporal () ,


### PR DESCRIPTION
Some update flags can only be applied to the `FEFaceValues` object and not to `FEValues` (e.g., `update_normal_vectors`).
Hence I added `additional_flags` to the `FEFaceValues` class.