### PR TITLE
Add maximum number of intervals per slab

### DIFF
--- a/include/ideal.II/distributed/fixed_tria.hh
+++ b/include/ideal.II/distributed/fixed_tria.hh
@@ -33,8 +33,10 @@ namespace idealii::spacetime::parallel::distributed::fixed{
     public:
         /**
          * @brief Constructor that initializes the underlying list object.
+         * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
          */
-        Triangulation();
+        Triangulation ( unsigned int max_N_intervals_per_slab=0);
+
         /**
          * @brief Generate a list of M slab triangulations with matching temporal meshes pointing to the same
          * spatial triangulation.

--- a/include/ideal.II/distributed/slab_tria.hh
+++ b/include/ideal.II/distributed/slab_tria.hh
@@ -43,9 +43,25 @@ namespace idealii::slab::parallel::distributed{
          * @param startpoint The startpoint of the temporal triangulation.
          * @param endpoint The endpoint of the temporal triangulation.
          */
-        Triangulation(std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> space_tria,
-                      double startpoint,
-                      double endpoint);
+        Triangulation(
+                std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> space_tria,
+                double startpoint,
+                double endpoint);
+
+
+        /**
+         * @brief Construct an object with a given spatial triangulation and a given
+         * division of elements in time.
+         *
+         * @param space_tria. The spatial triangulation to be used.
+         * @param step_sizes. The sizes of the temporal elements
+         * @param startpoint. The startpoint of the temporal triangulation.
+         * @param endpoint. The endpoint of the temporal triangulation.
+         */
+        Triangulation (
+                std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> space_tria,
+                std::vector<double> step_sizes,
+                double startpoint , double endpoint );
 
         /**
          * @brief (shallow) copy constructor. Only the values for the start- and endpoint
@@ -80,6 +96,19 @@ namespace idealii::slab::parallel::distributed{
          */
         double endpoint();
 
+        /**
+         * @brief Change the temporal triangulation to the given division
+         *
+         * @param step_sizes. The sizes of the temporal elements
+         * @param startpoint. The startpoint of the temporal triangulation.
+         * @param endpoint. The endpoint of the temporal triangulation.
+         *
+         * @warning Due to a call to clear() of the temporal triangulation no subscriptions can exist to it, such as DoFHandler.
+         */
+        void update_temporal_triangulation(
+                std::vector<double> step_sizes,
+                double startpoint,
+                double endpoint);
     private:
         std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> _spatial_tria;
         std::shared_ptr<dealii::Triangulation<1>> _temporal_tria;

--- a/include/ideal.II/distributed/spacetime_tria.hh
+++ b/include/ideal.II/distributed/spacetime_tria.hh
@@ -37,8 +37,9 @@ namespace idealii::spacetime::parallel::distributed{
     public:
         /**
          * @brief Constructor that initializes the underlying list object.
+         * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
          */
-        Triangulation();
+        Triangulation ( dealii::types::global_cell_index max_N_intervals_per_slab=0);
 
         /**
          * @brief Generate a list of M slab triangulations with matching temporal meshes and space_tria.
@@ -74,6 +75,7 @@ namespace idealii::spacetime::parallel::distributed{
         virtual void refine_global(const unsigned int times_space = 1, const unsigned int times_time = 1)=0;
 
     protected:
+        dealii::types::global_cell_index max_N_intervals_per_slab;
         std::list<slab::parallel::distributed::Triangulation<dim>> trias;
     };
 }

--- a/include/ideal.II/grid/fixed_tria.hh
+++ b/include/ideal.II/grid/fixed_tria.hh
@@ -33,8 +33,9 @@ namespace idealii::spacetime::fixed
     public:
         /**
          * @brief Constructor that initializes the underlying list object.
+         * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
          */
-        Triangulation ();
+        Triangulation ( unsigned int max_N_intervals_per_slab=0);
 
         /**
          * @brief Generate a list of M slab triangulations with matching temporal meshes pointing to the same

--- a/include/ideal.II/grid/slab_tria.hh
+++ b/include/ideal.II/grid/slab_tria.hh
@@ -37,12 +37,26 @@ namespace idealii::slab
          * @brief Construct an object with a given spatial triangulation and a single
          * element in time.
          *
-         * @param space_tria The spatial triangulation to be used.
-         * @param startpoint The startpoint of the temporal triangulation.
-         * @param endpoint The endpoint of the temporal triangulation.
+         * @param space_tria. The spatial triangulation to be used.
+         * @param startpoint. The startpoint of the temporal triangulation.
+         * @param endpoint. The endpoint of the temporal triangulation.
          */
         Triangulation (
                 std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
+                double startpoint , double endpoint );
+
+        /**
+         * @brief Construct an object with a given spatial triangulation and a given
+         * division of elements in time.
+         *
+         * @param space_tria. The spatial triangulation to be used.
+         * @param step_sizes. The sizes of the temporal elements
+         * @param startpoint. The startpoint of the temporal triangulation.
+         * @param endpoint. The endpoint of the temporal triangulation.
+         */
+        Triangulation (
+                std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
+                std::vector<double> step_sizes,
                 double startpoint , double endpoint );
 
         /**
@@ -77,6 +91,21 @@ namespace idealii::slab
          * @brief The endpoint of the temporal triangulation.
          */
         double endpoint ();
+
+        /**
+         * @brief Change the temporal triangulation to the given division
+         *
+         * @param step_sizes. The sizes of the temporal elements
+         * @param startpoint. The startpoint of the temporal triangulation.
+         * @param endpoint. The endpoint of the temporal triangulation.
+         *
+         * @warning Due to a call to clear() of the temporal triangulation no subscriptions can exist to it, such as DoFHandler.
+         */
+        void update_temporal_triangulation(
+                std::vector<double> step_sizes,
+                double startpoint,
+                double endpoint);
+
     private:
         std::shared_ptr<dealii::Triangulation<dim>> _spatial_tria;
         std::shared_ptr<dealii::Triangulation<1>> _temporal_tria;

--- a/include/ideal.II/grid/spacetime_tria.hh
+++ b/include/ideal.II/grid/spacetime_tria.hh
@@ -38,8 +38,9 @@ namespace idealii::spacetime
     public:
         /**
          * @brief Constructor that initializes the underlying list object.
+         * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
          */
-        Triangulation ();
+        Triangulation ( dealii::types::global_cell_index max_N_intervals_per_slab=0);
 
         /**
          * @brief Generate a list of M slab triangulations with matching temporal meshes and space_tria.
@@ -51,7 +52,7 @@ namespace idealii::spacetime
          */
         virtual void generate (
             std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
-            unsigned int M , double t0 = 0. , double T = 1. )=0;
+            unsigned int M , double t0 = 0. , double T = 1.)=0;
 
         /**
          * @brief Return the number of slabs in the triangulation.
@@ -76,6 +77,7 @@ namespace idealii::spacetime
             const unsigned int times_time = 1 )=0;
 
     protected:
+        dealii::types::global_cell_index max_N_intervals_per_slab;
         std::list<slab::Triangulation<dim>> trias;
     };
 }

--- a/src/distributed/fixed_tria.cc
+++ b/src/distributed/fixed_tria.cc
@@ -19,9 +19,9 @@
 namespace idealii::spacetime::parallel::distributed::fixed
 {
     template<int dim>
-    Triangulation<dim>::Triangulation ()
+    Triangulation<dim>::Triangulation (dealii::types::global_cell_index max_N_intervals_per_slab)
     :
-    spacetime::parallel::distributed::Triangulation<dim> ()
+    spacetime::parallel::distributed::Triangulation<dim> (max_N_intervals_per_slab)
     {
     }
 
@@ -53,6 +53,61 @@ namespace idealii::spacetime::parallel::distributed::fixed
         for ( ; slab_tria != this->end () ; ++slab_tria )
         {
             slab_tria->temporal ()->refine_global ( times_time );
+
+
+            //Check if temporal triangulation got too large (unless max_N = 0)
+            if ( this->max_N_intervals_per_slab &&
+                 slab_tria->temporal()->n_global_active_cells() > this->max_N_intervals_per_slab)
+            {
+                dealii::types::global_cell_index M = slab_tria->temporal()->n_global_active_cells();
+                std::vector<double> step_sizes(M);
+                dealii::types::global_cell_index i = 0;
+                for (auto &cell : slab_tria->temporal()->active_cell_iterators()){
+                    step_sizes[i] = cell->bounding_box().side_length(0);
+                    i++;
+                }
+
+                //number of subdivisions needed is at least
+                dealii::types::global_cell_index subdiv = M/this->max_N_intervals_per_slab;
+                //remaining intervals?
+                dealii::types::global_cell_index modulus = M%this->max_N_intervals_per_slab;
+
+                std::vector<std::vector<double>> partial_step_sizes;
+                for ( dealii::types::global_cell_index j = 0 ; j < subdiv ; j++){
+                    partial_step_sizes.push_back(std::vector<double>(this->max_N_intervals_per_slab));
+                }
+                if ( modulus ){
+                    partial_step_sizes.push_back(std::vector<double>(modulus));
+                }
+
+
+                //Distribute step sizes onto subdivisions
+                for ( i = 0 ; i < M ; ++i ){
+                    dealii::types::global_cell_index j = i/this->max_N_intervals_per_slab;
+                    dealii::types::global_cell_index k  = i%this->max_N_intervals_per_slab;
+                    partial_step_sizes[j][k] = step_sizes[i];
+                }
+
+                // we need to calculate temporal bounds for the new slabs
+                double end = slab_tria->startpoint();
+                double start = end;
+
+                //The first new slabs will be emplaced before the current one.
+                //Then, they will not invalidate the list iterator going forward
+                for ( i =  0 ; i < partial_step_sizes.size()-1 ; ++i ){
+                    start = end;
+                    for ( dealii::types::global_cell_index j = 0 ; j < partial_step_sizes[i].size() ; ++j ){
+                        end += partial_step_sizes[i][j];
+                    }
+                    this->trias.emplace(slab_tria,slab_tria->spatial(),partial_step_sizes[i],start,end);
+                }
+                //Finally, update the current slab triangulation
+                start = end;
+                for ( dealii::types::global_cell_index j = 0 ; j < partial_step_sizes[i].size() ; ++j ){
+                    end += partial_step_sizes[i][j];
+                }
+                slab_tria->update_temporal_triangulation(partial_step_sizes[i],start,end);
+            }
         }
 
     }

--- a/src/distributed/slab_tria.cc
+++ b/src/distributed/slab_tria.cc
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 #include <ideal.II/distributed/slab_tria.hh>
+#include <deal.II/base/config.h>
 
 #ifdef DEAL_II_WITH_MPI
 #include <deal.II/grid/grid_generator.h>
@@ -36,6 +37,33 @@ namespace idealii::slab::parallel::distributed
         dealii::GridGenerator::hyper_cube ( *_temporal_tria ,
                                             _startpoint ,
                                             _endpoint );
+    }
+
+
+    template<int dim>
+    Triangulation<dim>::Triangulation (
+        std::shared_ptr<
+        dealii::parallel::distributed::Triangulation<dim>> space_tria ,
+        std::vector<double> step_sizes,
+        double start ,
+        double end )
+        :
+        _startpoint ( start ),
+        _endpoint ( end )
+    {
+        _spatial_tria = space_tria;
+        _temporal_tria = std::make_shared<dealii::Triangulation<1>> ();
+        //Grid generator needs step sizes for each dimension,
+        //so we need to construct a new vector with on entry.
+        std::vector<std::vector<double>> spacing;
+        spacing.push_back(step_sizes);
+        dealii::Point<1> p1(_startpoint);
+        dealii::Point<1> p2(_endpoint);
+        dealii::GridGenerator::subdivided_hyper_rectangle( *_temporal_tria,
+                                                           spacing,
+                                                           p1,
+                                                           p2
+        );
     }
 
     template<int dim>
@@ -75,6 +103,26 @@ namespace idealii::slab::parallel::distributed
     double Triangulation<dim>::endpoint ()
     {
         return _endpoint;
+    }
+
+    template<int dim>
+    void Triangulation<dim>:: update_temporal_triangulation(
+        std::vector<double> step_sizes,
+        double startpoint,
+        double endpoint){
+        _startpoint = startpoint;
+        _endpoint = endpoint;
+        std::vector<std::vector<double>> spacing;
+        spacing.push_back(step_sizes);
+        //TODO: add an assertion that no subscribers exist
+        _temporal_tria->clear();
+        dealii::Point<1> p1(_startpoint);
+        dealii::Point<1> p2(_endpoint);
+        dealii::GridGenerator::subdivided_hyper_rectangle( *_temporal_tria,
+                                                           spacing,
+                                                           p1,
+                                                           p2
+        );
     }
 }
 

--- a/src/distributed/spacetime_tria.cc
+++ b/src/distributed/spacetime_tria.cc
@@ -19,7 +19,8 @@
 namespace idealii::spacetime::parallel::distributed
 {
     template<int dim>
-    Triangulation<dim>::Triangulation ()
+    Triangulation<dim>::Triangulation (dealii::types::global_cell_index max_N_intervals_per_slab)
+    :max_N_intervals_per_slab(max_N_intervals_per_slab)
     {
         trias =
             std::list<idealii::slab::parallel::distributed::Triangulation<dim>> ();

--- a/src/grid/fixed_tria.cc
+++ b/src/grid/fixed_tria.cc
@@ -18,9 +18,9 @@
 namespace idealii::spacetime::fixed
 {
     template<int dim>
-    Triangulation<dim>::Triangulation ()
+    Triangulation<dim>::Triangulation (dealii::types::global_cell_index max_N_intervals_per_slab)
     :
-    spacetime::Triangulation<dim> ()
+    spacetime::Triangulation<dim> (max_N_intervals_per_slab)
     {
     }
 
@@ -56,6 +56,60 @@ namespace idealii::spacetime::fixed
         for ( ; slab_tria != this->end () ; ++slab_tria )
         {
             slab_tria->temporal ()->refine_global ( times_time );
+
+            //Check if temporal triangulation got too large (unless max_N = 0)
+            if ( this->max_N_intervals_per_slab &&
+                 slab_tria->temporal()->n_global_active_cells( )> this->max_N_intervals_per_slab)
+            {
+                dealii::types::global_cell_index M = slab_tria->temporal()->n_global_active_cells();
+                std::vector<double> step_sizes(M);
+                dealii::types::global_cell_index i = 0;
+                for (auto &cell : slab_tria->temporal()->active_cell_iterators()){
+                    step_sizes[i] = cell->bounding_box().side_length(0);
+                    i++;
+                }
+
+                //number of subdivisions needed is at least
+                dealii::types::global_cell_index subdiv = M/this->max_N_intervals_per_slab;
+                //remaining intervals?
+                dealii::types::global_cell_index modulus = M%this->max_N_intervals_per_slab;
+
+                std::vector<std::vector<double>> partial_step_sizes;
+                for ( dealii::types::global_cell_index j = 0 ; j < subdiv ; j++){
+                    partial_step_sizes.push_back(std::vector<double>(this->max_N_intervals_per_slab));
+                }
+                if ( modulus ){
+                    partial_step_sizes.push_back(std::vector<double>(modulus));
+                }
+
+
+                //Distribute step sizes onto subdivisions
+                for ( i = 0 ; i < M ; ++i ){
+                    dealii::types::global_cell_index j = i/this->max_N_intervals_per_slab;
+                    dealii::types::global_cell_index k  = i%this->max_N_intervals_per_slab;
+                    partial_step_sizes[j][k] = step_sizes[i];
+                }
+
+                // we need to calculate temporal bounds for the new slabs
+                double end = slab_tria->startpoint();
+                double start = end;
+
+                //The first new slabs will be emplaced before the current one.
+                //Then, they will not invalidate the list iterator going forward
+                for ( i =  0 ; i < partial_step_sizes.size()-1 ; ++i ){
+                    start = end;
+                    for ( dealii::types::global_cell_index j = 0 ; j < partial_step_sizes[i].size() ; ++j ){
+                        end += partial_step_sizes[i][j];
+                    }
+                    this->trias.emplace(slab_tria,slab_tria->spatial(),partial_step_sizes[i],start,end);
+                }
+                //Finally, update the current slab triangulation
+                start = end;
+                for ( dealii::types::global_cell_index j = 0 ; j < partial_step_sizes[i].size() ; ++j ){
+                    end += partial_step_sizes[i][j];
+                }
+                slab_tria->update_temporal_triangulation(partial_step_sizes[i],start,end);
+            }
         }
 
     }

--- a/src/grid/slab_tria.cc
+++ b/src/grid/slab_tria.cc
@@ -38,6 +38,37 @@ namespace idealii::slab
     }
 
     template<int dim>
+    Triangulation<dim>::Triangulation (
+        std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
+        std::vector<double> step_sizes,
+        double start ,
+        double end )
+        :
+        _startpoint ( start ),
+        _endpoint ( end )
+    {
+        Assert( space_tria.use_count () , dealii::ExcNotInitialized () );
+        #ifdef DEBUG
+            double sum = std::accumulate(step_sizes.begin(),step_sizes.end(),0);
+            Assert ( ( (_startpoint + sum - _endpoint) < 1.0e-12),
+                    dealii::ExcMessage("Mismatch between provided endpoint and temporal step sizes in slab Triangulation."));
+        #endif
+        _spatial_tria = space_tria;
+        _temporal_tria = std::make_shared<dealii::Triangulation<1>> ();
+        //Grid generator needs step sizes for each dimension,
+        //so we need to construct a new vector with on entry.
+        std::vector<std::vector<double>> spacing;
+        spacing.push_back(step_sizes);
+        dealii::Point<1> p1(_startpoint);
+        dealii::Point<1> p2(_endpoint);
+        dealii::GridGenerator::subdivided_hyper_rectangle( *_temporal_tria,
+                                                           spacing,
+                                                           p1,
+                                                           p2
+        );
+    }
+
+    template<int dim>
         Triangulation<dim>::Triangulation ( const Triangulation &other )
             :
             _startpoint ( other._startpoint ),
@@ -74,6 +105,26 @@ namespace idealii::slab
         {
             return _endpoint;
         }
+
+    template<int dim>
+    void Triangulation<dim>:: update_temporal_triangulation(
+        std::vector<double> step_sizes,
+        double startpoint,
+        double endpoint){
+        _startpoint = startpoint;
+        _endpoint = endpoint;
+        std::vector<std::vector<double>> spacing;
+        spacing.push_back(step_sizes);
+        //TODO: add an assertion that no subscribers exist
+        _temporal_tria->clear();
+        dealii::Point<1> p1(_startpoint);
+        dealii::Point<1> p2(_endpoint);
+        dealii::GridGenerator::subdivided_hyper_rectangle( *_temporal_tria,
+                                                           spacing,
+                                                           p1,
+                                                           p2
+        );
+    }
 }
 
 #include "slab_tria.inst"

--- a/src/grid/spacetime_tria.cc
+++ b/src/grid/spacetime_tria.cc
@@ -18,10 +18,12 @@
 namespace idealii::spacetime
 {
     template<int dim>
-    Triangulation<dim>::Triangulation ()
+    Triangulation<dim>::Triangulation (dealii::types::global_cell_index max_N_intervals_per_slab)
+    :max_N_intervals_per_slab(max_N_intervals_per_slab)
     {
         trias = std::list<idealii::slab::Triangulation<dim>> ();
     }
+
 
     template<int dim>
     unsigned int Triangulation<dim>::M ()


### PR DESCRIPTION
Adds the option to Triangulation classes to specify a maximum number of temporal intervals per slab. 
If this number is exceeded a slab will be split into multiple slabs that each have at most this number of intervals.
This can be used to somewhat control the memory requirement of each slab and also ensure time-stepping
for the maximum equal to 1.