### PR TITLE
Doxygen rework: mainpage is Readme + documentation only option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,122 +15,126 @@
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 cmake_policy(SET CMP0022 NEW)
 project(ideal.II VERSION 0.9.0 LANGUAGES CXX)
+option(DOCUMENTATION_ONLY "Only prepare Doxyfile and command" OFF)
 
-set(CMAKE_CXX_STANDARD 17)
-if(NOT CMAKE_BUILD_TYPE)
-  message(WARNING "build type not set, using DebugRelease")
-  set(CMAKE_BUILD_TYPE "DebugRelease")
-endif()
 
 include(CMakePrintHelpers)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+
 option(BUILD_SHARED_LIBS "Build deallib as a shared library" ON)
 
-# deal.II
-find_package(deal.II 9.3 QUIET
-  HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
+if(NOT DOCUMENTATION_ONLY)
+  set(CMAKE_CXX_STANDARD 17)
+  if(NOT CMAKE_BUILD_TYPE)
+    message(WARNING "build type not set, using DebugRelease")
+    set(CMAKE_BUILD_TYPE "DebugRelease")
+  endif()
+  # deal.II
+  find_package(deal.II 9.3 QUIET
+    HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
+    )
+  if(NOT ${deal.II_FOUND})
+    MESSAGE(FATAL_ERROR "\n"
+      "*** Could not locate deal.II. ***\n\n"
+      "You may want to either pass a flag -DDEAL_II_DIR=/path/to/deal.II to cmake\n"
+      "or set an environment variable \"DEAL_II_DIR\" that contains this path."
+      )
+  endif()
+
+  DEAL_II_INITIALIZE_CACHED_VARIABLES()
+  cmake_print_variables(DEAL_II_TARGET_CONFIG)
+  include(${DEAL_II_TARGET_CONFIG})
+
+  option(IDEAL_II_COMPONENT_EXAMPLES
+    "Enable configuration and installation of the example steps. This adds a COMPONENT \"examples\" to the build system."
+    ON
   )
-if(NOT ${deal.II_FOUND})
-  MESSAGE(FATAL_ERROR "\n"
-    "*** Could not locate deal.II. ***\n\n"
-    "You may want to either pass a flag -DDEAL_II_DIR=/path/to/deal.II to cmake\n"
-    "or set an environment variable \"DEAL_II_DIR\" that contains this path."
-    )
+
+
+  if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    list(APPEND IDEAL_II_BUILD_TYPES "debug")
+    list(APPEND IDEAL_II_TARGETS ${PROJECT_NAME}_debug)
+  endif()
+
+  if(CMAKE_BUILD_TYPE MATCHES "Release")
+    list(APPEND IDEAL_II_BUILD_TYPES "release")
+    list(APPEND IDEAL_II_TARGETS ${PROJECT_NAME}_release)
+  endif()
+
+  if(NOT IDEAL_II_BUILD_TYPES)
+      message(FATAL_ERROR "\n"
+          "*** unsupported build type ***\n\n"
+          "Please choose either Debug, Release or DebugRelease."
+      )
+  endif()
+
+  add_subdirectory(cmake)
+  add_subdirectory(include)
+  add_subdirectory(src)
+
+  foreach(build_type IN LISTS IDEAL_II_BUILD_TYPES)
+          add_library(${PROJECT_NAME}_${build_type} ${IDEAL_II_SRCS})
+          string(TOUPPER ${build_type} caps_build_type) 
+          DEAL_II_SETUP_TARGET(${PROJECT_NAME}_${build_type} ${caps_build_type})
+          target_include_directories(${PROJECT_NAME}_${build_type}
+                  PUBLIC
+                  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+                  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+                  ${DEAL_II_INCLUDE_DIRS}
+                  PRIVATE
+                  ${CMAKE_SOURCE_DIR}/include
+          )
+          set_property(TARGET ${PROJECT_NAME}_${build_type} PROPERTY POSITION_INDEPENDENT_CODE ON)
+          set_target_properties(${PROJECT_NAME}_${build_type}
+                  PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+  endforeach()
+
+    
+  install(TARGETS ${IDEAL_II_TARGETS}
+    EXPORT ${PROJECT_NAME}_Exports
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      NAMELINK_SKIP
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+
+  install(EXPORT ${PROJECT_NAME}_Exports
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}
+    NAMESPACE ${PROJECT_NAME}::
+  )
+
+  install(TARGETS ${IDEAL_II_TARGETS}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      NAMELINK_ONLY
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+
+  configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
+    "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}
+  )
+
+  write_basic_package_version_file(
+      "${PROJECT_NAME}ConfigVersion.cmake"
+      VERSION ${PROJECT_VERSION}
+      COMPATIBILITY SameMajorVersion
+  )
+
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}
+  )
+
+
+
+  add_subdirectory(examples)
 endif()
-
-DEAL_II_INITIALIZE_CACHED_VARIABLES()
-cmake_print_variables(DEAL_II_TARGET_CONFIG)
-include(${DEAL_II_TARGET_CONFIG})
-
-option(IDEAL_II_COMPONENT_EXAMPLES
-  "Enable configuration and installation of the example steps. This adds a COMPONENT \"examples\" to the build system."
-  ON
-)
-
-
-if(CMAKE_BUILD_TYPE MATCHES "Debug")
-  list(APPEND IDEAL_II_BUILD_TYPES "debug")
-  list(APPEND IDEAL_II_TARGETS ${PROJECT_NAME}_debug)
-endif()
-
-if(CMAKE_BUILD_TYPE MATCHES "Release")
-  list(APPEND IDEAL_II_BUILD_TYPES "release")
-  list(APPEND IDEAL_II_TARGETS ${PROJECT_NAME}_release)
-endif()
-
-if(NOT IDEAL_II_BUILD_TYPES)
-    message(FATAL_ERROR "\n"
-    	"*** unsupported build type ***\n\n"
-    	"Please choose either Debug, Release or DebugRelease."
-    )
-endif()
-
-add_subdirectory(cmake)
-add_subdirectory(include)
-add_subdirectory(src)
-
-foreach(build_type IN LISTS IDEAL_II_BUILD_TYPES)
-	add_library(${PROJECT_NAME}_${build_type} ${IDEAL_II_SRCS})
-	string(TOUPPER ${build_type} caps_build_type) 
-	DEAL_II_SETUP_TARGET(${PROJECT_NAME}_${build_type} ${caps_build_type})
-	target_include_directories(${PROJECT_NAME}_${build_type}
- 		PUBLIC
-    		$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-    		$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
-    		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    		${DEAL_II_INCLUDE_DIRS}
-  		PRIVATE
-    		${CMAKE_SOURCE_DIR}/include
-	)
-	set_property(TARGET ${PROJECT_NAME}_${build_type} PROPERTY POSITION_INDEPENDENT_CODE ON)
-	set_target_properties(${PROJECT_NAME}_${build_type}
-  		PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
-endforeach()
-
-  
-install(TARGETS ${IDEAL_II_TARGETS}
-  EXPORT ${PROJECT_NAME}_Exports
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    NAMELINK_SKIP
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
-install(EXPORT ${PROJECT_NAME}_Exports
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}
-  NAMESPACE ${PROJECT_NAME}::
-)
-
-install(TARGETS ${IDEAL_II_TARGETS}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    NAMELINK_ONLY
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
-configure_package_config_file(
-  "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
-  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-INSTALL_DESTINATION
-  ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}
-)
-
-write_basic_package_version_file(
-    "${PROJECT_NAME}ConfigVersion.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
-
-install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-DESTINATION
-  ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}
-)
-
-
-
-add_subdirectory(examples)
 add_subdirectory(doc/doxygen)
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,4 @@
 <!---
----------------------------------------------------------------------
 Copyright (C) 2022 - 2023 by the ideal.II authors
 
 This file is part of the ideal.II library.
@@ -10,7 +9,6 @@ Public License as published by the Free Software Foundation; either
 version 3.0 of the License, or (at your option) any later version.
 The full text of the license can be found in the file LICENSE.md at
 the top level directory of ideal.II.
----------------------------------------------------------------------
 --->
 
 # ideal.II an extension to deal.II for tensor-product space-time finite elements
@@ -21,7 +19,6 @@ so you should make yourself familiar with solving stationary problems with that 
 
 
 ## How to install ideal.II
---------------------------
 First you need to install deal.II by following the instructions on their [site](https://dealii.org/current/readme.html).
 If you plan on using parallel linear algebra and other advanced features of deal.II and ideal.II 
 you should use either the [cmake superbuild](www.github.com/jpthiele/dealii-cmake-superbuild) or [candi](www.github.com/dealii/candi). 
@@ -33,29 +30,29 @@ The installation of ideal.II is based on CMake as well, the steps are as follows
 
 2. Open a console and go to a directory where you want to download the source files (e.g. ~/Downloads) and clone the repository 
 
-	cd ~/Downloads
-	
-	git clone https://github.com/instatdealii/idealii
+~~~~~
+    cd ~/Downloads
+    git clone https://github.com/instatdealii/idealii
+~~~~~
 
 3. After cloning is finished execute the following commands (with the above directory examples write
   ~/Software/dealii instead of <path_to_your_deal_installation> and ~/Software/idealii instead of <path_to_install_idealii_in>
  
-	cd idealii   
-
+~~~~~
+    cd idealii   
     cmake -S. -Bbuild -DDEAL_II_DIR=<path_to_your_deal_installation> -DCMAKE_INSTALL_PREFIX=<path_to_install_idealii_in> 
-
     cmake --build build
-
     cmake --install build
- 
+~~~~~
 
 ## How to use ideal.II in your codes
-------------------------------------
 Take a look at one of the example steps and copy the CMakeLists.txt file from there into your project directory. 
 Set the correct project name and sources and then call the following commands from your project directory.
 
+~~~~~
     cmake -S. -Bbuild -DIDEAL_II_DIR=<path_to_install_idealii_in>
     cmake --build build
+~~~~~
 
 Then the executable will be inside the build subdirectory. 
 
@@ -68,31 +65,34 @@ If you write a paper using results obtained with the help of ideal.II, please ci
    ideal.II: a Galerkin space-time extension to the finite element library deal.II,
    2023, in preparation
    
-   ```
+~~~~~
       @article{idealII,
                title = {\texttt{ideal.II}: a Galerkin space-time extension to the finite element library deal.II},
                author = {Jan Philipp Thiele},
                year = {2023,\textit{in preparation}}
       }
-   ```
+~~~~~
    
 2. Please also cite deal.II as explained [here](https://dealii.org/publications.html)
     
 ## Doxygen documentation
-------------------------
 The doxygen documentation of the library functions will soon be hosted centrally.
 Until then, doxygen documentation can be build with the following steps
 
-1. Open a terminal and navigate to the ideal.II build directory, e.g. ~/Downloads/idealii/build
+1. Open a terminal and navigate to the ideal.II directory, e.g. ~/Downloads/idealii
 
 2. Execute the following command to build the documentation
 
-	make doxygen
-	
+~~~~~
+    cmake --build build --target doxygen
+~~~~~
+
 3. The documentation start page is located at the <build_dir>/doc/doxygen/html/index.html
    and can be opened with a webbrowser of your choice e.g.
     
+~~~~~
    firefox ~/Downloads/idealii/build/doc/doxygen/html/index.html
+~~~~~
 
 
 

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -26,8 +26,10 @@ if(IDEAL_II_DOCUMENTATION)
 		add_custom_target(doxygen 
 			COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT} > warnings.out 2>&1
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINDARY_DIR}
-			COMMENT "Generating Doxygen docymentation"
+			COMMENT "Generating Doxygen documentation"
 			VERBATIM )
+			
+                
 	else()
 		message(STATUS "Doxygen not found - skipping documentation")
 	endif()

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -14,12 +14,13 @@
 ## ---------------------------------------------------------------------
 PROJECT_NAME           = "ideal.II"	
 
-JAVADOC_BANNER = YES
 CASE_SENSE_NAMES       = YES
-INPUT =  @CMAKE_CURRENT_SOURCE_DIR@/../../include
+INPUT =  @CMAKE_CURRENT_SOURCE_DIR@/../../Readme.md
+INPUT += @CMAKE_CURRENT_SOURCE_DIR@/../../include
 FILE_PATTERNS          = *.hh
 RECURSIVE              = YES
 SHOW_NAMESPACES = YES
+USE_MDFILE_AS_MAINPAGE = Readme.md
 
 # These variables are used to only offer certain functionality
 # if the base functionality is supplied by the current deal.II installation
@@ -32,4 +33,5 @@ MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
 PREDEFINED = DEAL_II_WITH_MPI=1 \
-			 DEAL_II_WITH_TRILINOS=1  
+             DEAL_II_WITH_TRILINOS=1
+			 


### PR DESCRIPTION
This is a small rework of the doxygen documentation and corresponding CMake files.
With the new CMake option -DDOCUMENTATION_ONLY=ON,
only the doxygen target will be added to quickly build the documentation.