### PR TITLE
Repair non MPI build

### DIFF
--- a/include/ideal.II/dofs/slab_dof_handler.hh
+++ b/include/ideal.II/dofs/slab_dof_handler.hh
@@ -45,14 +45,14 @@ namespace idealii::slab
          * @param tria A shared pointer to a slab::Triangulation.
          */
         DoFHandler ( Triangulation<dim> &tria );
-
+#ifdef DEAL_II_WITH_MPI
         /**
          * @brief Constructor linking a parallel::distributed::slab::Triangulation.
          * @param tria A shared pointer to a parallel::distributed::slab::Triangulation.
          */
         DoFHandler (
                 slab::parallel::distributed::Triangulation<dim> &tria );
-
+#endif
         /**
          * @brief (shallow) copy constructor. Only the index set and fe support type
          * are actually copied. The underlying pointers will point to the same

--- a/include/ideal.II/dofs/spacetime_dof_handler.hh
+++ b/include/ideal.II/dofs/spacetime_dof_handler.hh
@@ -74,7 +74,9 @@ namespace idealii::spacetime
 
     protected:
         Triangulation<dim> *_tria;
+#ifdef DEAL_II_WITH_MPI
         spacetime::parallel::distributed::Triangulation<dim> *_par_dist_tria;
+#endif
         std::list<slab::DoFHandler<dim>> _dof_handlers;
     };
 }

--- a/include/ideal.II/numerics/vector_tools.hh
+++ b/include/ideal.II/numerics/vector_tools.hh
@@ -191,6 +191,7 @@ namespace idealii::slab::VectorTools
         }
     }
 
+#ifdef DEAL_II_WITH_MPI
     /**
      * @brief Get the spatial Trilinos subvector of a specific temporal dof of the corresponding slab.
      *
@@ -214,7 +215,7 @@ namespace idealii::slab::VectorTools
         }
         space_vector = tmp;
     }
-
+#endif
     /**
      * @brief Get the spatial subvector at a specific time point of the corresponding slab.
      * The result is calculated by linear combination of each temporal dof vector according
@@ -266,6 +267,7 @@ namespace idealii::slab::VectorTools
         }
     }
 
+#ifdef DEAL_II_WITH_MPI
     /**
      * @brief Get the spatial Trilinos subvector at a specific time point of the corresponding slab.
      * The result is calculated by linear combination of each temporal dof vector according
@@ -322,6 +324,7 @@ namespace idealii::slab::VectorTools
             }
         }
     }
+#endif
 
     /**
      * @brief calculate the L2 inner product of (u-u_{kh}) with itself

--- a/src/base/time_iterator.cc
+++ b/src/base/time_iterator.cc
@@ -24,22 +24,24 @@ namespace idealii
         tria.obj_collection =
             std::vector<spacetime::Triangulation<dim>*> ();
 
+#ifdef DEAL__II_WITH_MPI
         par_dist_tria.it_collection =
             std::vector<slab::parallel::distributed::TriaIterator<dim>*> ();
 
         par_dist_tria.obj_collection =
             std::vector<spacetime::parallel::distributed::Triangulation<dim>*> ();
-
+#endif
         dof.it_collection = std::vector<slab::DoFHandlerIterator<dim>*> ();
         dof.obj_collection = std::vector<spacetime::DoFHandler<dim>*> ();
 
         vector_double.it_collection = std::vector<slab::VectorIterator<double>*> ();
 
         vector_double.obj_collection = std::vector<spacetime::Vector<double>*> ();
-
+#ifdef DEAL_II_WITH_MPI
         trilinos_vector.it_collection = std::vector<slab::TrilinosVectorIterator*> ();
 
         trilinos_vector.obj_collection = std::vector<spacetime::TrilinosVector*> ();
+#endif
     }
 
     template<int dim>
@@ -79,7 +81,7 @@ namespace idealii
         vector_double.it_collection.push_back ( it );
         vector_double.obj_collection.push_back ( obj );
     }
-
+#ifdef DEAL_II_WITH_MPI
     template<int dim>
     void TimeIteratorCollection<dim>::add_iterator (
          slab::TrilinosVectorIterator *it ,
@@ -88,7 +90,7 @@ namespace idealii
         trilinos_vector.it_collection.push_back ( it );
         trilinos_vector.obj_collection.push_back ( obj );
     }
-
+#endif
     template<int dim>
     void TimeIteratorCollection<dim>::increment ()
     {
@@ -120,12 +122,14 @@ namespace idealii
                     dealii::ExcIteratorPastEnd () );
             ++( *vector_double.it_collection[i] );
         }
+#ifdef DEAL_II_WITH_MPI
         for ( unsigned int i = 0 ; i < trilinos_vector.it_collection.size () ; i++ )
         {
             Assert( *trilinos_vector.it_collection[i] != trilinos_vector.obj_collection[i]->end () ,
                     dealii::ExcIteratorPastEnd () );
             ++( *trilinos_vector.it_collection[i] );
         }
+#endif
     }
 
     template<int dim>

--- a/src/dofs/slab_dof_handler.cc
+++ b/src/dofs/slab_dof_handler.cc
@@ -26,7 +26,7 @@ namespace idealii::slab
         _temporal_dof = std::make_shared<dealii::DoFHandler<1>> ( *tria.temporal () );
         _locally_owned_dofs = dealii::IndexSet ();
     }
-
+#ifdef DEAL_II_WITH_MPI
     template<int dim>
     DoFHandler<dim>::DoFHandler ( slab::parallel::distributed::Triangulation<dim> &tria )
     {
@@ -36,6 +36,7 @@ namespace idealii::slab
         _temporal_dof = std::make_shared<dealii::DoFHandler<1>> ( *tria.temporal () );
         _locally_owned_dofs = dealii::IndexSet ();
     }
+#endif
 
     template<int dim>
     DoFHandler<dim>::DoFHandler ( const DoFHandler<dim> &other )

--- a/src/dofs/spacetime_dof_handler.cc
+++ b/src/dofs/spacetime_dof_handler.cc
@@ -21,7 +21,9 @@ namespace idealii::spacetime
     DoFHandler<dim>::DoFHandler ( Triangulation<dim> *tria )
     {
         _tria = tria;
+#ifdef DEAL_II_WITH_MPI
         _par_dist_tria = nullptr;
+#endif
         _dof_handlers = std::list<idealii::slab::DoFHandler<dim>> ();
     }
 
@@ -53,6 +55,7 @@ namespace idealii::spacetime
                 this->_dof_handlers.push_back ( idealii::slab::DoFHandler<dim> ( *tria_it ) );
             }
         }
+#ifdef DEAL_II_WITH_MPI
         else if ( _par_dist_tria != nullptr )
         {
             slab::parallel::distributed::TriaIterator<dim> tria_it = this->_par_dist_tria->begin ();
@@ -62,6 +65,7 @@ namespace idealii::spacetime
                 this->_dof_handlers.push_back ( idealii::slab::DoFHandler<dim> ( *tria_it ) );
             }
         }
+#endif
         else
         {
             Assert( false , dealii::ExcInternalError () );


### PR DESCRIPTION
Some `#ifdef DEAL_II_WITH_MPI` clauses were missing leading to failing builds using deal.II without external libraries like Trilinos.