### PR TITLE
Add Gauss Radau quadrature

### DIFF
--- a/include/ideal.II/base/quadrature_lib.hh
+++ b/include/ideal.II/base/quadrature_lib.hh
@@ -21,6 +21,69 @@
 namespace idealii
 {
 
+
+    
+/**
+ * The Gauss-Radau family of quadrature rules for numerical integration.
+ *
+ * This modification of the Gauss quadrature uses one of the two interval end
+ * points as well. Being exact for polynomials of degree $2n-2$, this
+ * formula is suboptimal by one degree.
+ *
+ * This formula is often used in the context of discontinuous Galerkin
+ * discretizations of ODEs and the temporal part of PDEs.
+ *
+ * The quadrature points are the left interval end point plus the $n-1$
+ * roots of the polynomial
+ * \f[
+ *   \frac{P_{n-1}(x)+P_n(x)}{1+x}
+ * \f]
+ * where $P_{n-1}$ and $P_n$ are Legendre polynomials.
+ * The quadrature weights are
+ * \f[
+ *   w_0=\frac{2}{n^2}\quad\text{and}
+ *   \quad w_i=\frac{1-x_i}{n^2(P_{n-1}(x_i))^2}\text{ for }i>0
+ * \f]
+ *
+ * For the right Gauss-Radau formula the quadrature points are
+ * $\tilde{x}_i=1-x_{n-i-1}$ and the weights are $\tilde{w}_i=w_{n-i-1}$,
+ * with $(x_i,w_i)$ as quadrature points
+ * and weights of the left Gauss-Radau formula.
+ *
+ * @see https://mathworld.wolfram.com/RadauQuadrature.html
+ */
+    template<int dim>
+    class QGaussRadau :public dealii::Quadrature<dim>
+    {
+    public:
+        /*
+         * EndPoint is used to specify which of the two endpoints of the 
+         * unit interval is used as quadrature point 
+         */
+        enum EndPoint
+        {
+            /**
+             * Left end point.
+             */
+            left,
+            /**
+             * Right end point.
+             */
+            right
+        };
+
+        /// Generate a formula wit <tt>n</tt> quadrature points
+        QGaussRadau(const unsigned int n,
+                    EndPoint           end_point = QGaussRadau::left);
+        /**
+         * Move constructor. We cannot rely on the move constructor for `Quadrature`,
+         * since it does not know about the additional member `end_point` of this class.
+         */             
+        QGaussRadau(QGaussRadau<dim> &&) noexcept = default;
+    private:
+        const EndPoint end_point;
+    };
+
     /**
      * @brief 1D right box rule.
      *
@@ -31,7 +94,7 @@ namespace idealii
      * elements in time leads to the backward Euler method.
      *
      */
-    class QRightBox : public dealii::Quadrature<1>
+    class QRightBox : public QGaussRadau<1>
     {
     public:
         /**
@@ -52,7 +115,7 @@ namespace idealii
      * Although this is not necessarily desirable, using this formula for dG(0)
      * elements in time leads to the forward Euler method.
      */
-    class QLeftBox : public dealii::Quadrature<1>
+    class QLeftBox : public QGaussRadau<1>
     {
     public:
         /**
@@ -64,6 +127,7 @@ namespace idealii
         QLeftBox ();
     };
 
+    
     namespace spacetime
     {
 

--- a/include/ideal.II/dofs/slab_dof_tools.hh
+++ b/include/ideal.II/dofs/slab_dof_tools.hh
@@ -8,10 +8,12 @@
 #ifndef INCLUDE_IDEAL_II_DOFS_SLAB_DOF_TOOLS_HH_
 #define INCLUDE_IDEAL_II_DOFS_SLAB_DOF_TOOLS_HH_
 
+#include <deal.II/base/types.h>
 #include <ideal.II/dofs/slab_dof_handler.hh>
 
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/dofs/dof_tools.h>
+#include "ideal.II/fe/fe_dg.hh"
 
 namespace idealii::slab::DoFTools
 {
@@ -35,6 +37,34 @@ namespace idealii::slab::DoFTools
                     time_dsp.add ( ii , ii - 1 );
                 }
             }
+            else if ( dof.fe_support_type() == spacetime::DG_FiniteElement<dim>::support_type::RadauLeft)
+            {
+                for ( dealii::types::global_dof_index ii =
+                       dof.dofs_per_cell_time() ; 
+                       ii < dof.n_dofs_time() ;
+                       ii += dof.dofs_per_cell_time())
+                {
+                    for (dealii::types::global_dof_index l = 0 ;
+                         l < dof.dofs_per_cell_time() ; l++)
+                        {
+                             time_dsp.add ( ii , ii - l - 1);
+                        }
+                }
+            }
+            else if ( dof.fe_support_type() == spacetime::DG_FiniteElement<dim>::support_type::RadauRight)
+            {
+                for ( dealii::types::global_dof_index ii =
+                       dof.dofs_per_cell_time() ; 
+                       ii < dof.n_dofs_time() ;
+                       ii += dof.dofs_per_cell_time())
+                {
+                    for (dealii::types::global_dof_index k = 0 ;
+                          k < dof.dofs_per_cell_time() ; k++)
+                        {
+                             time_dsp.add ( ii + k , ii -1);
+                        }
+                }
+            } 
             else
             {
                 //go over first DoF of each cell
@@ -74,7 +104,35 @@ namespace idealii::slab::DoFTools
                     time_dsp.add ( ii-1 , ii );
                 }
             }
-            else
+            else if ( dof.fe_support_type() == spacetime::DG_FiniteElement<dim>::support_type::RadauRight)
+            {
+                for ( dealii::types::global_dof_index ii =
+                       dof.dofs_per_cell_time() ; 
+                       ii < dof.n_dofs_time() ;
+                       ii += dof.dofs_per_cell_time())
+                {
+                    for (dealii::types::global_dof_index k = 0 ;
+                          k < dof.dofs_per_cell_time() ; k++)
+                        {
+                             time_dsp.add ( ii -1 , ii + k );
+                        }
+                }
+            } 
+            else if ( dof.fe_support_type() == spacetime::DG_FiniteElement<dim>::support_type::RadauLeft)
+            {
+                for ( dealii::types::global_dof_index ii =
+                       dof.dofs_per_cell_time() ; 
+                       ii < dof.n_dofs_time() ;
+                       ii += dof.dofs_per_cell_time())
+                {
+                    for (dealii::types::global_dof_index l = 0 ;
+                         l < dof.dofs_per_cell_time() ; l++)
+                        {
+                             time_dsp.add ( ii - l - 1 , ii );
+                        }
+                }
+            }
+            else 
             {
                 //go over first DoF of each cell
                 for ( dealii::types::global_dof_index ii =

--- a/include/ideal.II/fe/fe_dg.hh
+++ b/include/ideal.II/fe/fe_dg.hh
@@ -57,7 +57,11 @@ namespace idealii::spacetime
             /**Support points based on QGauss<1>*/
             Legendre,
             /**for dG(r), r>0: Support points based on QGaussLobatto<1>*/
-            Lobatto
+            Lobatto,
+            /**Support points based on left QGaussRadau<1>*/
+            RadauLeft,
+            /**Support points based on right QGaussRadau<1>*/
+            RadauRight
         };
         /**
          * @brief Constructor for the finite element class.

--- a/src/base/quadrature_lib.cc
+++ b/src/base/quadrature_lib.cc
@@ -13,26 +13,262 @@
 //
 // ---------------------------------------------------------------------
 
+#include <cmath>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/quadrature.h>
 #include <ideal.II/base/quadrature_lib.hh>
 #include <deal.II/base/quadrature_lib.h>
+#include <vector>
 namespace idealii
 {
+    namespace internal::QGaussRadau
+    {
+        // Implements lookup table after affine transformation to [0,1].
+        //
+        // Analytical values for [-1,1] and n < 4 listed on
+        // https://mathworld.wolfram.com/RadauQuadrature.html
+        // Values for n > 3 calculated with the Julia Package
+        // FastGaussQuadrature.jl
+        // https://github.com/JuliaApproximation/FastGaussQuadrature.jl
+        //
+        std::vector<double>
+        get_left_quadrature_points(const unsigned int n)
+        {
+            std::vector<double> q_points(n);
+            switch(n)
+            {
+                case 1:
+                    q_points[0] = 0.;
+                    break;
+                case 2:
+                    q_points[0] = 0.;
+                    q_points[1] = 2./3.;
+                    break;
+                case 3:
+                    q_points[0] = 0.;
+                    q_points[1] = (6.-std::sqrt(6))*0.1;
+                    q_points[2] = (6.+std::sqrt(6))*0.1;
+                    break;
+                case 4:
+                    q_points[0] = 0.000000000000000000;
+                    q_points[1] = 0.212340538239152943;
+                    q_points[2] = 0.590533135559265343;
+                    q_points[3] = 0.911412040487296071;
+                    break;
+                case 5:
+                    q_points[0] = 0.000000000000000000;
+                    q_points[1] = 0.139759864343780571;
+                    q_points[2] = 0.416409567631083166;
+                    q_points[3] = 0.723156986361876197;
+                    q_points[4] = 0.942895803885482331;
+                    break;
+                case 6:
+                    q_points[0] = 0.000000000000000000;
+                    q_points[1] = 0.098535085798826416;
+                    q_points[2] = 0.304535726646363913;
+                    q_points[3] = 0.562025189752613841;
+                    q_points[4] = 0.801986582126391845;
+                    q_points[5] = 0.960190142948531222;
+                    break;
+                case 7:
+                    q_points[0] = 0.000000000000000000;
+                    q_points[1] = 0.073054328680258851;
+                    q_points[2] = 0.230766137969945495;
+                    q_points[3] = 0.441328481228449865;
+                    q_points[4] = 0.663015309718845702;
+                    q_points[5] = 0.851921400331515644;
+                    q_points[6] = 0.970683572840215114;
+                    break;
+                case 8:
+                    q_points[0] = 0.000000000000000000;
+                    q_points[1] = 0.056262560536922135;
+                    q_points[2] = 0.180240691736892389;
+                    q_points[3] = 0.352624717113169672;
+                    q_points[4] = 0.547153626330555420;
+                    q_points[5] = 0.734210177215410598;
+                    q_points[6] = 0.885320946839095790;
+                    q_points[7] = 0.977520613561287499;
+                    break;
+                default:
+                    Assert(false, dealii::StandardExceptions::ExcNotImplemented());
+                    break;
+            }
+            return q_points;
+        }
+
+        std::vector<double>
+        get_quadrature_points(const unsigned int                  n,
+                              ::idealii::QGaussRadau<1>::EndPoint end_point)
+        {
+            std::vector<double> left_points = get_left_quadrature_points(n);
+            switch(end_point)
+            {
+                case ::idealii::QGaussRadau<1>::left:
+                {
+                    return left_points;
+                }
+                case ::idealii::QGaussRadau<1>::right:
+                {
+                    std::vector<double> points(n);
+                    for (unsigned int i = 0 ; i < n ; ++i){
+                        points[n-i-1] = 1.-left_points[i];
+                    }
+                    return points;
+                }
+                default:
+                {
+                    Assert(
+                        false,
+                        dealii::ExcMessage(
+                          "This constructor can only be called with either "
+                          "QGaussRadau::left or QGaussRadau::right as "
+                          "second argument."  
+                        ));
+                    return {};
+                }
+            }
+        }
+
+        // Implements lookup table after affine transformation to [0,1].
+        //
+        // Analytical values for [-1,1] and n < 4 listed on
+        // https://mathworld.wolfram.com/RadauQuadrature.html
+        // Values for n > 3 calculated with the Julia Package
+        // FastGaussQuadrature.jl
+        // https://github.com/JuliaApproximation/FastGaussQuadrature.jl
+        //
+        std::vector<double>
+        get_left_quadrature_weights(const unsigned int n)
+        {
+            std::vector<double> weights(n);
+            switch(n)
+            {
+                case 1:
+                    weights[0] = 1.;
+                    break;
+                case 2:
+                    weights[0] = 0.25;
+                    weights[1] = 0.75;
+                    break;
+                case 3:
+                    weights[0] = 1./9.;
+                    weights[1] = (16.+std::sqrt(6))/36.;
+                    weights[2] = (16.-std::sqrt(6))/36.;
+                    break;
+                case 4:
+                    weights[0] = 0.062500000000000000;
+                    weights[1] = 0.328844319980059696;
+                    weights[2] = 0.388193468843171852;
+                    weights[3] = 0.220462211176768369;
+                    break;
+                case 5:
+                    weights[0] = 0.040000000000000001;
+                    weights[1] = 0.223103901083570894;
+                    weights[2] = 0.311826522975741427;
+                    weights[3] = 0.281356015149462124;
+                    weights[4] = 0.143713560791225797;
+                    break;
+                case 6:
+                    weights[0] = 0.027777777777777776;
+                    weights[1] = 0.159820376610255471;
+                    weights[2] = 0.242693594234484888;
+                    weights[3] = 0.260463391594787597;
+                    weights[4] = 0.208450667155953895;
+                    weights[5] = 0.100794192626740456;
+                    break;
+                case 7:
+                    weights[0] = 0.020408163265306121;
+                    weights[1] = 0.119613744612656100;
+                    weights[2] = 0.190474936822115581;
+                    weights[3] = 0.223554914507283209;
+                    weights[4] = 0.212351889502977870;
+                    weights[5] = 0.159102115733650767;
+                    weights[6] = 0.074494235556010341;
+                    break;
+                case 8:
+                    weights[0] = 0.015625000000000000;
+                    weights[1] = 0.092679077401489660;
+                    weights[2] = 0.152065310323392683;
+                    weights[3] = 0.188258772694559262;
+                    weights[4] = 0.195786083726246729;
+                    weights[5] = 0.173507397817250691;
+                    weights[6] = 0.124823950664932445;
+                    weights[7] = 0.057254407372128648;
+                    break;
+                default:
+                    Assert(false, dealii::StandardExceptions::ExcNotImplemented());
+                    break;
+            }
+            return weights;
+        }
+        std::vector<double>
+        get_quadrature_weights(const unsigned int                       n,
+                            const ::idealii::QGaussRadau<1>::EndPoint end_point)
+        {
+        std::vector<double> left_weights = get_left_quadrature_weights(n);
+        switch (end_point)
+            {
+            case ::idealii::QGaussRadau<1>::EndPoint::left:
+                return left_weights;
+            case ::idealii::QGaussRadau<1>::EndPoint::right:
+                {
+                std::vector<double> weights(n);
+                for (unsigned int i = 0; i < n; ++i)
+                    {
+                    weights[n - i - 1] = left_weights[i];
+                    }
+                return weights;
+                }
+            default:
+                Assert(false,
+                    dealii::ExcMessage(
+                        "This constructor can only be called with either "
+                        "QGaussRadau::EndPoint::left or "
+                        "QGaussRadau::EndPoint::right as second argument."));
+                return {};
+            }
+        }
+    }
+
+#ifndef DOXYGEN
+    template<>
+    QGaussRadau<1>::QGaussRadau(const unsigned int n, EndPoint end_point)
+        : dealii::Quadrature<1>(n),
+        end_point(end_point)
+    {
+        Assert(n > 0, dealii::ExcMessage("Need at least one point for quadrature rules"));
+        std::vector<double> p = 
+          internal::QGaussRadau::get_quadrature_points(n,end_point);
+        std::vector<double> w = 
+          internal::QGaussRadau::get_quadrature_weights(n,end_point);
+
+        for ( unsigned int i = 0 ; i < this->size() ; ++i)
+        {
+            this->quadrature_points[i] = dealii::Point<1>(p[i]);
+            this->weights[i]           = w[i];
+        }
+    }
+#endif
+
+    template<int dim>
+    QGaussRadau<dim>::QGaussRadau(const unsigned int n,
+                                  EndPoint           end_point)
+        : dealii::Quadrature<dim>(QGaussRadau<1>(
+            n,
+            static_cast<QGaussRadau<1>::EndPoint>(end_point)))
+        , end_point(end_point)
+    {}
+
     QRightBox::QRightBox ()
         :
-        dealii::Quadrature<1> ( 1 )
-    {
-        this->quadrature_points[0] = dealii::Point<1> ( 1.0 );
-        this->weights[0] = 1.0;
-    }
+        QGaussRadau<1> ( 1 , QGaussRadau<1>::EndPoint::right )
+    {}
 
     QLeftBox::QLeftBox ()
         :
-        dealii::Quadrature<1> ( 1 )
-    {
-        this->quadrature_points[0] = dealii::Point<1> ( 0.0 );
-        this->weights[0] = 1.0;
-    }
-
+        QGaussRadau<1> ( 1, QGaussRadau<1>::EndPoint::right )
+    {}
+    
     namespace spacetime
     {
         template<int dim>

--- a/src/base/quadrature_lib.inst
+++ b/src/base/quadrature_lib.inst
@@ -16,8 +16,16 @@
 #ifndef __IDEAL_II_BASE_SPACETIME_QUADRATURE_inst
 #define __IDEAL_II_BASE_SPACETIME_QUADRATURE_inst
 
-namespace idealii::spacetime
+namespace idealii
 {
+  
+  // explicit specialization
+  // note that 1d formulae are specialized by implementation
+  template class QGaussRadau<2>;
+  template class QGaussRadau<3>;
+
+  namespace spacetime
+  {
     template class QGauss<1> ;
     template class QGauss<2> ;
     template class QGauss<3> ;
@@ -25,6 +33,7 @@ namespace idealii::spacetime
     template class QGaussRightBox<1> ;
     template class QGaussRightBox<2> ;
     template class QGaussRightBox<3> ;
+  }
 }
 
 #endif

--- a/src/fe/fe_dg.cc
+++ b/src/fe/fe_dg.cc
@@ -13,7 +13,10 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/fe/fe_dgq.h>
 #include <ideal.II/fe/fe_dg.hh>
+#include <memory>
+#include "ideal.II/base/quadrature_lib.hh"
 #include <deal.II/base/quadrature_lib.h>
 
 namespace idealii::spacetime
@@ -27,16 +30,31 @@ namespace idealii::spacetime
         _fe_space (fe_space ),
         _type ( type )
     {
-        if ( type == support_type::Legendre || r == 0 )
+        if ( type == support_type::Legendre || (type == support_type::Lobatto && r == 0) )
         {
             _fe_time =
                 std::make_shared<dealii::FE_DGQArbitraryNodes<1>> (dealii::QGauss<1> ( r + 1 ) );
         }
-        else
+        else if (type == support_type::Lobatto)
         {
             _fe_time =
                 std::make_shared<dealii::FE_DGQArbitraryNodes<1>> (dealii::QGaussLobatto<1> ( r + 1 ) );
         }
+        else if (type == support_type::RadauLeft)
+        {
+            _fe_time = 
+                std::make_shared<dealii::FE_DGQArbitraryNodes<1>>(
+                    idealii::QGaussRadau<1>(r+1,QGaussRadau<1>::left)
+                );
+        }
+        else 
+        {
+            _fe_time = 
+                std::make_shared<dealii::FE_DGQArbitraryNodes<1>>(
+                    idealii::QGaussRadau<1>(r+1,QGaussRadau<1>::right)
+                );
+        }
+    
     }
 
     template<int dim>


### PR DESCRIPTION
This adds both the Quadrature rules (left and right) 
as well as corresponding options for constructing 
`DG_FiniteElement` objects with temporal support points
based on the quadrature points.