### PR TITLE
Add clang-format specification

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,205 @@
+#
+# The clang-format (Clang 16) style file used by ideal.II.
+#
+
+AccessModifierOffset: -2
+
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterExternBlock: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: true
+  IndentBraces: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: false
+
+ColumnLimit: 80
+
+CompactNamespaces: false
+
+ConstructorInitializerIndentWidth: 2
+
+ContinuationIndentWidth: 2
+
+Cpp11BracedListStyle: true
+
+DerivePointerAlignment: false
+
+FixNamespaceComments: true
+
+IncludeBlocks: Regroup
+
+
+# TODO: This has to be adapted to ideal!!
+
+IncludeCategories:
+# configs must always be first:
+  - Regex:    "ideal.II/base/idealii.hh"
+    Priority: -2
+  - Regex:    "deal.II/base/config.h"
+    Priority: -1
+# ideal.II folders in sorted order:
+  - Regex:    "ideal.II/base/.*\\.hh"
+    Priority: 10
+  - Regex:    "ideal.II/distributed/.*\\.hh"
+    Priority: 20
+  - Regex:    "ideal.II/dofs/.*\\.hh"
+    Priority: 30
+  - Regex:    "ideal.II/fe/.*\\.hh"
+    Priority: 40
+  - Regex:    "ideal.II/grid/.*\\.hh"
+    Priority: 50
+  - Regex:    "ideal.II/lac/.*\\.hh"
+    Priority: 60
+  - Regex:    "ideal.II/numerics/.*\\.hh"
+    Priority: 70
+# deal.II folders in sorted order:
+  - Regex:    "deal.II/algorithms/.*\\.h"
+    Priority: 100
+  - Regex:    "deal.II/arborx/.*\\.h"
+    Priority: 110
+  - Regex:    "deal.II/base/.*\\.h"
+    Priority: 120
+  - Regex:    "deal.II/boost_adaptors/.*\\.h"
+    Priority: 125
+  - Regex:    "deal.II/differentiation/.*\\.h"
+    Priority: 130
+  - Regex:    "deal.II/distributed/.*\\.h"
+    Priority: 140
+  - Regex:    "deal.II/dofs/.*\\.h"
+    Priority: 150
+  - Regex:    "deal.II/fe/.*\\.h"
+    Priority: 160
+  - Regex:    "deal.II/gmsh/.*\\.h"
+    Priority: 170
+  - Regex:    "deal.II/grid/.*\\.h"
+    Priority: 180
+  - Regex:    "deal.II/hp/.*\\.h"
+    Priority: 190
+  - Regex:    "deal.II/integrators/.*\\.h"
+    Priority: 200
+  - Regex:    "deal.II/lac/.*\\.h"
+    Priority: 210
+  - Regex:    "deal.II/matrix_free/.*\\.h"
+    Priority: 220
+  - Regex:    "deal.II/meshworker/.*\\.h"
+    Priority: 230
+  - Regex:    "deal.II/multigrid/.*\\.h"
+    Priority: 240
+  - Regex:    "deal.II/non_matching/.*\\.h"
+    Priority: 250
+  - Regex:    "deal.II/numerics/.*\\.h"
+    Priority: 260
+  - Regex:    "deal.II/opencascade/.*\\.h"
+    Priority: 270
+  - Regex:    "deal.II/optimization/.*\\.h"
+    Priority: 280
+  - Regex:    "deal.II/particles/.*\\.h"
+    Priority: 290
+  - Regex:    "deal.II/physics/.*\\.h"
+    Priority: 300
+  - Regex:    "deal.II/sundials/.*\\.h"
+    Priority: 310
+  - Regex:    "deal.II/trilinos/.*\\.h"
+    Priority: 320
+# put boost right after deal:
+  - Regex: "<boost.*>"
+    Priority: 500
+# try to group PETSc headers:
+  - Regex: "<petsc.*\\.h>"
+    Priority: 1000
+# try to catch all third party headers and put them after deal.II but before
+# standard headers:
+  - Regex: "<.*\\.(h|hpp|hxx|hh)>"
+    Priority: 2000
+# match all standard headers. Things like '#include <armadillo>' should be
+# surrounded by #ifdef checks (which will not be merged by clang-format) so they
+# should not be caught here
+  - Regex: "<[a-z_]+>"
+    Priority: 100000
+# make sure that "../tests.h" appears before all other local include files
+# such that replacing Assert in tests also applies to the testing header files.
+  - Regex: "\\.\\./tests\\.h"
+    Priority: 200000
+
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth: 2
+
+IndentWrappedFunctionNames: false
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+Language: Cpp
+
+MaxEmptyLinesToKeep: 3
+
+NamespaceIndentation: All
+
+PenaltyBreakBeforeFirstCallParameter: 90
+
+PointerAlignment: Right
+
+ReflowComments: true
+CommentPragmas: '( \| |\*--|<li>|@ref | @p |@param |@name |@returns |@warning |@ingroup |@author |@date |@related |@relates |@relatesalso |@deprecated |@image |@return |@brief |@attention |@copydoc |@addtogroup |@todo |@tparam |@see |@note |@skip |@skipline |@until |@line |@dontinclude |@include |Note)'
+
+QualifierAlignment: Left
+
+SortIncludes: true
+SortUsingDeclarations: true
+
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+Standard: c++20
+
+TabWidth: 2
+
+UseTab: Never

--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -1,0 +1,22 @@
+name: indent
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
+jobs:
+  indent:
+    name: indent
+    runs-on: [ubuntu-24.04]
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: install_dependencies
+      sudo apt update && sudo apt install clang-format
+    - name: configure
+      cmake -D DOCUMENTATION_ONLY=ON -S. -Bbuild
+    - name: check-format
+      cmake --build build --target check-format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,22 @@ if(NOT DOCUMENTATION_ONLY)
 
 
   add_subdirectory(examples)
+
+
 endif()
 add_subdirectory(doc/doxygen)
 
+find_program(CLANG_FORMAT clang-format)
+
+if(${CLANG_FORMAT} STREQUAL "CLANG_FORMAT-NOTFOUND")
+    message("-- clang-format not found, custom check-format target will not be configured.")
+else()
+    message("-- clang-format found, setting up target check-format.")
+    file(GLOB_RECURSE FORMAT_SRC "src/*/*.cc" "src/*/*.inst")
+    file(GLOB_RECURSE FORMAT_INCLUDE "include/*/*.hh")
+    file(GLOB_RECURSE FORMAT_EXAMPLES "examples/*/*.cc")
+
+    add_custom_target(check-format 
+    COMMENT "Using clang-format to check for wrong indents"
+       COMMAND ${CLANG_FORMAT} --dry-run --Werror ${FORMAT_SRC} ${FORMAT_INCLUDE} ${FORMAT_EXAMPLES})
+endif()

--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -58,15 +58,15 @@
 #include <deal.II/fe/fe_q.h>
 
 // needed to generate underlying spatial grid
-#include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
 
 // All the linear algebra classes are used from deal.II directly
-#include <deal.II/lac/vector.h>
-#include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/sparse_direct.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
 
 // ideal.II uses deal.II functions with set and get time
 #include <deal.II/base/function.h>
@@ -86,26 +86,24 @@
  * It could be used to calculate L2-errors for example.
  * Here it is only used to give the full problem description
  */
-class ExactSolution : public dealii::Function<2,double>
+class ExactSolution : public dealii::Function<2, double>
 {
 public:
-    ExactSolution ()
-        :
-        dealii::Function<2,double> ()
-    {
-    }
-    double
-    value ( const dealii::Point<2> &p ,
-            const unsigned int component = 0 ) const;
+  ExactSolution()
+    : dealii::Function<2, double>()
+  {}
+  double
+  value(const dealii::Point<2> &p, const unsigned int component = 0) const;
 };
 
-double ExactSolution::value ( const dealii::Point<2> &p ,
-                              [[maybe_unused]] const unsigned int component ) const
+double
+ExactSolution::value(const dealii::Point<2>             &p,
+                     [[maybe_unused]] const unsigned int component) const
 {
-    double t = get_time ();
-    double x = p ( 0 );
-    double y = p ( 1 );
-    return ( x * x - x ) * ( y * y - y ) * t * 0.25;
+  double t = get_time();
+  double x = p(0);
+  double y = p(1);
+  return (x * x - x) * (y * y - y) * t * 0.25;
 }
 
 /**
@@ -119,21 +117,22 @@ double ExactSolution::value ( const dealii::Point<2> &p ,
 class RightHandSide : public dealii::Function<2>
 {
 public:
-    virtual double
-    value ( const dealii::Point<2> &p , const unsigned int component = 0 );
+  virtual double
+  value(const dealii::Point<2> &p, const unsigned int component = 0);
 };
 
-double RightHandSide::value ( const dealii::Point<2> &p ,
-                              [[maybe_unused]] const unsigned int component )
+double
+RightHandSide::value(const dealii::Point<2>             &p,
+                     [[maybe_unused]] const unsigned int component)
 {
-    double t = get_time ();
-    double return_value = 0;
-    double x = p ( 0 );
-    double y = p ( 1 );
-    return_value += ( x * x - x ) * 0.5 * t;
-    return_value += ( y * y - y ) * 0.5 * t;
-    return_value -= ( x * x - x ) * ( y * y - y ) * 0.25;
-    return return_value;
+  double t            = get_time();
+  double return_value = 0;
+  double x            = p(0);
+  double y            = p(1);
+  return_value += (x * x - x) * 0.5 * t;
+  return_value += (y * y - y) * 0.5 * t;
+  return_value -= (x * x - x) * (y * y - y) * 0.25;
+  return return_value;
 }
 
 // This class describes the solution of the heat equation with
@@ -141,442 +140,455 @@ double RightHandSide::value ( const dealii::Point<2> &p ,
 class Step1
 {
 public:
-    // We want to be able to easily switch spatial and temporal polynomial degree
-    // i.e. bilinear/biquadratic elements in space and dG(0),dG(1),... elements in time.
-    Step1 ( unsigned int spatial_degree , unsigned int temporal_degree );
-    // This is the main function of the problem calling all other functions in the right order
-    void
-    run ();
+  // We want to be able to easily switch spatial and temporal polynomial degree
+  // i.e. bilinear/biquadratic elements in space and dG(0),dG(1),... elements in
+  // time.
+  Step1(unsigned int spatial_degree, unsigned int temporal_degree);
+  // This is the main function of the problem calling all other functions in the
+  // right order
+  void
+  run();
 
 private:
-    // Construct a spatial mesh and use it to construct a resulting space-time mesh
-    void
-    make_grid ();
-    // Iterate over all slabs in the space-time mesh
-    void
-    time_marching ();
-    // Distribute degrees of freedom and reinitialize linear algebra objects to correct size.
-    void
-    setup_system_on_slab ();
-    // Go over space-time elements in slab and calculate local contributions
-    void
-    assemble_system_on_slab ();
-    // Solve the slab space-time linear equation system
-    void
-    solve_system_on_slab ();
-    // Output the results of the current slab
-    void
-    output_results_on_slab ();
+  // Construct a spatial mesh and use it to construct a resulting space-time
+  // mesh
+  void
+  make_grid();
+  // Iterate over all slabs in the space-time mesh
+  void
+  time_marching();
+  // Distribute degrees of freedom and reinitialize linear algebra objects to
+  // correct size.
+  void
+  setup_system_on_slab();
+  // Go over space-time elements in slab and calculate local contributions
+  void
+  assemble_system_on_slab();
+  // Solve the slab space-time linear equation system
+  void
+  solve_system_on_slab();
+  // Output the results of the current slab
+  void
+  output_results_on_slab();
 
-    /////////////////////////////////////////////
-    // space-time collections of slab objects
-    /////////////////////////////////////////////
+  /////////////////////////////////////////////
+  // space-time collections of slab objects
+  /////////////////////////////////////////////
 
-    // The fixed triangulation shared a pointer to the spatial mesh
-    // such that all slabs operate on the same mesh.
-    // Without adaptivity this is the best choice as it saves on memory
-    idealii::spacetime::fixed::Triangulation<2> triangulation;
-    idealii::spacetime::DoFHandler<2> dof_handler;
-    idealii::spacetime::Vector<double> solution;
+  // The fixed triangulation shared a pointer to the spatial mesh
+  // such that all slabs operate on the same mesh.
+  // Without adaptivity this is the best choice as it saves on memory
+  idealii::spacetime::fixed::Triangulation<2> triangulation;
+  idealii::spacetime::DoFHandler<2>           dof_handler;
+  idealii::spacetime::Vector<double>          solution;
 
-    // The space-time finite element description
-    idealii::spacetime::DG_FiniteElement<2> fe;
+  // The space-time finite element description
+  idealii::spacetime::DG_FiniteElement<2> fe;
 
-    ////////////////////////////////////////////
-    // objects needed on a single slab
-    ////////////////////////////////////////////
-    dealii::SparsityPattern slab_sparsity_pattern;
-    std::shared_ptr<dealii::AffineConstraints<double>> slab_constraints;
-    dealii::SparseMatrix<double> slab_system_matrix;
-    dealii::Vector<double> slab_system_rhs;
-    dealii::Vector<double> slab_initial_value;
-    unsigned int slab; // count the index of the current slab
+  ////////////////////////////////////////////
+  // objects needed on a single slab
+  ////////////////////////////////////////////
+  dealii::SparsityPattern                            slab_sparsity_pattern;
+  std::shared_ptr<dealii::AffineConstraints<double>> slab_constraints;
+  dealii::SparseMatrix<double>                       slab_system_matrix;
+  dealii::Vector<double>                             slab_system_rhs;
+  dealii::Vector<double>                             slab_initial_value;
+  unsigned int slab; // count the index of the current slab
 
-    /////////////////////////////////////////////////////////////
-    // Struct holding all iterators over the space-time objects.
-    //   this is completely optional but hopefully enhances
-    //   readability as it becomes clear that these are iterators.
-    /////////////////////////////////////////////////////////////
-    struct
-    {
-        idealii::slab::TriaIterator<2> tria;
-        idealii::slab::DoFHandlerIterator<2> dof;
-        idealii::slab::VectorIterator<double> solution;
-    } slab_its;
-
+  /////////////////////////////////////////////////////////////
+  // Struct holding all iterators over the space-time objects.
+  //   this is completely optional but hopefully enhances
+  //   readability as it becomes clear that these are iterators.
+  /////////////////////////////////////////////////////////////
+  struct
+  {
+    idealii::slab::TriaIterator<2>        tria;
+    idealii::slab::DoFHandlerIterator<2>  dof;
+    idealii::slab::VectorIterator<double> solution;
+  } slab_its;
 };
 
 // constructor
-Step1::Step1 ( unsigned int spatial_degree , unsigned int temporal_degree )
-        :
-        // space-time triangulation
-        triangulation (),
-        // DoFHandler has to get pointer to space-time tria
-        // as different types (e.g. MPI parallel triangulations) can't be derived
-        // from a common base class due to lists of shared pointers.
-        dof_handler ( &triangulation ),
-        // space-time finite element with
-        // * continuous Lagrangian FE_Q finite element in space of order spatial_degree
-        // * discontinuous Lagrangian FE_DGQ finite element in time of order temporal_degree
-        fe ( std::make_shared < dealii::FE_Q < 2 >> ( spatial_degree ) ,
-             temporal_degree ),
-        // initialize current slab number to 0
-        slab ( 0 )
-{
-}
+Step1::Step1(unsigned int spatial_degree, unsigned int temporal_degree)
+  : // space-time triangulation
+  triangulation()
+  ,
+  // DoFHandler has to get pointer to space-time tria
+  // as different types (e.g. MPI parallel triangulations) can't be derived
+  // from a common base class due to lists of shared pointers.
+  dof_handler(&triangulation)
+  ,
+  // space-time finite element with
+  // * continuous Lagrangian FE_Q finite element in space of order
+  // spatial_degree
+  // * discontinuous Lagrangian FE_DGQ finite element in time of order
+  // temporal_degree
+  fe(std::make_shared<dealii::FE_Q<2>>(spatial_degree), temporal_degree)
+  ,
+  // initialize current slab number to 0
+  slab(0)
+{}
 
 // This functions is much shorter compared to the stationary versions
 // as the common FE-code loop is inside the time_marching function
-void Step1::run ()
+void
+Step1::run()
 {
-    make_grid ();
-    time_marching ();
+  make_grid();
+  time_marching();
 }
 
-void Step1::make_grid ()
+void
+Step1::make_grid()
 {
-    // construct a shared pointer to a spatial triangulation
-    auto space_tria = std::make_shared<dealii::Triangulation<2>> ();
-    // generate a unit square spatial domain
-    dealii::GridGenerator::hyper_cube ( *space_tria );
-    // number of initial slabs in the triangulation
-    const unsigned int M = 5;
-    // Fill the internal list with M slab::Triangulation objects sharing the same spatial triangulation
-    triangulation.generate ( space_tria , M );
-    // Refine the grids on each slab in (space,time)
-    triangulation.refine_global ( 4 , 0 );
-    // Generate a slab::DoFHandler for each slab::Triangulation
-    dof_handler.generate ();
+  // construct a shared pointer to a spatial triangulation
+  auto space_tria = std::make_shared<dealii::Triangulation<2>>();
+  // generate a unit square spatial domain
+  dealii::GridGenerator::hyper_cube(*space_tria);
+  // number of initial slabs in the triangulation
+  const unsigned int M = 5;
+  // Fill the internal list with M slab::Triangulation objects sharing the same
+  // spatial triangulation
+  triangulation.generate(space_tria, M);
+  // Refine the grids on each slab in (space,time)
+  triangulation.refine_global(4, 0);
+  // Generate a slab::DoFHandler for each slab::Triangulation
+  dof_handler.generate();
 }
 
-void Step1::time_marching ()
+void
+Step1::time_marching()
 {
-    // This collection simplifies time marching and increments all
-    // registered spacetime iterators at the same time
-    idealii::TimeIteratorCollection < 2 > tic = idealii::TimeIteratorCollection<
-            2> ();
+  // This collection simplifies time marching and increments all
+  // registered spacetime iterators at the same time
+  idealii::TimeIteratorCollection<2> tic = idealii::TimeIteratorCollection<2>();
 
-    // Fill the internal list of vectors with M dealii::Vector<double> vectors.
-    solution.reinit ( triangulation.M () );
+  // Fill the internal list of vectors with M dealii::Vector<double> vectors.
+  solution.reinit(triangulation.M());
 
-    // Get iterators to the first slabs
-    slab_its.tria = triangulation.begin ();
-    slab_its.dof = dof_handler.begin ();
-    slab_its.solution = solution.begin ();
+  // Get iterators to the first slabs
+  slab_its.tria     = triangulation.begin();
+  slab_its.dof      = dof_handler.begin();
+  slab_its.solution = solution.begin();
 
-    // Register iterators with the TimeIteratorCollection
-    tic.add_iterator ( &slab_its.tria , &triangulation );
-    tic.add_iterator ( &slab_its.dof , &dof_handler );
-    tic.add_iterator ( &slab_its.solution , &solution );
-    std::cout << "*******Starting time-stepping*********" << std::endl;
+  // Register iterators with the TimeIteratorCollection
+  tic.add_iterator(&slab_its.tria, &triangulation);
+  tic.add_iterator(&slab_its.dof, &dof_handler);
+  tic.add_iterator(&slab_its.solution, &solution);
+  std::cout << "*******Starting time-stepping*********" << std::endl;
 
-    slab = 0;
-    // Iterate over the iterator collection
-    for ( ; !tic.at_end () ; tic.increment () )
+  slab = 0;
+  // Iterate over the iterator collection
+  for (; !tic.at_end(); tic.increment())
     {
-        std::cout << "Starting time-step (" << slab_its.tria->startpoint ()
-        << ","
-        << slab_its.tria->endpoint () << "]" << std::endl;
+      std::cout << "Starting time-step (" << slab_its.tria->startpoint() << ","
+                << slab_its.tria->endpoint() << "]" << std::endl;
 
-        // this is the "typical" FE-code loop without the make_grid function
-        setup_system_on_slab ();
-        assemble_system_on_slab ();
-        solve_system_on_slab ();
-        output_results_on_slab ();
-        // Take the slab solution subvector at the final temporal dof of the current slab
-        // This is needed as the initial value for the next slab
-        idealii::slab::VectorTools::extract_subvector_at_time_dof (
-                *slab_its.solution , slab_initial_value ,
-                slab_its.tria->temporal ()->n_global_active_cells () - 1 );
-        slab++;
+      // this is the "typical" FE-code loop without the make_grid function
+      setup_system_on_slab();
+      assemble_system_on_slab();
+      solve_system_on_slab();
+      output_results_on_slab();
+      // Take the slab solution subvector at the final temporal dof of the
+      // current slab This is needed as the initial value for the next slab
+      idealii::slab::VectorTools::extract_subvector_at_time_dof(
+        *slab_its.solution,
+        slab_initial_value,
+        slab_its.tria->temporal()->n_global_active_cells() - 1);
+      slab++;
     }
 }
 
-void Step1::setup_system_on_slab ()
+void
+Step1::setup_system_on_slab()
 {
+  // Distribute spatial and temporal dofs
+  slab_its.dof->distribute_dofs(fe);
+  std::cout << "Number of degrees of freedom: \n\t"
+            << slab_its.dof->n_dofs_space() << " (space) * "
+            << slab_its.dof->n_dofs_time()
+            << " (time) = " << slab_its.dof->n_dofs_spacetime() << std::endl;
 
-    // Distribute spatial and temporal dofs
-    slab_its.dof->distribute_dofs ( fe );
-    std::cout << "Number of degrees of freedom: \n\t"
-              << slab_its.dof->n_dofs_space () << " (space) * "
-              << slab_its.dof->n_dofs_time () << " (time) = "
-              << slab_its.dof->n_dofs_spacetime ()
-              << std::endl;
-
-    // On the first slab the initial value vector has to be set to the correct (spatial) size.
-    if ( slab == 0 )
+  // On the first slab the initial value vector has to be set to the correct
+  // (spatial) size.
+  if (slab == 0)
     {
-        slab_initial_value.reinit ( slab_its.dof->n_dofs_space () );
-        // For the above ExactSolution the initial value is 0
-        slab_initial_value = 0;
+      slab_initial_value.reinit(slab_its.dof->n_dofs_space());
+      // For the above ExactSolution the initial value is 0
+      slab_initial_value = 0;
     }
 
-    // construct the constraint object
-    slab_constraints = std::make_shared<dealii::AffineConstraints<double>> ();
+  // construct the constraint object
+  slab_constraints = std::make_shared<dealii::AffineConstraints<double>>();
 
-    // The Dirichlet boundary condition for the ExactSolution is homogeneous
-    auto zero = dealii::Functions::ZeroFunction<2> ();
-    // Add Dirichlet boundary values to the constraint object.
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              0 ,
-                                                              zero ,
-                                                              slab_constraints );
+  // The Dirichlet boundary condition for the ExactSolution is homogeneous
+  auto zero = dealii::Functions::ZeroFunction<2>();
+  // Add Dirichlet boundary values to the constraint object.
+  idealii::slab::VectorTools::interpolate_boundary_values(*slab_its.dof,
+                                                          0,
+                                                          zero,
+                                                          slab_constraints);
 
-    slab_constraints->close ();
+  slab_constraints->close();
 
-    // initialize a dynamic sparsity pattern to the slab size
-    dealii::DynamicSparsityPattern dsp ( slab_its.dof->n_dofs_spacetime () );
-    // construct the space-time sparsity pattern
-    // Upwind means we solve forward in time and need information for
-    // internal jump terms for slabs with more than one temporal element.
-    idealii::slab::DoFTools::make_upwind_sparsity_pattern ( *slab_its.dof , dsp );
+  // initialize a dynamic sparsity pattern to the slab size
+  dealii::DynamicSparsityPattern dsp(slab_its.dof->n_dofs_spacetime());
+  // construct the space-time sparsity pattern
+  // Upwind means we solve forward in time and need information for
+  // internal jump terms for slabs with more than one temporal element.
+  idealii::slab::DoFTools::make_upwind_sparsity_pattern(*slab_its.dof, dsp);
 
-    // as in deal.II
-    slab_sparsity_pattern.copy_from ( dsp );
-    slab_system_matrix.reinit ( slab_sparsity_pattern );
+  // as in deal.II
+  slab_sparsity_pattern.copy_from(dsp);
+  slab_system_matrix.reinit(slab_sparsity_pattern);
 
-    // set solution and right hand side to the correct number of unknowns
-    slab_its.solution->reinit ( slab_its.dof->n_dofs_spacetime () );
-    slab_system_rhs.reinit ( slab_its.dof->n_dofs_spacetime () );
+  // set solution and right hand side to the correct number of unknowns
+  slab_its.solution->reinit(slab_its.dof->n_dofs_spacetime());
+  slab_system_rhs.reinit(slab_its.dof->n_dofs_spacetime());
 }
 
-void Step1::assemble_system_on_slab ()
+void
+Step1::assemble_system_on_slab()
 {
+  // Similar to the stationary case we start with a quadrature and FEValues
+  // objects
+  idealii::spacetime::QGauss<2> quad(fe.spatial()->degree + 2,
+                                     fe.temporal()->degree + 2);
 
-    // Similar to the stationary case we start with a quadrature and FEValues objects
-    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 2 ,
-                                            fe.temporal ()->degree + 2 );
+  idealii::spacetime::FEValues<2> fe_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    idealii::spacetime::FEValues < 2 > fe_values_spacetime ( fe ,
-                                                             quad ,
-                                                             dealii::update_values |
-                                                             dealii::update_gradients|
-                                                             dealii::update_quadrature_points|
-                                                             dealii::update_JxW_values );
+  // To account for jump values we use the FEJumpValues object which is somewhat
+  // similar to FEFaceValues objects.
+  idealii::spacetime::FEJumpValues<2> fe_jump_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    // To account for jump values we use the FEJumpValues object which is somewhat similar
-    // to FEFaceValues objects.
-    idealii::spacetime::FEJumpValues < 2 > fe_jump_values_spacetime ( fe ,
-                                                                      quad ,
-                                                                      dealii::update_values |
-                                                                      dealii::update_gradients |
-                                                                      dealii::update_quadrature_points |
-                                                                      dealii::update_JxW_values );
+  RightHandSide right_hand_side;
 
-    RightHandSide right_hand_side;
+  // Get the number of dofs in a space-time elmement
+  const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
 
-    // Get the number of dofs in a space-time elmement
-    const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
+  // Number of temporal elements
+  unsigned int N = slab_its.tria->temporal()->n_global_active_cells();
 
-    // Number of temporal elements
-    unsigned int N = slab_its.tria->temporal ()->n_global_active_cells ();
+  // The easiest way to account for jump values is to construct local objects
+  // extruded in the temporal direction, such that they hold information over
+  // all temporal elements but just the information of a single spatial element
+  dealii::FullMatrix<double> cell_matrix(N * dofs_per_spacetime_cell,
+                                         N * dofs_per_spacetime_cell);
 
-    // The easiest way to account for jump values is to construct local objects
-    // extruded in the temporal direction, such that they hold information over all
-    // temporal elements but just the information of a single spatial element
-    dealii::FullMatrix<double> cell_matrix ( N * dofs_per_spacetime_cell ,
-                                             N * dofs_per_spacetime_cell );
+  dealii::Vector<double> cell_rhs(N * dofs_per_spacetime_cell);
 
-    dealii::Vector<double> cell_rhs ( N * dofs_per_spacetime_cell );
+  std::vector<dealii::types::global_dof_index> local_spacetime_dof_index(
+    N * dofs_per_spacetime_cell);
 
-    std::vector < dealii::types::global_dof_index > local_spacetime_dof_index ( N * dofs_per_spacetime_cell );
+  // index of the current temporal element to calculate index offset
+  unsigned int n;
+  // number of space-time and space quadrature points
+  unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
+  unsigned int n_quad_space     = quad.spatial()->size();
 
-    // index of the current temporal element to calculate index offset
-    unsigned int n;
-    // number of space-time and space quadrature points
-    unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
-    unsigned int n_quad_space = quad.spatial ()->size ();
-
-    // First, iterate over active spatial elements
-    for ( const auto &cell_space : slab_its.dof->spatial ()->active_cell_iterators () )
+  // First, iterate over active spatial elements
+  for (const auto &cell_space :
+       slab_its.dof->spatial()->active_cell_iterators())
     {
-        // recalculate local information for the current spatial element
-        fe_values_spacetime.reinit_space ( cell_space );
-        fe_jump_values_spacetime.reinit_space ( cell_space );
+      // recalculate local information for the current spatial element
+      fe_values_spacetime.reinit_space(cell_space);
+      fe_jump_values_spacetime.reinit_space(cell_space);
 
-        // get local contribution of the slab_initial_value vector
-        std::vector<double> initial_values ( fe_values_spacetime.spatial ()->n_quadrature_points );
-        fe_values_spacetime.spatial ()->get_function_values ( slab_initial_value ,
-                                                              initial_values );
+      // get local contribution of the slab_initial_value vector
+      std::vector<double> initial_values(
+        fe_values_spacetime.spatial()->n_quadrature_points);
+      fe_values_spacetime.spatial()->get_function_values(slab_initial_value,
+                                                         initial_values);
 
-        // Reset local contributions to 0
-        cell_matrix = 0;
-        cell_rhs = 0;
+      // Reset local contributions to 0
+      cell_matrix = 0;
+      cell_rhs    = 0;
 
-        // Second, iterator over active temporal elements
-        for ( const auto &cell_time : slab_its.dof->temporal ()->active_cell_iterators () )
+      // Second, iterator over active temporal elements
+      for (const auto &cell_time :
+           slab_its.dof->temporal()->active_cell_iterators())
         {
-            // As the temporal elements are part of a 1-d triangulation
-            // the indices are ordered from left to right, i.e. startpoint to endpoint
-            n = cell_time->index ();
+          // As the temporal elements are part of a 1-d triangulation
+          // the indices are ordered from left to right, i.e. startpoint to
+          // endpoint
+          n = cell_time->index();
 
-            // recalculate local information for the current temporal element
-            fe_values_spacetime.reinit_time ( cell_time );
-            fe_jump_values_spacetime.reinit_time ( cell_time );
-            // get local space-time dof indices for the current
-            // cell_space x cell_time tensor product cell
-            fe_values_spacetime.get_local_dof_indices ( local_spacetime_dof_index );
+          // recalculate local information for the current temporal element
+          fe_values_spacetime.reinit_time(cell_time);
+          fe_jump_values_spacetime.reinit_time(cell_time);
+          // get local space-time dof indices for the current
+          // cell_space x cell_time tensor product cell
+          fe_values_spacetime.get_local_dof_indices(local_spacetime_dof_index);
 
-            // Iterate over space-time quadrature points for
-            // all contributions except for jump terms
-            for ( unsigned int q = 0 ; q < n_quad_spacetime ; ++q )
+          // Iterate over space-time quadrature points for
+          // all contributions except for jump terms
+          for (unsigned int q = 0; q < n_quad_spacetime; ++q)
             {
-
-                // set the time of the right hand side to the time current quadrature point
-                right_hand_side.set_time ( fe_values_spacetime.time_quadrature_point ( q ) );
-                // get the spatial location of the current quadrature point
-                const auto &x_q = fe_values_spacetime.space_quadrature_point (
-                                                                               q );
-                // iterate over all space-time dofs of the current element
-                // and calculate contributions at current quadrature point
-                for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
+              // set the time of the right hand side to the time current
+              // quadrature point
+              right_hand_side.set_time(
+                fe_values_spacetime.time_quadrature_point(q));
+              // get the spatial location of the current quadrature point
+              const auto &x_q = fe_values_spacetime.space_quadrature_point(q);
+              // iterate over all space-time dofs of the current element
+              // and calculate contributions at current quadrature point
+              for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                 {
-                    for ( unsigned int j = 0 ; j < dofs_per_spacetime_cell ;
-                            ++j )
+                  for (unsigned int j = 0; j < dofs_per_spacetime_cell; ++j)
                     {
+                      // Note that for unsymmetric matrices the indices are flipped
+                      // in comparison to the usual weak form derivation by
+                      // multiplying test functions from the right.
 
-                        // Note that for unsymmetric matrices the indices are flipped
-                        // in comparison to the usual weak form derivation by multiplying
-                        // test functions from the right.
+                      // offset indices by the past space-time dofs of previous
+                      // temporal elements
 
-                        // offset indices by the past space-time dofs of previous
-                        // temporal elements
+                      // (dt u, v)
+                      cell_matrix(i + n * dofs_per_spacetime_cell,
+                                  j + n * dofs_per_spacetime_cell) +=
+                        fe_values_spacetime.shape_value(i, q) *
+                        fe_values_spacetime.shape_dt(j, q) *
+                        fe_values_spacetime.JxW(q);
 
-                        // (dt u, v)
-                        cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                      j + n * dofs_per_spacetime_cell )
-                        += fe_values_spacetime.shape_value ( i , q )
-                         * fe_values_spacetime.shape_dt ( j , q )
-                         * fe_values_spacetime.JxW ( q );
+                      // (grad u, grad v)
+                      cell_matrix(i + n * dofs_per_spacetime_cell,
+                                  j + n * dofs_per_spacetime_cell) +=
+                        fe_values_spacetime.shape_space_grad(i, q) *
+                        fe_values_spacetime.shape_space_grad(j, q) *
+                        fe_values_spacetime.JxW(q);
 
-                        // (grad u, grad v)
-                        cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                      j + n * dofs_per_spacetime_cell )
-                        += fe_values_spacetime.shape_space_grad ( i , q )
-                         * fe_values_spacetime.shape_space_grad ( j , q )
-                         * fe_values_spacetime.JxW ( q );
+                    } // dofs j
+                      //  Calculate local contribution of the right hand side
+                      //  function.
+                  // Note that the correct time was set above so it still is an evaluation
+                  // f(t,x)
+                  cell_rhs(i + n * dofs_per_spacetime_cell) +=
+                    fe_values_spacetime.shape_value(i, q) *
+                    right_hand_side.value(x_q) * fe_values_spacetime.JxW(q);
 
-                    } //dofs j
-                      // Calculate local contribution of the right hand side function.
-                      // Note that the correct time was set above so it still is an evaluation
-                      // f(t,x)
-                    cell_rhs ( i + n * dofs_per_spacetime_cell )
-                    += fe_values_spacetime.shape_value ( i , q )
-                     * right_hand_side.value ( x_q )
-                     * fe_values_spacetime.JxW ( q );
+                } // dofs i
+            }     // quad
 
-                } //dofs i
-            } //quad
-
-            //Jump terms and initial values just have a spatial quadrature loop
-            for ( unsigned int q = 0 ; q < n_quad_space ; ++q )
+          // Jump terms and initial values just have a spatial quadrature loop
+          for (unsigned int q = 0; q < n_quad_space; ++q)
             {
-                // However, dof loops are still over space-time indices
-                // as different temporal support points might not have a
-                // degree of freedom at the edges of the temporal element
-                // and so all shape functions contribute to the jump values
-                for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
+              // However, dof loops are still over space-time indices
+              // as different temporal support points might not have a
+              // degree of freedom at the edges of the temporal element
+              // and so all shape functions contribute to the jump values
+              for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                 {
-                    for ( unsigned int j = 0 ; j < dofs_per_spacetime_cell ;
-                            ++j )
+                  for (unsigned int j = 0; j < dofs_per_spacetime_cell; ++j)
                     {
-                        // (v^+, u^+)
-                        cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                      j + n * dofs_per_spacetime_cell )
-                        += fe_jump_values_spacetime.shape_value_plus ( i , q )
-                         * fe_jump_values_spacetime.shape_value_plus ( j , q )
-                         * fe_jump_values_spacetime.JxW ( q );
+                      // (v^+, u^+)
+                      cell_matrix(i + n * dofs_per_spacetime_cell,
+                                  j + n * dofs_per_spacetime_cell) +=
+                        fe_jump_values_spacetime.shape_value_plus(i, q) *
+                        fe_jump_values_spacetime.shape_value_plus(j, q) *
+                        fe_jump_values_spacetime.JxW(q);
 
-                        // -(v^+, u^-)
-                        // If we have more than a single element per slab
-                        // We have to account for the inner jumps between elements
-                        // Therefore the column index is offset by one temporal element
-                        if ( n > 0 )
+                      // -(v^+, u^-)
+                      // If we have more than a single element per slab
+                      // We have to account for the inner jumps between elements
+                      // Therefore the column index is offset by one temporal
+                      // element
+                      if (n > 0)
                         {
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + ( n - 1 ) * dofs_per_spacetime_cell )
-                            -= fe_jump_values_spacetime.shape_value_plus ( i , q )
-                             * fe_jump_values_spacetime.shape_value_minus ( j , q )
-                             * fe_jump_values_spacetime.JxW ( q );
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + (n - 1) * dofs_per_spacetime_cell) -=
+                            fe_jump_values_spacetime.shape_value_plus(i, q) *
+                            fe_jump_values_spacetime.shape_value_minus(j, q) *
+                            fe_jump_values_spacetime.JxW(q);
                         }
-                    } //dofs j
-                      // The first temporal element has to account for the jump to the previous
-                      // slab or the initial value in the right hand side.
-                    if ( n == 0 )
+                    } // dofs j
+                      //  The first temporal element has to account for the jump
+                      //  to the previous slab or the initial value in the right
+                      //  hand side.
+                  if (n == 0)
                     {
-                        cell_rhs ( i )
-                        += fe_jump_values_spacetime.shape_value_plus ( i , q )
-                         * initial_values[q] //value of previous solution at t0
-                         * fe_jump_values_spacetime.JxW ( q );
+                      cell_rhs(i) +=
+                        fe_jump_values_spacetime.shape_value_plus(i, q) *
+                        initial_values[q] // value of previous solution at t0
+                        * fe_jump_values_spacetime.JxW(q);
                     }
-                } //dofs i
+                } // dofs i
             }
 
-        } //cell time
-          // after contributions for all temporal elements are calculated,
-          // write this information into the slab system matrix and rhs
-        slab_constraints->distribute_local_to_global ( cell_matrix ,
-                                                       cell_rhs ,
-                                                       local_spacetime_dof_index ,
-                                                       slab_system_matrix ,
-                                                       slab_system_rhs );
-    } //cell space
+        } // cell time
+          //  after contributions for all temporal elements are calculated,
+          //  write this information into the slab system matrix and rhs
+      slab_constraints->distribute_local_to_global(cell_matrix,
+                                                   cell_rhs,
+                                                   local_spacetime_dof_index,
+                                                   slab_system_matrix,
+                                                   slab_system_rhs);
+    } // cell space
 }
 
-void Step1::solve_system_on_slab ()
+void
+Step1::solve_system_on_slab()
 {
-    // Simply use a direct solver here. CG would not work as the matrix is not symmetric.
-    dealii::SparseDirectUMFPACK solver;
-    solver.factorize ( slab_system_matrix );
-    solver.vmult ( *slab_its.solution , slab_system_rhs );
-    // after solving set the correct Dirichlet values in the solution
-    slab_constraints->distribute ( *slab_its.solution );
+  // Simply use a direct solver here. CG would not work as the matrix is not
+  // symmetric.
+  dealii::SparseDirectUMFPACK solver;
+  solver.factorize(slab_system_matrix);
+  solver.vmult(*slab_its.solution, slab_system_rhs);
+  // after solving set the correct Dirichlet values in the solution
+  slab_constraints->distribute(*slab_its.solution);
 }
 
 // For now the output is done somewhat by hand.
 // But a spacetime or slab DataOut object is planned/WIP.
-void Step1::output_results_on_slab ()
+void
+Step1::output_results_on_slab()
 {
-    // Simply output the subvectors at all temporal degrees of freedom.
-    auto n_dofs = slab_its.dof->n_dofs_time ();
-    for ( unsigned i = 0 ; i < n_dofs ; i++ )
+  // Simply output the subvectors at all temporal degrees of freedom.
+  auto n_dofs = slab_its.dof->n_dofs_time();
+  for (unsigned i = 0; i < n_dofs; i++)
     {
-        // Construct a spatial DataOut object
-        dealii::DataOut < 2 > data_out;
-        // Register the spatial dof handler
-        data_out.attach_dof_handler ( *slab_its.dof->spatial () );
+      // Construct a spatial DataOut object
+      dealii::DataOut<2> data_out;
+      // Register the spatial dof handler
+      data_out.attach_dof_handler(*slab_its.dof->spatial());
 
-        // extract the spatial solution at the current temporal dof
-        dealii::Vector<double> local_solution;
-        local_solution.reinit ( slab_its.dof->n_dofs_space () );
-        idealii::slab::VectorTools::extract_subvector_at_time_dof ( *slab_its.solution ,
-                                                                    local_solution , i );
+      // extract the spatial solution at the current temporal dof
+      dealii::Vector<double> local_solution;
+      local_solution.reinit(slab_its.dof->n_dofs_space());
+      idealii::slab::VectorTools::extract_subvector_at_time_dof(
+        *slab_its.solution, local_solution, i);
 
-        // add this vector to the DataOut object
-        data_out.add_data_vector ( local_solution , "Solution" );
-        data_out.build_patches ();
+      // add this vector to the DataOut object
+      data_out.add_data_vector(local_solution, "Solution");
+      data_out.build_patches();
 
-        // construct a filename, for a fixed triangulation with uniform refinement
-        // this is relatively easy as all slabs have the same number of temporal degrees of freedom.
-        // Later slabs are just offset
-        std::ostringstream filename;
-        filename << "solution_split_dG(" << fe.temporal ()->degree << ")_t_"
-        << slab * n_dofs + i
-        << ".vtk";
+      // construct a filename, for a fixed triangulation with uniform refinement
+      // this is relatively easy as all slabs have the same number of temporal
+      // degrees of freedom. Later slabs are just offset
+      std::ostringstream filename;
+      filename << "solution_split_dG(" << fe.temporal()->degree << ")_t_"
+               << slab * n_dofs + i << ".vtk";
 
-        std::ofstream output ( filename.str () );
-        data_out.write_vtk ( output );
-        output.close ();
+      std::ofstream output(filename.str());
+      data_out.write_vtk(output);
+      output.close();
     }
 }
-int main ()
+int
+main()
 {
-    // spatial finite element order
-    unsigned int s = 1;
-    // temporal finite element order
-    unsigned int r = 1;
-    // Run the problem with cG(s)dG(r) finite elements.
-    Step1 problem ( s , r );
-    problem.run ();
+  // spatial finite element order
+  unsigned int s = 1;
+  // temporal finite element order
+  unsigned int r = 1;
+  // Run the problem with cG(s)dG(r) finite elements.
+  Step1 problem(s, r);
+  problem.run();
 }
-

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -17,15 +17,20 @@
 // ideal.II includes
 ////////////////////////////////////////////
 
-//same as in step-1
-#include <ideal.II/base/time_iterator.hh>
+// same as in step-1
 #include <ideal.II/base/quadrature_lib.hh>
+#include <ideal.II/base/time_iterator.hh>
+
 #include <ideal.II/dofs/slab_dof_tools.hh>
 #include <ideal.II/dofs/spacetime_dof_handler.hh>
+
 #include <ideal.II/fe/fe_dg.hh>
 #include <ideal.II/fe/spacetime_fe_values.hh>
+
 #include <ideal.II/grid/fixed_tria.hh>
+
 #include <ideal.II/lac/spacetime_vector.hh>
+
 #include <ideal.II/numerics/vector_tools.hh>
 
 ////////////////////////////////////////////
@@ -41,8 +46,8 @@
 // For Stokes we have a system of finite elements
 #include <deal.II/fe/fe_system.h>
 
-#include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
 // for reading inp files and others
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
@@ -50,15 +55,14 @@
 // needed to ensure the circle obstacle is refined correctly
 #include <deal.II/grid/manifold_lib.h>
 
-#include <deal.II/numerics/vector_tools.h>
-
-#include <deal.II/lac/vector.h>
-#include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/sparse_direct.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools.h>
 
 ////////////////////////////////////////////
 // C++ includes
@@ -72,478 +76,490 @@
 class PoisseuilleInflow : public dealii::Function<2>
 {
 public:
-    PoisseuilleInflow ( double max_inflow_velocity = 1.5 , double channel_height = 0.41 )
-        :
-        Function<2> ( 3 ),
-        max_inflow_velocity ( max_inflow_velocity ),
-        H ( channel_height )
-    {
-    }
+  PoisseuilleInflow(double max_inflow_velocity = 1.5,
+                    double channel_height      = 0.41)
+    : Function<2>(3)
+    , max_inflow_velocity(max_inflow_velocity)
+    , H(channel_height)
+  {}
 
-    virtual double
-    value ( const dealii::Point<2> &p , const unsigned int component = 0 ) const;
+  virtual double
+  value(const dealii::Point<2> &p, const unsigned int component = 0) const;
 
-    virtual void
-    vector_value ( const dealii::Point<2> &p , dealii::Vector<double> &value ) const;
-    private:
-    double max_inflow_velocity;
-    double H;
+  virtual void
+  vector_value(const dealii::Point<2> &p, dealii::Vector<double> &value) const;
+
+private:
+  double max_inflow_velocity;
+  double H;
 };
 
-double PoisseuilleInflow::value ( const dealii::Point<2> &p ,
-                                  const unsigned int component ) const
+double
+PoisseuilleInflow::value(const dealii::Point<2> &p,
+                         const unsigned int      component) const
 {
-    Assert ( component < this->n_components , dealii::ExcIndexRange ( component , 0 , this->n_components ) );
+  Assert(component < this->n_components,
+         dealii::ExcIndexRange(component, 0, this->n_components));
 
-    if ( component == 0 )
+  if (component == 0)
     {
-        double y = p ( 1 );
-        if ( p ( 0 ) == 0 && y <= 0.41 )
+      double y = p(1);
+      if (p(0) == 0 && y <= 0.41)
         {
-            double t = get_time ();
-            return 4 * max_inflow_velocity * y * ( H - y )
-                   * std::sin ( M_PI * t * 0.125 )
-                   / ( H * H );
+          double t = get_time();
+          return 4 * max_inflow_velocity * y * (H - y) *
+                 std::sin(M_PI * t * 0.125) / (H * H);
         }
     }
-    return 0;
+  return 0;
 }
 
-void PoisseuilleInflow::vector_value ( const dealii::Point<2> &p ,
-                                       dealii::Vector<double> &values ) const
+void
+PoisseuilleInflow::vector_value(const dealii::Point<2> &p,
+                                dealii::Vector<double> &values) const
 {
-    for ( unsigned int c = 0 ; c < this->n_components ; c++ )
+  for (unsigned int c = 0; c < this->n_components; c++)
     {
-        values ( c ) = value ( p , c );
+      values(c) = value(p, c);
     }
 }
 
-//note that the exact solution is unknown and the force term (rhs) is zero.
+// note that the exact solution is unknown and the force term (rhs) is zero.
 
 // This class describes the solution of Stokes equations with
 // space-time slab tensor-product elements
 class Step2
 {
 public:
-    Step2 ( unsigned int temporal_degree = 1 );
-    void
-    run ();
+  Step2(unsigned int temporal_degree = 1);
+  void
+  run();
 
 private:
-    //nothing new here
-    void
-    make_grid ();
-    void
-    time_marching ();
-    void
-    setup_system_on_slab ();
-    void
-    assemble_system_on_slab ();
-    void
-    solve_system_on_slab ();
-    void
-    output_results_on_slab ();
+  // nothing new here
+  void
+  make_grid();
+  void
+  time_marching();
+  void
+  setup_system_on_slab();
+  void
+  assemble_system_on_slab();
+  void
+  solve_system_on_slab();
+  void
+  output_results_on_slab();
 
-    /////////////////////////////////////////////
-    // space-time collections of slab objects
-    /////////////////////////////////////////////
-    idealii::spacetime::fixed::Triangulation<2> triangulation;
-    idealii::spacetime::DoFHandler<2> dof_handler;
-    idealii::spacetime::Vector<double> solution;
+  /////////////////////////////////////////////
+  // space-time collections of slab objects
+  /////////////////////////////////////////////
+  idealii::spacetime::fixed::Triangulation<2> triangulation;
+  idealii::spacetime::DoFHandler<2>           dof_handler;
+  idealii::spacetime::Vector<double>          solution;
 
-    // The space-time finite element description
-    idealii::spacetime::DG_FiniteElement<2> fe;
+  // The space-time finite element description
+  idealii::spacetime::DG_FiniteElement<2> fe;
 
-    ////////////////////////////////////////////
-    // objects needed on a single slab
-    ////////////////////////////////////////////
-    dealii::SparsityPattern sparsity_pattern;
-    std::shared_ptr<dealii::AffineConstraints<double>> slab_constraints;
-    dealii::SparseMatrix<double> slab_system_matrix;
-    dealii::Vector<double> slab_system_rhs;
-    dealii::Vector<double> slab_initial_value;
-    unsigned int slab;
+  ////////////////////////////////////////////
+  // objects needed on a single slab
+  ////////////////////////////////////////////
+  dealii::SparsityPattern                            sparsity_pattern;
+  std::shared_ptr<dealii::AffineConstraints<double>> slab_constraints;
+  dealii::SparseMatrix<double>                       slab_system_matrix;
+  dealii::Vector<double>                             slab_system_rhs;
+  dealii::Vector<double>                             slab_initial_value;
+  unsigned int                                       slab;
 
-    ///////////////////////////////////////////////////////////////
-    // Struct holding all iterators over the space-time objects.
-    ///////////////////////////////////////////////////////////////
-    struct
-    {
-        idealii::slab::TriaIterator<2> tria;
-        idealii::slab::DoFHandlerIterator<2> dof;
-        idealii::slab::VectorIterator<double> solution;
-    } slab_its;
+  ///////////////////////////////////////////////////////////////
+  // Struct holding all iterators over the space-time objects.
+  ///////////////////////////////////////////////////////////////
+  struct
+  {
+    idealii::slab::TriaIterator<2>        tria;
+    idealii::slab::DoFHandlerIterator<2>  dof;
+    idealii::slab::VectorIterator<double> solution;
+  } slab_its;
 };
 
-Step2::Step2 ( unsigned int temporal_degree )
-        :
-        triangulation (),
-        dof_handler ( &triangulation ),
-        // space-time finite element with
-        // * continuous Taylor-Hood i.e. Q2/Q1 element in space
-        //     vector-valued biquadratic velocity
-        //     scalar-valued bilinear pressure
-        // * discontinuous Lagrangian FE_DGQ finite element in time
-        fe ( std::make_shared < dealii::FESystem
-             < 2 >> ( dealii::FE_Q < 2 > ( 2 ) , 2 , dealii::FE_Q < 2 > ( 1 ) , 1 ) ,
-             temporal_degree ),
-        slab ( 0 )
+Step2::Step2(unsigned int temporal_degree)
+  : triangulation()
+  , dof_handler(&triangulation)
+  ,
+  // space-time finite element with
+  // * continuous Taylor-Hood i.e. Q2/Q1 element in space
+  //     vector-valued biquadratic velocity
+  //     scalar-valued bilinear pressure
+  // * discontinuous Lagrangian FE_DGQ finite element in time
+  fe(std::make_shared<dealii::FESystem<2>>(dealii::FE_Q<2>(2),
+                                           2,
+                                           dealii::FE_Q<2>(1),
+                                           1),
+     temporal_degree)
+  , slab(0)
+{}
+
+void
+Step2::run()
 {
+  make_grid();
+  time_marching();
 }
 
-void Step2::run ()
+void
+Step2::make_grid()
 {
-    make_grid ();
-    time_marching ();
+  auto space_tria = std::make_shared<dealii::Triangulation<2>>();
+  // instead of a grid generator we read the mesh from the provided input file
+  dealii::GridIn<2> grid_in;
+  grid_in.attach_triangulation(*space_tria);
+  std::ifstream input_file("nsbench4.inp");
+  grid_in.read_ucd(input_file);
+  // The interior obstacle is a circle in theory
+  // In the input mesh it is approximated by a polyhedron and so
+  // we need to tell the triangulation to properly refine it.
+  dealii::Point<2>                          p(0.2, 0.2);
+  static const dealii::SphericalManifold<2> boundary(p);
+  dealii::GridTools::copy_boundary_to_manifold_id(*space_tria);
+  space_tria->set_manifold(80, boundary);
+
+  const unsigned int M = 64;
+  triangulation.generate(space_tria, M);
+  triangulation.refine_global(2, 0);
+  dof_handler.generate();
 }
 
-void Step2::make_grid ()
+void
+Step2::time_marching()
 {
-    auto space_tria = std::make_shared<dealii::Triangulation<2>> ();
-    // instead of a grid generator we read the mesh from the provided input file
-    dealii::GridIn < 2 > grid_in;
-    grid_in.attach_triangulation ( *space_tria );
-    std::ifstream input_file ( "nsbench4.inp" );
-    grid_in.read_ucd ( input_file );
-    // The interior obstacle is a circle in theory
-    // In the input mesh it is approximated by a polyhedron and so
-    // we need to tell the triangulation to properly refine it.
-    dealii::Point < 2 > p ( 0.2 , 0.2 );
-    static const dealii::SphericalManifold<2> boundary ( p );
-    dealii::GridTools::copy_boundary_to_manifold_id ( *space_tria );
-    space_tria->set_manifold ( 80 , boundary );
+  // This function is the same as before
+  idealii::TimeIteratorCollection<2> tic = idealii::TimeIteratorCollection<2>();
 
-    const unsigned int M = 64;
-    triangulation.generate ( space_tria , M );
-    triangulation.refine_global ( 2 , 0 );
-    dof_handler.generate ();
-}
+  solution.reinit(triangulation.M());
 
-void Step2::time_marching ()
-{
-    //This function is the same as before
-    idealii::TimeIteratorCollection < 2 > tic = idealii::TimeIteratorCollection<2> ();
-
-    solution.reinit ( triangulation.M () );
-
-    slab_its.tria = triangulation.begin ();
-    slab_its.dof = dof_handler.begin ();
-    slab_its.solution = solution.begin ();
-    slab = 0;
-    slab_initial_value = 0;	//initial value is 0 for now
-    tic.add_iterator ( &slab_its.tria , &triangulation );
-    tic.add_iterator ( &slab_its.dof , &dof_handler );
-    tic.add_iterator ( &slab_its.solution , &solution );
-    std::cout << "*******Starting time-stepping*********" << std::endl;
-    for ( ; !tic.at_end () ; tic.increment () )
+  slab_its.tria      = triangulation.begin();
+  slab_its.dof       = dof_handler.begin();
+  slab_its.solution  = solution.begin();
+  slab               = 0;
+  slab_initial_value = 0; // initial value is 0 for now
+  tic.add_iterator(&slab_its.tria, &triangulation);
+  tic.add_iterator(&slab_its.dof, &dof_handler);
+  tic.add_iterator(&slab_its.solution, &solution);
+  std::cout << "*******Starting time-stepping*********" << std::endl;
+  for (; !tic.at_end(); tic.increment())
     {
-        std::cout << "Starting time-step (" << slab_its.tria->startpoint ()
-        << ","
-        << slab_its.tria->endpoint () << "]" << std::endl;
+      std::cout << "Starting time-step (" << slab_its.tria->startpoint() << ","
+                << slab_its.tria->endpoint() << "]" << std::endl;
 
-        setup_system_on_slab ();
-        std::cout << "setup done" << std::endl;
-        assemble_system_on_slab ();
-        std::cout << "assembly done" << std::endl;
-        solve_system_on_slab ();
-        output_results_on_slab ();
-        idealii::slab::VectorTools::extract_subvector_at_time_dof (
-                *slab_its.solution , slab_initial_value ,
-                slab_its.tria->temporal ()->n_global_active_cells () - 1 );
-        slab++;
+      setup_system_on_slab();
+      std::cout << "setup done" << std::endl;
+      assemble_system_on_slab();
+      std::cout << "assembly done" << std::endl;
+      solve_system_on_slab();
+      output_results_on_slab();
+      idealii::slab::VectorTools::extract_subvector_at_time_dof(
+        *slab_its.solution,
+        slab_initial_value,
+        slab_its.tria->temporal()->n_global_active_cells() - 1);
+      slab++;
     }
 }
 
-void Step2::setup_system_on_slab ()
+void
+Step2::setup_system_on_slab()
 {
-    slab_its.dof->distribute_dofs ( fe );
+  slab_its.dof->distribute_dofs(fe);
 
-    dealii::DoFRenumbering::component_wise ( *slab_its.dof->spatial () );
+  dealii::DoFRenumbering::component_wise(*slab_its.dof->spatial());
 
-    std::cout << "Number of degrees of freedom: \n\t"
-              << slab_its.dof->n_dofs_space () << " (space) * "
-              << slab_its.dof->n_dofs_time ()   << " (time) = "
-              << slab_its.dof->n_dofs_spacetime () << " (spacetime)" << std::endl;
+  std::cout << "Number of degrees of freedom: \n\t"
+            << slab_its.dof->n_dofs_space() << " (space) * "
+            << slab_its.dof->n_dofs_time()
+            << " (time) = " << slab_its.dof->n_dofs_spacetime()
+            << " (spacetime)" << std::endl;
 
-    if ( slab == 0 )
+  if (slab == 0)
     {
-        slab_initial_value.reinit ( slab_its.dof->n_dofs_space () );
-        slab_initial_value = 0;
+      slab_initial_value.reinit(slab_its.dof->n_dofs_space());
+      slab_initial_value = 0;
     }
 
-    slab_constraints = std::make_shared<dealii::AffineConstraints<double>> ();
+  slab_constraints = std::make_shared<dealii::AffineConstraints<double>>();
 
-    // Now we have multiple Dirichlet boundaries.
-    // 0 is assigned to the left wall as an inhom. inflow
-    // 2 is assigned to the upper and lower wall as no-slip (hom.)
-    // 80 is assigned to the obstacle as no-slip as well
-    auto zero = dealii::Functions::ZeroFunction < 2 > ( 3 );
-    auto inflow = PoisseuilleInflow ();
-    std::vector<bool> component_mask ( 3 , true );
-    component_mask[2] = false;
+  // Now we have multiple Dirichlet boundaries.
+  // 0 is assigned to the left wall as an inhom. inflow
+  // 2 is assigned to the upper and lower wall as no-slip (hom.)
+  // 80 is assigned to the obstacle as no-slip as well
+  auto              zero   = dealii::Functions::ZeroFunction<2>(3);
+  auto              inflow = PoisseuilleInflow();
+  std::vector<bool> component_mask(3, true);
+  component_mask[2] = false;
 
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              0 ,
-                                                              inflow ,
-                                                              slab_constraints ,
-                                                              component_mask );
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    *slab_its.dof, 0, inflow, slab_constraints, component_mask);
 
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              2 ,
-                                                              zero ,
-                                                              slab_constraints ,
-                                                              component_mask );
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    *slab_its.dof, 2, zero, slab_constraints, component_mask);
 
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              80 ,
-                                                              zero ,
-                                                              slab_constraints ,
-                                                              component_mask );
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    *slab_its.dof, 80, zero, slab_constraints, component_mask);
 
-    slab_constraints->close ();
+  slab_constraints->close();
 
-    // The spatial pressure-pressure coupling block is empty
-    // and the sparsity pattern can be empty in these blocks
-    dealii::Table < 2 , dealii::DoFTools::Coupling> coupling_space ( 2 + 1 , 2 + 1 );
-    // init with no coupling
-    coupling_space.fill ( dealii::DoFTools::none );
-    // coupling of velocities
-    for ( unsigned int i = 0 ; i < 2 ; i++ )
+  // The spatial pressure-pressure coupling block is empty
+  // and the sparsity pattern can be empty in these blocks
+  dealii::Table<2, dealii::DoFTools::Coupling> coupling_space(2 + 1, 2 + 1);
+  // init with no coupling
+  coupling_space.fill(dealii::DoFTools::none);
+  // coupling of velocities
+  for (unsigned int i = 0; i < 2; i++)
     {
-        for ( unsigned int j = 0 ; j < 2 ; j++ )
+      for (unsigned int j = 0; j < 2; j++)
         {
-            coupling_space[i][j] = dealii::DoFTools::always;
+          coupling_space[i][j] = dealii::DoFTools::always;
         }
     }
-    // coupling of velocity and pressure
-    for ( unsigned int i = 0 ; i < 2 ; i++ )
+  // coupling of velocity and pressure
+  for (unsigned int i = 0; i < 2; i++)
     {
-        coupling_space[i][2] = dealii::DoFTools::always;
-        coupling_space[2][i] = dealii::DoFTools::always;
+      coupling_space[i][2] = dealii::DoFTools::always;
+      coupling_space[2][i] = dealii::DoFTools::always;
     }
 
-    dealii::DynamicSparsityPattern dsp ( slab_its.dof->n_dofs_spacetime () );
-    idealii::slab::DoFTools::make_upwind_sparsity_pattern ( *slab_its.dof ,
-                                                            coupling_space ,
-                                                            dsp ,
-                                                            slab_constraints );
-    sparsity_pattern.copy_from ( dsp );
-    slab_system_matrix.reinit ( sparsity_pattern );
+  dealii::DynamicSparsityPattern dsp(slab_its.dof->n_dofs_spacetime());
+  idealii::slab::DoFTools::make_upwind_sparsity_pattern(*slab_its.dof,
+                                                        coupling_space,
+                                                        dsp,
+                                                        slab_constraints);
+  sparsity_pattern.copy_from(dsp);
+  slab_system_matrix.reinit(sparsity_pattern);
 
-    slab_its.solution->reinit ( slab_its.dof->n_dofs_spacetime () );
-    slab_system_rhs.reinit ( slab_its.dof->n_dofs_spacetime () );
+  slab_its.solution->reinit(slab_its.dof->n_dofs_spacetime());
+  slab_system_rhs.reinit(slab_its.dof->n_dofs_spacetime());
 }
 
-void Step2::assemble_system_on_slab ()
+void
+Step2::assemble_system_on_slab()
 {
-    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 3 ,
-                                            fe.temporal ()->degree + 2 );
+  idealii::spacetime::QGauss<2> quad(fe.spatial()->degree + 3,
+                                     fe.temporal()->degree + 2);
 
-    idealii::spacetime::FEValues < 2 > fe_values_spacetime ( fe ,
-                                                             quad ,
-                                                             dealii::update_values |
-                                                             dealii::update_gradients |
-                                                             dealii::update_quadrature_points |
-                                                             dealii::update_JxW_values );
+  idealii::spacetime::FEValues<2> fe_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    idealii::spacetime::FEJumpValues < 2 > fe_jump_values_spacetime ( fe ,
-                                                                      quad ,
-                                                                      dealii::update_values |
-                                                                      dealii::update_gradients |
-                                                                      dealii::update_quadrature_points |
-                                                                      dealii::update_JxW_values );
+  idealii::spacetime::FEJumpValues<2> fe_jump_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
+  const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
 
-    auto N = slab_its.tria->temporal ()->n_global_active_cells ();
-    dealii::FullMatrix<double> cell_matrix ( N * dofs_per_spacetime_cell ,
-                                             N * dofs_per_spacetime_cell );
-    dealii::Vector<double> cell_rhs ( N * dofs_per_spacetime_cell );
+  auto N = slab_its.tria->temporal()->n_global_active_cells();
+  dealii::FullMatrix<double> cell_matrix(N * dofs_per_spacetime_cell,
+                                         N * dofs_per_spacetime_cell);
+  dealii::Vector<double>     cell_rhs(N * dofs_per_spacetime_cell);
 
-    std::vector < dealii::types::global_dof_index > local_spacetime_dof_index ( N * dofs_per_spacetime_cell );
+  std::vector<dealii::types::global_dof_index> local_spacetime_dof_index(
+    N * dofs_per_spacetime_cell);
 
-    unsigned int n;
-    unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
-    unsigned int n_quad_space = quad.spatial ()->size ();
+  unsigned int n;
+  unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
+  unsigned int n_quad_space     = quad.spatial()->size();
 
-    // To get the velocity and pressure subvalues of the fe system shape functions
-    // we use the following extractors
-    dealii::FEValuesExtractors::Vector velocity ( 0 );
-    dealii::FEValuesExtractors::Scalar pressure ( 2 );
-    // set the kinematic viscosity
-    double nu_f = 1.0e-3;
+  // To get the velocity and pressure subvalues of the fe system shape functions
+  // we use the following extractors
+  dealii::FEValuesExtractors::Vector velocity(0);
+  dealii::FEValuesExtractors::Scalar pressure(2);
+  // set the kinematic viscosity
+  double nu_f = 1.0e-3;
 
-    for ( const auto &cell_space : slab_its.dof->spatial ()->active_cell_iterators () )
+  for (const auto &cell_space :
+       slab_its.dof->spatial()->active_cell_iterators())
     {
-        fe_values_spacetime.reinit_space ( cell_space );
-        fe_jump_values_spacetime.reinit_space ( cell_space );
-        std::vector<dealii::Tensor<1,2>> initial_values (
-                                                          fe_values_spacetime.spatial ()->n_quadrature_points );
-        fe_values_spacetime.spatial ()->operator[] ( velocity ).get_function_values ( slab_initial_value ,
-                                                                                      initial_values );
+      fe_values_spacetime.reinit_space(cell_space);
+      fe_jump_values_spacetime.reinit_space(cell_space);
+      std::vector<dealii::Tensor<1, 2>> initial_values(
+        fe_values_spacetime.spatial()->n_quadrature_points);
+      fe_values_spacetime.spatial()->operator[](velocity).get_function_values(
+        slab_initial_value, initial_values);
 
-        cell_matrix = 0;
-        cell_rhs = 0;
-        for ( const auto &cell_time : slab_its.dof->temporal ()->active_cell_iterators () )
+      cell_matrix = 0;
+      cell_rhs    = 0;
+      for (const auto &cell_time :
+           slab_its.dof->temporal()->active_cell_iterators())
         {
-            n = cell_time->index ();
-            fe_values_spacetime.reinit_time ( cell_time );
-            fe_jump_values_spacetime.reinit_time ( cell_time );
-            fe_values_spacetime.get_local_dof_indices ( local_spacetime_dof_index );
+          n = cell_time->index();
+          fe_values_spacetime.reinit_time(cell_time);
+          fe_jump_values_spacetime.reinit_time(cell_time);
+          fe_values_spacetime.get_local_dof_indices(local_spacetime_dof_index);
 
-            for ( unsigned int q = 0 ; q < n_quad_spacetime ; ++q )
+          for (unsigned int q = 0; q < n_quad_spacetime; ++q)
             {
-
-                for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
+              for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                 {
-                    for ( unsigned int j = 0 ; j < dofs_per_spacetime_cell ;
-                            ++j )
+                  for (unsigned int j = 0; j < dofs_per_spacetime_cell; ++j)
                     {
+                      // The FEValues calls with extractors are a bit different
+                      // to the ones in deal.II. There, all possibilities are
+                      // saved to a cache, so duplicating this cache is
+                      // unnecessarily ineffective. Instead of the operator[]()
+                      // returning a Scalar or Vector FEValues object depending
+                      // on the extractor we provide different functions for
+                      // vector and scalar valued shape functions.
+                      // For example
+                      // vector_value(extractor,i,q) instead of
+                      // [extractor].value(i,q); See Readme.md for the list of
+                      // corresponding shape functions used here.
 
-                        // The FEValues calls with extractors are a bit different to the ones in deal.II.
-                        // There, all possibilities are saved to a cache, so duplicating this cache
-                        // is unnecessarily ineffective.
-                        // Instead of the operator[]() returning a Scalar or Vector FEValues object
-                        // depending on the extractor we provide different functions for
-                        // vector and scalar valued shape functions.
-                        // For example
-                        // vector_value(extractor,i,q) instead of [extractor].value(i,q);
-                        // See Readme.md for the list of corresponding shape functions
-                        // used here.
+                      // (dt u, v)
+                      cell_matrix(i + n * dofs_per_spacetime_cell,
+                                  j + n * dofs_per_spacetime_cell) +=
+                        fe_values_spacetime.vector_value(velocity, i, q) *
+                        fe_values_spacetime.vector_dt(velocity, j, q) *
+                        fe_values_spacetime.JxW(q);
 
-                        // (dt u, v)
-                        cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                      j + n * dofs_per_spacetime_cell )
-                        += fe_values_spacetime.vector_value ( velocity , i , q )
-                         * fe_values_spacetime.vector_dt ( velocity , j , q )
-                         * fe_values_spacetime.JxW ( q );
+                      // (grad u, grad v)
+                      cell_matrix(i + n * dofs_per_spacetime_cell,
+                                  j + n * dofs_per_spacetime_cell)
+                        // as the shape function is vector valued we need to
+                        // take the scalar product.
+                        +=
+                        dealii::scalar_product(
+                          fe_values_spacetime.vector_space_grad(velocity, i, q),
+                          fe_values_spacetime.vector_space_grad(velocity,
+                                                                j,
+                                                                q)) *
+                        fe_values_spacetime.JxW(q) * nu_f;
 
-                        // (grad u, grad v)
-                        cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                      j + n * dofs_per_spacetime_cell )
-                        // as the shape function is vector valued we need to take the
-                        // scalar product.
-                        += dealii::scalar_product (
-                                fe_values_spacetime.vector_space_grad ( velocity , i , q ) ,
-                                fe_values_spacetime.vector_space_grad ( velocity , j , q )
-                           )
-                           * fe_values_spacetime.JxW ( q ) * nu_f;
+                      // (pressure gradient)
+                      cell_matrix(i + n * dofs_per_spacetime_cell,
+                                  j + n * dofs_per_spacetime_cell) -=
+                        fe_values_spacetime.vector_divergence(velocity, i, q) *
+                        fe_values_spacetime.scalar_value(pressure, j, q) *
+                        fe_values_spacetime.JxW(q);
 
-                        // (pressure gradient)
-                        cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                      j + n * dofs_per_spacetime_cell )
-                        -= fe_values_spacetime.vector_divergence ( velocity , i , q )
-                         * fe_values_spacetime.scalar_value ( pressure , j , q )
-                         * fe_values_spacetime.JxW ( q );
+                      // (div free constraint)
+                      cell_matrix(i + n * dofs_per_spacetime_cell,
+                                  j + n * dofs_per_spacetime_cell) +=
+                        fe_values_spacetime.scalar_value(pressure, i, q) *
+                        fe_values_spacetime.vector_divergence(velocity, j, q) *
+                        fe_values_spacetime.JxW(q);
 
-                        // (div free constraint)
-                        cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                      j + n * dofs_per_spacetime_cell )
-                        += fe_values_spacetime.scalar_value ( pressure , i , q )
-                         * fe_values_spacetime.vector_divergence ( velocity , j , q )
-                         * fe_values_spacetime.JxW ( q );
+                    } // dofs j
+                }     // dofs i
+            }         // quad
 
-                    } //dofs j
-                } //dofs i
-            } //quad
-
-            // Jump terms and initial values just have a spatial loop
-            // Only the velocity has a temporal derivative, so we don't need
-            // jump values for the pressure.
-            for ( unsigned int q = 0 ; q < n_quad_space ; ++q )
+          // Jump terms and initial values just have a spatial loop
+          // Only the velocity has a temporal derivative, so we don't need
+          // jump values for the pressure.
+          for (unsigned int q = 0; q < n_quad_space; ++q)
             {
-                for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
+              for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                 {
-                    for ( unsigned int j = 0 ; j < dofs_per_spacetime_cell ;
-                            ++j )
+                  for (unsigned int j = 0; j < dofs_per_spacetime_cell; ++j)
                     {
-                        // (phi^+, v^+)
-                        cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                      j + n * dofs_per_spacetime_cell )
-                        += fe_jump_values_spacetime.vector_value_plus ( velocity , i , q )
-                         * fe_jump_values_spacetime.vector_value_plus ( velocity , j , q )
-                         * fe_jump_values_spacetime.JxW ( q );
+                      // (phi^+, v^+)
+                      cell_matrix(i + n * dofs_per_spacetime_cell,
+                                  j + n * dofs_per_spacetime_cell) +=
+                        fe_jump_values_spacetime.vector_value_plus(velocity,
+                                                                   i,
+                                                                   q) *
+                        fe_jump_values_spacetime.vector_value_plus(velocity,
+                                                                   j,
+                                                                   q) *
+                        fe_jump_values_spacetime.JxW(q);
 
-                        // -(phi^+, v^-)
-                        if ( n > 0 )
+                      // -(phi^+, v^-)
+                      if (n > 0)
                         {
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + ( n - 1 ) * dofs_per_spacetime_cell )
-                            -= fe_jump_values_spacetime.vector_value_plus ( velocity , i , q )
-                             * fe_jump_values_spacetime.vector_value_minus ( velocity , j , q )
-                             * fe_jump_values_spacetime.JxW ( q );
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + (n - 1) * dofs_per_spacetime_cell) -=
+                            fe_jump_values_spacetime.vector_value_plus(velocity,
+                                                                       i,
+                                                                       q) *
+                            fe_jump_values_spacetime.vector_value_minus(
+                              velocity, j, q) *
+                            fe_jump_values_spacetime.JxW(q);
                         }
-                    } //dofs j
-                    if ( n == 0 )
+                    } // dofs j
+                  if (n == 0)
                     {
-                        cell_rhs ( i )
-                        += fe_jump_values_spacetime.vector_value_plus ( velocity , i , q )
-                         * initial_values[q] //value of previous solution at t0
-                         * fe_jump_values_spacetime.JxW ( q );
+                      cell_rhs(i) +=
+                        fe_jump_values_spacetime.vector_value_plus(velocity,
+                                                                   i,
+                                                                   q) *
+                        initial_values[q] // value of previous solution at t0
+                        * fe_jump_values_spacetime.JxW(q);
                     }
-                } //dofs i
+                } // dofs i
             }
 
-        } //cell time
-        slab_constraints->distribute_local_to_global ( cell_matrix ,
-                                                       cell_rhs ,
-                                                       local_spacetime_dof_index ,
-                                                       slab_system_matrix ,
-                                                       slab_system_rhs );
-    } //cell space
+        } // cell time
+      slab_constraints->distribute_local_to_global(cell_matrix,
+                                                   cell_rhs,
+                                                   local_spacetime_dof_index,
+                                                   slab_system_matrix,
+                                                   slab_system_rhs);
+    } // cell space
 }
 
-void Step2::solve_system_on_slab ()
+void
+Step2::solve_system_on_slab()
 {
-    dealii::SparseDirectUMFPACK solver;
-    solver.factorize ( slab_system_matrix );
-    solver.vmult ( *slab_its.solution , slab_system_rhs );
-    slab_constraints->distribute ( *slab_its.solution );
+  dealii::SparseDirectUMFPACK solver;
+  solver.factorize(slab_system_matrix);
+  solver.vmult(*slab_its.solution, slab_system_rhs);
+  slab_constraints->distribute(*slab_its.solution);
 }
 
-void Step2::output_results_on_slab ()
+void
+Step2::output_results_on_slab()
 {
-    auto n_dofs = slab_its.dof->n_dofs_time ();
-    // As in deal.II we need to tell the DataOut what to do with the vector and scalar valued
-    // entries in the solution vector.
-    std::vector < std::string > field_names;
-    std::vector < dealii::DataComponentInterpretation::DataComponentInterpretation > dci;
-    for ( unsigned int i = 0 ; i < 2 ; i++ )
+  auto n_dofs = slab_its.dof->n_dofs_time();
+  // As in deal.II we need to tell the DataOut what to do with the vector and
+  // scalar valued entries in the solution vector.
+  std::vector<std::string> field_names;
+  std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+    dci;
+  for (unsigned int i = 0; i < 2; i++)
     {
-        field_names.push_back ( "velocity" );
-        dci.push_back ( dealii::DataComponentInterpretation::component_is_part_of_vector );
+      field_names.push_back("velocity");
+      dci.push_back(
+        dealii::DataComponentInterpretation::component_is_part_of_vector);
     }
-    field_names.push_back ( "pressure" );
-    dci.push_back ( dealii::DataComponentInterpretation::component_is_scalar );
+  field_names.push_back("pressure");
+  dci.push_back(dealii::DataComponentInterpretation::component_is_scalar);
 
-    for ( unsigned i = 0 ; i < n_dofs ; i++ )
+  for (unsigned i = 0; i < n_dofs; i++)
     {
-        dealii::DataOut < 2 > data_out;
-        data_out.attach_dof_handler ( *slab_its.dof->spatial () );
-        dealii::Vector<double> local_solution;
-        local_solution.reinit ( slab_its.dof->n_dofs_space () );
-        idealii::slab::VectorTools::extract_subvector_at_time_dof ( *slab_its.solution ,
-                                                                    local_solution ,
-                                                                    i );
-        data_out.add_data_vector ( local_solution ,
-                                   field_names ,
-                                   dealii::DataOut < 2 > ::type_dof_data ,
-                                   dci );
+      dealii::DataOut<2> data_out;
+      data_out.attach_dof_handler(*slab_its.dof->spatial());
+      dealii::Vector<double> local_solution;
+      local_solution.reinit(slab_its.dof->n_dofs_space());
+      idealii::slab::VectorTools::extract_subvector_at_time_dof(
+        *slab_its.solution, local_solution, i);
+      data_out.add_data_vector(local_solution,
+                               field_names,
+                               dealii::DataOut<2>::type_dof_data,
+                               dci);
 
-        data_out.build_patches ( 1 );
-        std::ostringstream filename;
-        filename << "solution_dG(" << fe.temporal ()->degree << ")_t_"
-        << slab * n_dofs + i
-        << ".vtk";
+      data_out.build_patches(1);
+      std::ostringstream filename;
+      filename << "solution_dG(" << fe.temporal()->degree << ")_t_"
+               << slab * n_dofs + i << ".vtk";
 
-        std::ofstream output ( filename.str () );
-        data_out.write_vtk ( output );
-        output.close ();
+      std::ofstream output(filename.str());
+      data_out.write_vtk(output);
+      output.close();
     }
 }
 
-int main ()
+int
+main()
 {
-    Step2 problem ( 1 );
-    problem.run ();
+  Step2 problem(1);
+  problem.run();
 }

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -23,41 +23,46 @@
 
 // now we use the parallel distributed instead of the sequential triangulation
 #include <ideal.II/distributed/fixed_tria.hh>
-// as well as trilinos linear algebra, so the collection is now over trilinos vectors
+// as well as trilinos linear algebra, so the collection is now over trilinos
+// vectors
 #include <ideal.II/lac/spacetime_trilinos_vector.hh>
 
-//all other ideal.II includes are known
-#include <ideal.II/base/time_iterator.hh>
+// all other ideal.II includes are known
 #include <ideal.II/base/quadrature_lib.hh>
-#include <ideal.II/dofs/spacetime_dof_handler.hh>
+#include <ideal.II/base/time_iterator.hh>
+
 #include <ideal.II/dofs/slab_dof_tools.hh>
+#include <ideal.II/dofs/spacetime_dof_handler.hh>
+
 #include <ideal.II/fe/fe_dg.hh>
 #include <ideal.II/fe/spacetime_fe_values.hh>
+
 #include <ideal.II/numerics/vector_tools.hh>
 
 ////////////////////////////////////////////
 // deal.II includes
 ////////////////////////////////////////////
 
-// we only want process 0 to write to the console, ConditionalOStream provides this
+// we only want process 0 to write to the console, ConditionalOStream provides
+// this
 #include <deal.II/base/conditional_ostream.h>
 
 // now we use the parallel distributed instead of the sequential triangulation
-#include <deal.II/distributed/tria.h>
-
 #include <deal.II/base/function.h>
 
-// and also distributed linear algebra provided by trilinos
-#include <deal.II/lac/trilinos_sparse_matrix.h>
-#include <deal.II/lac/trilinos_vector.h>
-#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/distributed/tria.h>
 
-#include <deal.II/grid/grid_generator.h>
+// and also distributed linear algebra provided by trilinos
 #include <deal.II/fe/fe_q.h>
 
-#include <deal.II/lac/vector.h>
-#include <deal.II/lac/full_matrix.h>
+#include <deal.II/grid/grid_generator.h>
+
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/data_out.h>
 
@@ -68,477 +73,480 @@
 
 // right hand side function is derived from the exact solution described in
 // Ralf Hartmann
-// A-posteriori Fehlerschätzung und adaptive Schrittweiten- und Ortsgittersteuerung bei Galerkin-Verfahren für die Wärmeleitungsgleichung
+// A-posteriori Fehlerschätzung und adaptive Schrittweiten- und
+// Ortsgittersteuerung bei Galerkin-Verfahren für die Wärmeleitungsgleichung
 // Diploma thesis, University of Heidelberg, 1998. (in German)
 
 class RightHandSide : public dealii::Function<2>
 {
 public:
-    virtual double
-    value ( const dealii::Point<2> &p , const unsigned int component = 0 );
+  virtual double
+  value(const dealii::Point<2> &p, const unsigned int component = 0);
 };
 
-double RightHandSide::value ( const dealii::Point<2> &p ,
-                              [[maybe_unused]] const unsigned int component )
+double
+RightHandSide::value(const dealii::Point<2>             &p,
+                     [[maybe_unused]] const unsigned int component)
 {
-    double t = get_time ();
-    const double x0 = 0.5 + 0.25 * std::cos ( 2. * M_PI * t );
-    const double x1 = 0.5 + 0.25 * std::sin ( 2. * M_PI * t );
-    double a = 50.;
-    const double divisor = 1. + a * ( ( p[0] - x0 ) * ( p[0] - x0 ) + ( p[1] - x1 ) * ( p[1] - x1 ) );
+  double       t  = get_time();
+  const double x0 = 0.5 + 0.25 * std::cos(2. * M_PI * t);
+  const double x1 = 0.5 + 0.25 * std::sin(2. * M_PI * t);
+  double       a  = 50.;
+  const double divisor =
+    1. + a * ((p[0] - x0) * (p[0] - x0) + (p[1] - x1) * (p[1] - x1));
 
-    double dtu = -( ( a * ( p[0] - x0 ) * M_PI * std::sin ( 2. * M_PI * t ) )
-                  - ( a * ( p[1] - x1 ) * M_PI * std::cos ( 2. * M_PI * t ) )
-                  ) / ( divisor * divisor );
+  double dtu = -((a * (p[0] - x0) * M_PI * std::sin(2. * M_PI * t)) -
+                 (a * (p[1] - x1) * M_PI * std::cos(2. * M_PI * t))) /
+               (divisor * divisor);
 
-    const double u_xx = -2. * a *
-                        (     1. / ( divisor * divisor )
-                            + 2. * a * ( p[0] - x0 ) * ( p[0] - x0 ) * ( -2. / ( divisor * divisor * divisor ) )
-                        );
+  const double u_xx =
+    -2. * a *
+    (1. / (divisor * divisor) + 2. * a * (p[0] - x0) * (p[0] - x0) *
+                                  (-2. / (divisor * divisor * divisor)));
 
-    const double u_yy = -2. * a *
-                        (     1. / ( divisor * divisor )
-                            + 2. * a * ( p[1] - x1 ) * ( p[1] - x1 ) * ( -2. / ( divisor * divisor * divisor ) ) );
+  const double u_yy =
+    -2. * a *
+    (1. / (divisor * divisor) + 2. * a * (p[1] - x1) * (p[1] - x1) *
+                                  (-2. / (divisor * divisor * divisor)));
 
-    return dtu - ( u_xx + u_yy );
+  return dtu - (u_xx + u_yy);
 }
 
-class ExactSolution : public dealii::Function<2,double>
+class ExactSolution : public dealii::Function<2, double>
 {
 public:
-    ExactSolution ()
-        :
-        dealii::Function<2,double> ()
-    {
-    }
-    double
-    value ( const dealii::Point<2> &p ,
-            const unsigned int component = 0 ) const;
+  ExactSolution()
+    : dealii::Function<2, double>()
+  {}
+  double
+  value(const dealii::Point<2> &p, const unsigned int component = 0) const;
 };
 
-double ExactSolution::value (
-                              const dealii::Point<2> &p ,
-                              [[maybe_unused]] const unsigned int component ) const
+double
+ExactSolution::value(const dealii::Point<2>             &p,
+                     [[maybe_unused]] const unsigned int component) const
 {
-    const double t = get_time ();
-    const double x0 = 0.5 + 0.25 * std::cos ( 2. * M_PI * t );
-    const double x1 = 0.5 + 0.25 * std::sin ( 2. * M_PI * t );
-    return 1. / ( 1. + 50. * ( ( p[0] - x0 ) * ( p[0] - x0 ) + ( p[1] - x1 ) * ( p[1] - x1 ) ) );
+  const double t  = get_time();
+  const double x0 = 0.5 + 0.25 * std::cos(2. * M_PI * t);
+  const double x1 = 0.5 + 0.25 * std::sin(2. * M_PI * t);
+  return 1. /
+         (1. + 50. * ((p[0] - x0) * (p[0] - x0) + (p[1] - x1) * (p[1] - x1)));
 }
 
 class Step3
 {
 public:
-    Step3 ( unsigned int spatial_degree , unsigned int temporal_degree );
-    void
-    run ();
+  Step3(unsigned int spatial_degree, unsigned int temporal_degree);
+  void
+  run();
 
 private:
-    void
-    make_grid ();
-    void
-    time_marching ();
-    void
-    setup_system_on_slab ();
-    void
-    assemble_system_on_slab ();
-    void
-    solve_system_on_slab ();
-    void
-    output_results_on_slab ();
+  void
+  make_grid();
+  void
+  time_marching();
+  void
+  setup_system_on_slab();
+  void
+  assemble_system_on_slab();
+  void
+  solve_system_on_slab();
+  void
+  output_results_on_slab();
 
-    // we need to know the MPI communicator
-    MPI_Comm mpi_comm;
-    // Output based on some condition (here MPI process id = 0)
-    dealii::ConditionalOStream pout;
-    /////////////////////////////////////////////
-    // space-time collections of slab objects
-    /////////////////////////////////////////////
-    // The triangulation is now parallel distributed
-    idealii::spacetime::parallel::distributed::fixed::Triangulation<2> triangulation;
-    idealii::spacetime::DoFHandler<2> dof_handler;
-    idealii::spacetime::TrilinosVector solution;
+  // we need to know the MPI communicator
+  MPI_Comm mpi_comm;
+  // Output based on some condition (here MPI process id = 0)
+  dealii::ConditionalOStream pout;
+  /////////////////////////////////////////////
+  // space-time collections of slab objects
+  /////////////////////////////////////////////
+  // The triangulation is now parallel distributed
+  idealii::spacetime::parallel::distributed::fixed::Triangulation<2>
+                                     triangulation;
+  idealii::spacetime::DoFHandler<2>  dof_handler;
+  idealii::spacetime::TrilinosVector solution;
 
-    // The space-time finite element description
-    idealii::spacetime::DG_FiniteElement<2> fe;
+  // The space-time finite element description
+  idealii::spacetime::DG_FiniteElement<2> fe;
 
-    ////////////////////////////////////////////
-    // objects needed on a single slab
-    ////////////////////////////////////////////
-    dealii::SparsityPattern slab_sparsity_pattern;
-    std::shared_ptr<dealii::AffineConstraints<double>> slab_constraints;
-    dealii::TrilinosWrappers::SparseMatrix slab_system_matrix;
-    dealii::TrilinosWrappers::MPI::Vector slab_system_rhs;
-    dealii::TrilinosWrappers::MPI::Vector slab_initial_value;
-    unsigned int slab;
-    // For initial and Dirichlet boundary values it is simplest
-    // to use the exact solution if known.
-    ExactSolution exact_solution;
+  ////////////////////////////////////////////
+  // objects needed on a single slab
+  ////////////////////////////////////////////
+  dealii::SparsityPattern                            slab_sparsity_pattern;
+  std::shared_ptr<dealii::AffineConstraints<double>> slab_constraints;
+  dealii::TrilinosWrappers::SparseMatrix             slab_system_matrix;
+  dealii::TrilinosWrappers::MPI::Vector              slab_system_rhs;
+  dealii::TrilinosWrappers::MPI::Vector              slab_initial_value;
+  unsigned int                                       slab;
+  // For initial and Dirichlet boundary values it is simplest
+  // to use the exact solution if known.
+  ExactSolution exact_solution;
 
-    // to allow for communication between locally owned and shared vectors
-    // we sometimes need temporary vectors that we can write into
-    dealii::TrilinosWrappers::MPI::Vector slab_owned_tmp;
-    // set of space-time dofs owned by the processor
-    dealii::IndexSet slab_locally_owned_dofs;
-    // owned or belonging to owned elements (ghost dofs)
-    dealii::IndexSet slab_locally_relevant_dofs;
+  // to allow for communication between locally owned and shared vectors
+  // we sometimes need temporary vectors that we can write into
+  dealii::TrilinosWrappers::MPI::Vector slab_owned_tmp;
+  // set of space-time dofs owned by the processor
+  dealii::IndexSet slab_locally_owned_dofs;
+  // owned or belonging to owned elements (ghost dofs)
+  dealii::IndexSet slab_locally_relevant_dofs;
 
-    // same as above but just on the spatial grid
-    dealii::IndexSet space_locally_owned_dofs;
-    dealii::IndexSet space_locally_relevant_dofs;
+  // same as above but just on the spatial grid
+  dealii::IndexSet space_locally_owned_dofs;
+  dealii::IndexSet space_locally_relevant_dofs;
 
-    ///////////////////////////////////////////////////////////////
-    // Struct holding all iterators over the space-time objects.
-    ///////////////////////////////////////////////////////////////
-    struct
-    {
-        idealii::slab::parallel::distributed::TriaIterator<2> tria;
-        idealii::slab::DoFHandlerIterator<2> dof;
-        idealii::slab::TrilinosVectorIterator solution;
-    } slab_its;
+  ///////////////////////////////////////////////////////////////
+  // Struct holding all iterators over the space-time objects.
+  ///////////////////////////////////////////////////////////////
+  struct
+  {
+    idealii::slab::parallel::distributed::TriaIterator<2> tria;
+    idealii::slab::DoFHandlerIterator<2>                  dof;
+    idealii::slab::TrilinosVectorIterator                 solution;
+  } slab_its;
 };
 
-Step3::Step3 ( unsigned int spatial_degree , unsigned int temporal_degree )
-        :
-        // MPI communicator is set to world i.e. all nodes provided by MPI
-        mpi_comm ( MPI_COMM_WORLD ),
-        // Only output if process id is 0
-        pout ( std::cout ,
-               dealii::Utilities::MPI::this_mpi_process ( mpi_comm ) == 0 ),
-        triangulation (),
-        dof_handler ( &triangulation ),
-        fe ( std::make_shared < dealii::FE_Q < 2 >> ( spatial_degree ) ,
-             temporal_degree ,
-             idealii::spacetime::DG_FiniteElement < 2 > ::support_type::Legendre ),
-        slab ( 0 ),
-        exact_solution ()
+Step3::Step3(unsigned int spatial_degree, unsigned int temporal_degree)
+  : // MPI communicator is set to world i.e. all nodes provided by MPI
+  mpi_comm(MPI_COMM_WORLD)
+  ,
+  // Only output if process id is 0
+  pout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+  , triangulation()
+  , dof_handler(&triangulation)
+  , fe(std::make_shared<dealii::FE_Q<2>>(spatial_degree),
+       temporal_degree,
+       idealii::spacetime::DG_FiniteElement<2>::support_type::Legendre)
+  , slab(0)
+  , exact_solution()
+{}
+
+void
+Step3::run()
 {
+  make_grid();
+  time_marching();
 }
 
-void Step3::run ()
+void
+Step3::make_grid()
 {
-    make_grid ();
-    time_marching ();
+  // construct an MPI parallel triangulation with the provided MPI communicator
+  auto space_tria =
+    std::make_shared<dealii::parallel::distributed::Triangulation<2>>(mpi_comm);
+  dealii::GridGenerator::hyper_cube(*space_tria);
+  const unsigned int M = 5;
+  triangulation.generate(space_tria, M);
+  triangulation.refine_global(4, 0);
+  dof_handler.generate();
 }
 
-void Step3::make_grid ()
+void
+Step3::time_marching()
 {
-    //construct an MPI parallel triangulation with the provided MPI communicator
-    auto space_tria = std::make_shared< dealii::parallel::distributed::Triangulation< 2 >> ( mpi_comm );
-    dealii::GridGenerator::hyper_cube ( *space_tria );
-    const unsigned int M = 5;
-    triangulation.generate ( space_tria , M );
-    triangulation.refine_global ( 4 , 0 );
-    dof_handler.generate ();
-}
+  idealii::TimeIteratorCollection<2> tic = idealii::TimeIteratorCollection<2>();
 
-void Step3::time_marching ()
-{
-    idealii::TimeIteratorCollection < 2 > tic = idealii::TimeIteratorCollection<2> ();
+  solution.reinit(triangulation.M());
 
-    solution.reinit ( triangulation.M () );
-
-    slab_its.tria = triangulation.begin ();
-    slab_its.dof = dof_handler.begin ();
-    slab_its.solution = solution.begin ();
-    slab = 0;
-    tic.add_iterator ( &slab_its.tria , &triangulation );
-    tic.add_iterator ( &slab_its.dof , &dof_handler );
-    tic.add_iterator ( &slab_its.solution , &solution );
-    pout << "*******Starting time-stepping*********" << std::endl;
-    for ( ; !tic.at_end () ; tic.increment () )
+  slab_its.tria     = triangulation.begin();
+  slab_its.dof      = dof_handler.begin();
+  slab_its.solution = solution.begin();
+  slab              = 0;
+  tic.add_iterator(&slab_its.tria, &triangulation);
+  tic.add_iterator(&slab_its.dof, &dof_handler);
+  tic.add_iterator(&slab_its.solution, &solution);
+  pout << "*******Starting time-stepping*********" << std::endl;
+  for (; !tic.at_end(); tic.increment())
     {
-        pout << "Starting time-step (" << slab_its.tria->startpoint () << ","
-        << slab_its.tria->endpoint ()
-        << "]" << std::endl;
+      pout << "Starting time-step (" << slab_its.tria->startpoint() << ","
+           << slab_its.tria->endpoint() << "]" << std::endl;
 
-        setup_system_on_slab ();
-        assemble_system_on_slab ();
-        solve_system_on_slab ();
-        output_results_on_slab ();
-        idealii::slab::VectorTools::extract_subvector_at_time_point ( *slab_its.dof ,
-                                                                      *slab_its.solution ,
-                                                                      slab_initial_value ,
-                                                                      slab_its.tria->endpoint () );
-        slab++;
+      setup_system_on_slab();
+      assemble_system_on_slab();
+      solve_system_on_slab();
+      output_results_on_slab();
+      idealii::slab::VectorTools::extract_subvector_at_time_point(
+        *slab_its.dof,
+        *slab_its.solution,
+        slab_initial_value,
+        slab_its.tria->endpoint());
+      slab++;
     }
 }
 
-void Step3::setup_system_on_slab ()
+void
+Step3::setup_system_on_slab()
 {
-    slab_its.dof->distribute_dofs ( fe );
-    pout << "Number of degrees of freedom: \n\t"
-         << slab_its.dof->n_dofs_space () << " (space) * "
-         << slab_its.dof->n_dofs_time ()  << " (time) = "
-         << slab_its.dof->n_dofs_spacetime ()
-         << std::endl;
+  slab_its.dof->distribute_dofs(fe);
+  pout << "Number of degrees of freedom: \n\t" << slab_its.dof->n_dofs_space()
+       << " (space) * " << slab_its.dof->n_dofs_time()
+       << " (time) = " << slab_its.dof->n_dofs_spacetime() << std::endl;
 
-    // we need to know the spatial set of degrees of freedom owned by the current MPI processor
-    space_locally_owned_dofs = slab_its.dof->spatial ()->locally_owned_dofs ();
-    // and beloging to elements owned by the processor
-    dealii::DoFTools::extract_locally_relevant_dofs ( *slab_its.dof->spatial () ,
-                                                      space_locally_relevant_dofs );
+  // we need to know the spatial set of degrees of freedom owned by the current
+  // MPI processor
+  space_locally_owned_dofs = slab_its.dof->spatial()->locally_owned_dofs();
+  // and beloging to elements owned by the processor
+  dealii::DoFTools::extract_locally_relevant_dofs(*slab_its.dof->spatial(),
+                                                  space_locally_relevant_dofs);
 
-    // The same holds for the set of space-time degrees of freedom
-    slab_locally_owned_dofs = slab_its.dof->locally_owned_dofs ();
-    slab_locally_relevant_dofs =
-            idealii::slab::DoFTools::extract_locally_relevant_dofs ( *slab_its.dof );
+  // The same holds for the set of space-time degrees of freedom
+  slab_locally_owned_dofs = slab_its.dof->locally_owned_dofs();
+  slab_locally_relevant_dofs =
+    idealii::slab::DoFTools::extract_locally_relevant_dofs(*slab_its.dof);
 
-    slab_owned_tmp.reinit ( slab_locally_owned_dofs , mpi_comm );
+  slab_owned_tmp.reinit(slab_locally_owned_dofs, mpi_comm);
 
-    if ( slab == 0 )
+  if (slab == 0)
     {
-        // On the first slab the initial value has to be set to the correct
-        // set of spatially relevant dofs
-        slab_initial_value.reinit ( space_locally_owned_dofs ,
-                                    space_locally_relevant_dofs ,
-                                    mpi_comm );
+      // On the first slab the initial value has to be set to the correct
+      // set of spatially relevant dofs
+      slab_initial_value.reinit(space_locally_owned_dofs,
+                                space_locally_relevant_dofs,
+                                mpi_comm);
 
-        // We only have full write access for locally owned vectors
-        dealii::TrilinosWrappers::MPI::Vector tmp;
-        tmp.reinit ( space_locally_owned_dofs , mpi_comm );
+      // We only have full write access for locally owned vectors
+      dealii::TrilinosWrappers::MPI::Vector tmp;
+      tmp.reinit(space_locally_owned_dofs, mpi_comm);
 
-        // set time of the exact solution to initial time point
-        // (For a time independent initial value function this is not needed)
-        exact_solution.set_time ( 0 );
-        // Interpolate the initial value into the FE space
-        dealii::VectorTools::interpolate ( *slab_its.dof->spatial () ,
-                                           exact_solution ,
-                                           tmp );
-        // transfer locally owned initial value to locally relevant vector
-        slab_initial_value = tmp;
+      // set time of the exact solution to initial time point
+      // (For a time independent initial value function this is not needed)
+      exact_solution.set_time(0);
+      // Interpolate the initial value into the FE space
+      dealii::VectorTools::interpolate(*slab_its.dof->spatial(),
+                                       exact_solution,
+                                       tmp);
+      // transfer locally owned initial value to locally relevant vector
+      slab_initial_value = tmp;
     }
 
-    //same as for the sequential case
-    slab_constraints = std::make_shared<dealii::AffineConstraints<double>> ();
-    auto zero = dealii::Functions::ZeroFunction<2> ();
-    idealii::slab::VectorTools::interpolate_boundary_values ( space_locally_relevant_dofs ,
-                                                              *slab_its.dof ,
-                                                              0 ,
-                                                              zero ,
-                                                              slab_constraints );
+  // same as for the sequential case
+  slab_constraints = std::make_shared<dealii::AffineConstraints<double>>();
+  auto zero        = dealii::Functions::ZeroFunction<2>();
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    space_locally_relevant_dofs, *slab_its.dof, 0, zero, slab_constraints);
 
-    slab_constraints->close ();
+  slab_constraints->close();
 
-    dealii::DynamicSparsityPattern dsp ( slab_its.dof->n_dofs_spacetime () );
-    idealii::slab::DoFTools::make_upwind_sparsity_pattern ( *slab_its.dof ,
-                                                            dsp );
+  dealii::DynamicSparsityPattern dsp(slab_its.dof->n_dofs_spacetime());
+  idealii::slab::DoFTools::make_upwind_sparsity_pattern(*slab_its.dof, dsp);
 
-    // To save memory we distribute the sparsity pattern to only hold the locally
-    // needed set of space-time degrees of freedom
-    dealii::SparsityTools::distribute_sparsity_pattern ( dsp ,
-                                                         slab_locally_owned_dofs ,
-                                                         mpi_comm ,
-                                                         slab_locally_relevant_dofs );
+  // To save memory we distribute the sparsity pattern to only hold the locally
+  // needed set of space-time degrees of freedom
+  dealii::SparsityTools::distribute_sparsity_pattern(
+    dsp, slab_locally_owned_dofs, mpi_comm, slab_locally_relevant_dofs);
 
-    // reinit the system matrix and vectors to hold only local information
-    slab_system_matrix.reinit ( slab_locally_owned_dofs ,
-                                slab_locally_owned_dofs ,
-                                dsp );
+  // reinit the system matrix and vectors to hold only local information
+  slab_system_matrix.reinit(slab_locally_owned_dofs,
+                            slab_locally_owned_dofs,
+                            dsp);
 
-    slab_its.solution->reinit ( slab_locally_owned_dofs ,
-                                slab_locally_relevant_dofs ,
-                                mpi_comm );
-    slab_system_rhs.reinit ( slab_locally_owned_dofs , mpi_comm );
+  slab_its.solution->reinit(slab_locally_owned_dofs,
+                            slab_locally_relevant_dofs,
+                            mpi_comm);
+  slab_system_rhs.reinit(slab_locally_owned_dofs, mpi_comm);
 }
 
-void Step3::assemble_system_on_slab ()
+void
+Step3::assemble_system_on_slab()
 {
+  idealii::spacetime::QGauss<2> quad(fe.spatial()->degree + 2,
+                                     fe.temporal()->degree + 2);
 
-    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 2 ,
-                                            fe.temporal ()->degree + 2 );
+  idealii::spacetime::FEValues<2> fe_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    idealii::spacetime::FEValues < 2 > fe_values_spacetime ( fe ,
-                                                             quad ,
-                                                             dealii::update_values |
-                                                             dealii::update_gradients |
-                                                             dealii::update_quadrature_points |
-                                                             dealii::update_JxW_values );
+  idealii::spacetime::FEJumpValues<2> fe_jump_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    idealii::spacetime::FEJumpValues < 2 > fe_jump_values_spacetime ( fe ,
-                                                                      quad ,
-                                                                      dealii::update_values |
-                                                                      dealii::update_gradients |
-                                                                      dealii::update_quadrature_points |
-                                                                      dealii::update_JxW_values );
+  RightHandSide      right_hand_side;
+  const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
 
-    RightHandSide right_hand_side;
-    const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
+  auto N = slab_its.tria->temporal()->n_global_active_cells();
+  dealii::FullMatrix<double> cell_matrix(N * dofs_per_spacetime_cell,
+                                         N * dofs_per_spacetime_cell);
+  dealii::Vector<double>     cell_rhs(N * dofs_per_spacetime_cell);
 
-    auto N = slab_its.tria->temporal ()->n_global_active_cells ();
-    dealii::FullMatrix<double> cell_matrix ( N * dofs_per_spacetime_cell ,
-                                             N * dofs_per_spacetime_cell );
-    dealii::Vector<double> cell_rhs ( N * dofs_per_spacetime_cell );
+  std::vector<dealii::types::global_dof_index> local_spacetime_dof_index(
+    N * dofs_per_spacetime_cell);
 
-    std::vector < dealii::types::global_dof_index > local_spacetime_dof_index ( N * dofs_per_spacetime_cell );
-
-    unsigned int n;
-    unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
-    unsigned int n_quad_space = quad.spatial ()->size ();
-    for ( const auto &cell_space : slab_its.dof->spatial ()->active_cell_iterators () )
+  unsigned int n;
+  unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
+  unsigned int n_quad_space     = quad.spatial()->size();
+  for (const auto &cell_space :
+       slab_its.dof->spatial()->active_cell_iterators())
     {
-        // We only can calculate the contributions of processor local cells
-        // Otherwise the assembly is the same as in step-1
-        if ( cell_space->is_locally_owned () )
+      // We only can calculate the contributions of processor local cells
+      // Otherwise the assembly is the same as in step-1
+      if (cell_space->is_locally_owned())
         {
-            fe_values_spacetime.reinit_space ( cell_space );
-            fe_jump_values_spacetime.reinit_space ( cell_space );
-            std::vector<double> initial_values ( fe_values_spacetime.spatial ()->n_quadrature_points );
-            fe_values_spacetime.spatial ()->get_function_values ( slab_initial_value ,
-                                                                  initial_values );
+          fe_values_spacetime.reinit_space(cell_space);
+          fe_jump_values_spacetime.reinit_space(cell_space);
+          std::vector<double> initial_values(
+            fe_values_spacetime.spatial()->n_quadrature_points);
+          fe_values_spacetime.spatial()->get_function_values(slab_initial_value,
+                                                             initial_values);
 
-            cell_matrix = 0;
-            cell_rhs = 0;
-            for ( const auto &cell_time : slab_its.dof->temporal ()->active_cell_iterators () )
+          cell_matrix = 0;
+          cell_rhs    = 0;
+          for (const auto &cell_time :
+               slab_its.dof->temporal()->active_cell_iterators())
             {
-                n = cell_time->index ();
-                fe_values_spacetime.reinit_time ( cell_time );
-                fe_jump_values_spacetime.reinit_time ( cell_time );
-                fe_values_spacetime.get_local_dof_indices ( local_spacetime_dof_index );
+              n = cell_time->index();
+              fe_values_spacetime.reinit_time(cell_time);
+              fe_jump_values_spacetime.reinit_time(cell_time);
+              fe_values_spacetime.get_local_dof_indices(
+                local_spacetime_dof_index);
 
-                for ( unsigned int q = 0 ; q < n_quad_spacetime ; ++q )
+              for (unsigned int q = 0; q < n_quad_spacetime; ++q)
                 {
-
-                    right_hand_side.set_time ( fe_values_spacetime.time_quadrature_point ( q ) );
-                    const auto &x_q =
-                            fe_values_spacetime.space_quadrature_point ( q );
-                    for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ;
-                            ++i )
+                  right_hand_side.set_time(
+                    fe_values_spacetime.time_quadrature_point(q));
+                  const auto &x_q =
+                    fe_values_spacetime.space_quadrature_point(q);
+                  for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                     {
-                        for ( unsigned int j = 0 ; j < dofs_per_spacetime_cell ;
-                                ++j )
+                      for (unsigned int j = 0; j < dofs_per_spacetime_cell; ++j)
                         {
+                          // (dt u, v)
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + n * dofs_per_spacetime_cell) +=
+                            fe_values_spacetime.shape_value(i, q) *
+                            fe_values_spacetime.shape_dt(j, q) *
+                            fe_values_spacetime.JxW(q);
 
-                            // (dt u, v)
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + n * dofs_per_spacetime_cell )
-                            += fe_values_spacetime.shape_value ( i , q )
-                             * fe_values_spacetime.shape_dt ( j , q )
-                             * fe_values_spacetime.JxW ( q );
+                          // (grad u, grad v)
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + n * dofs_per_spacetime_cell) +=
+                            fe_values_spacetime.shape_space_grad(i, q) *
+                            fe_values_spacetime.shape_space_grad(j, q) *
+                            fe_values_spacetime.JxW(q);
 
-                            // (grad u, grad v)
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + n * dofs_per_spacetime_cell )
-                            += fe_values_spacetime.shape_space_grad ( i , q )
-                             * fe_values_spacetime.shape_space_grad ( j , q )
-                             * fe_values_spacetime.JxW ( q );
+                        } // dofs j
 
-                        } //dofs j
+                      cell_rhs(i + n * dofs_per_spacetime_cell) +=
+                        fe_values_spacetime.shape_value(i, q) *
+                        right_hand_side.value(x_q) * fe_values_spacetime.JxW(q);
 
-                        cell_rhs ( i + n * dofs_per_spacetime_cell )
-                        += fe_values_spacetime.shape_value ( i , q )
-                         * right_hand_side.value ( x_q )
-                         * fe_values_spacetime.JxW ( q );
+                    } // dofs i
+                }     // quad
 
-                    } //dofs i
-                } //quad
-
-                //Jump terms and initial values just have a spatial loop
-                for ( unsigned int q = 0 ; q < n_quad_space ; ++q )
+              // Jump terms and initial values just have a spatial loop
+              for (unsigned int q = 0; q < n_quad_space; ++q)
                 {
-                    for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ;
-                            ++i )
+                  for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                     {
-                        for ( unsigned int j = 0 ; j < dofs_per_spacetime_cell ;
-                                ++j )
+                      for (unsigned int j = 0; j < dofs_per_spacetime_cell; ++j)
                         {
-                            // (v^+, u^+)
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + n * dofs_per_spacetime_cell )
-                            += fe_jump_values_spacetime.shape_value_plus ( i , q )
-                             * fe_jump_values_spacetime.shape_value_plus ( j , q )
-                             * fe_jump_values_spacetime.JxW ( q );
+                          // (v^+, u^+)
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + n * dofs_per_spacetime_cell) +=
+                            fe_jump_values_spacetime.shape_value_plus(i, q) *
+                            fe_jump_values_spacetime.shape_value_plus(j, q) *
+                            fe_jump_values_spacetime.JxW(q);
 
-                            // -(v^-, u^+)
-                            if ( n > 0 )
+                          // -(v^-, u^+)
+                          if (n > 0)
                             {
-                                cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                              j + ( n - 1 ) * dofs_per_spacetime_cell )
-                                -= fe_jump_values_spacetime.shape_value_plus ( i , q )
-                                 * fe_jump_values_spacetime.shape_value_minus ( j , q )
-                                 * fe_jump_values_spacetime.JxW ( q );
+                              cell_matrix(i + n * dofs_per_spacetime_cell,
+                                          j + (n - 1) *
+                                                dofs_per_spacetime_cell) -=
+                                fe_jump_values_spacetime.shape_value_plus(i,
+                                                                          q) *
+                                fe_jump_values_spacetime.shape_value_minus(j,
+                                                                           q) *
+                                fe_jump_values_spacetime.JxW(q);
                             }
-                        } //dofs j
-                        if ( n == 0 )
+                        } // dofs j
+                      if (n == 0)
                         {
-                            cell_rhs ( i )
-                            += fe_jump_values_spacetime.shape_value_plus ( i , q )
-                             * initial_values[q] //value of previous solution at t0
-                             * fe_jump_values_spacetime.JxW ( q );
+                          cell_rhs(i) +=
+                            fe_jump_values_spacetime.shape_value_plus(i, q) *
+                            initial_values[q] // value of previous solution at
+                                              // t0
+                            * fe_jump_values_spacetime.JxW(q);
                         }
-                    } //dofs i
+                    } // dofs i
                 }
 
-            } //cell time
-            slab_constraints->distribute_local_to_global ( cell_matrix ,
-                                                           cell_rhs ,
-                                                           local_spacetime_dof_index ,
-                                                           slab_system_matrix ,
-                                                           slab_system_rhs );
+            } // cell time
+          slab_constraints->distribute_local_to_global(
+            cell_matrix,
+            cell_rhs,
+            local_spacetime_dof_index,
+            slab_system_matrix,
+            slab_system_rhs);
         }
-    } //cell space
+    } // cell space
 
-    // We need to communicate local contributions to other processors after assembly
-    slab_system_matrix.compress ( dealii::VectorOperation::add );
-    slab_system_rhs.compress ( dealii::VectorOperation::add );
+  // We need to communicate local contributions to other processors after
+  // assembly
+  slab_system_matrix.compress(dealii::VectorOperation::add);
+  slab_system_rhs.compress(dealii::VectorOperation::add);
 }
 
-void Step3::solve_system_on_slab ()
+void
+Step3::solve_system_on_slab()
 {
-
-    // The interface needs a solver control that is more or less irrelevant
-    // as we use a direct solver without convergence criterion
-    dealii::SolverControl sc ( 10000 , 1.0e-14 , false , false );
-    // When Trilinos is compiled with MUMPS we prefer it.
-    // If not installed switch to Amesos_Klu
-    dealii::TrilinosWrappers::SolverDirect::AdditionalData ad ( false , "Amesos_Mumps" );
-    dealii::TrilinosWrappers::SolverDirect solver ( sc , ad );
-    // In this interface the factorize is called initialize
-    solver.initialize ( slab_system_matrix );
-    // And vmult is called solve
-    solver.solve ( slab_owned_tmp , slab_system_rhs );
-    slab_constraints->distribute ( slab_owned_tmp );
-    // The solver can only write into a vector with locally owned dofs
-    // so we need to communicate between the processors
-    *slab_its.solution = slab_owned_tmp;
+  // The interface needs a solver control that is more or less irrelevant
+  // as we use a direct solver without convergence criterion
+  dealii::SolverControl sc(10000, 1.0e-14, false, false);
+  // When Trilinos is compiled with MUMPS we prefer it.
+  // If not installed switch to Amesos_Klu
+  dealii::TrilinosWrappers::SolverDirect::AdditionalData ad(false,
+                                                            "Amesos_Mumps");
+  dealii::TrilinosWrappers::SolverDirect                 solver(sc, ad);
+  // In this interface the factorize is called initialize
+  solver.initialize(slab_system_matrix);
+  // And vmult is called solve
+  solver.solve(slab_owned_tmp, slab_system_rhs);
+  slab_constraints->distribute(slab_owned_tmp);
+  // The solver can only write into a vector with locally owned dofs
+  // so we need to communicate between the processors
+  *slab_its.solution = slab_owned_tmp;
 }
 
-void Step3::output_results_on_slab ()
+void
+Step3::output_results_on_slab()
 {
-    auto n_dofs = slab_its.dof->n_dofs_time ();
+  auto n_dofs = slab_its.dof->n_dofs_time();
 
-    dealii::TrilinosWrappers::MPI::Vector tmp = *slab_its.solution;
-    for ( unsigned i = 0 ; i < n_dofs ; i++ )
+  dealii::TrilinosWrappers::MPI::Vector tmp = *slab_its.solution;
+  for (unsigned i = 0; i < n_dofs; i++)
     {
-        dealii::DataOut < 2 > data_out;
-        data_out.attach_dof_handler ( *slab_its.dof->spatial () );
-        dealii::TrilinosWrappers::MPI::Vector local_solution;
-        local_solution.reinit ( space_locally_owned_dofs ,
-                                space_locally_relevant_dofs ,
-                                mpi_comm );
+      dealii::DataOut<2> data_out;
+      data_out.attach_dof_handler(*slab_its.dof->spatial());
+      dealii::TrilinosWrappers::MPI::Vector local_solution;
+      local_solution.reinit(space_locally_owned_dofs,
+                            space_locally_relevant_dofs,
+                            mpi_comm);
 
-        idealii::slab::VectorTools::extract_subvector_at_time_dof ( tmp ,
-                                                                    local_solution ,
-                                                                    i );
-        data_out.add_data_vector ( local_solution , "Solution" );
-        data_out.build_patches ();
-        std::ostringstream filename;
-        filename << "solution2_dG(" << fe.temporal ()->degree << ")_t_"
-        << slab * n_dofs + i
-        << ".vtu";
-        // instead of a vtk we use the parallel write function
-        data_out.write_vtu_in_parallel ( filename.str ().c_str () , mpi_comm );
+      idealii::slab::VectorTools::extract_subvector_at_time_dof(tmp,
+                                                                local_solution,
+                                                                i);
+      data_out.add_data_vector(local_solution, "Solution");
+      data_out.build_patches();
+      std::ostringstream filename;
+      filename << "solution2_dG(" << fe.temporal()->degree << ")_t_"
+               << slab * n_dofs + i << ".vtu";
+      // instead of a vtk we use the parallel write function
+      data_out.write_vtu_in_parallel(filename.str().c_str(), mpi_comm);
     }
 }
-int main ( int argc , char *argv[] )
+int
+main(int argc, char *argv[])
 {
-    //With MPI we need to begin with an InitFinalize call.
-    dealii::Utilities::MPI::MPI_InitFinalize mpi ( argc , argv , MPIX_THREADS );
-    // spatial finite element order
-    unsigned int s = 1;
-    // temporal finite element order
-    unsigned int r = 0;
-    Step3 problem ( s , r );
-    problem.run ();
+  // With MPI we need to begin with an InitFinalize call.
+  dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, MPIX_THREADS);
+  // spatial finite element order
+  unsigned int s = 1;
+  // temporal finite element order
+  unsigned int r = 0;
+  Step3        problem(s, r);
+  problem.run();
 }
-

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -29,43 +29,47 @@
 ////////////////////////////////////////////
 
 #include <ideal.II/distributed/fixed_tria.hh>
+
 #include <ideal.II/lac/spacetime_trilinos_vector.hh>
 
-//all other ideal.II includes are known
-#include <ideal.II/base/time_iterator.hh>
+// all other ideal.II includes are known
 #include <ideal.II/base/quadrature_lib.hh>
-#include <ideal.II/dofs/spacetime_dof_handler.hh>
+#include <ideal.II/base/time_iterator.hh>
+
 #include <ideal.II/dofs/slab_dof_tools.hh>
-#include <deal.II/dofs/dof_renumbering.h>
+#include <ideal.II/dofs/spacetime_dof_handler.hh>
+
 #include <ideal.II/fe/fe_dg.hh>
 #include <ideal.II/fe/spacetime_fe_values.hh>
+
 #include <ideal.II/numerics/vector_tools.hh>
+
+#include <deal.II/dofs/dof_renumbering.h>
 
 ////////////////////////////////////////////
 // deal.II includes
 ////////////////////////////////////////////
 
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/function.h>
+
 #include <deal.II/distributed/tria.h>
 
-#include <deal.II/base/conditional_ostream.h>
-
-#include <deal.II/base/function.h>
-#include <deal.II/base/conditional_ostream.h>
-
-#include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/dofs/dof_renumbering.h>
-#include <deal.II/lac/trilinos_vector.h>
-#include <deal.II/lac/trilinos_solver.h>
-#include <deal.II/lac/sparse_direct.h>
 
-#include <deal.II/grid/grid_in.h>
-#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 
-#include <deal.II/lac/vector.h>
-#include <deal.II/lac/full_matrix.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/manifold_lib.h>
+
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/data_out.h>
 
@@ -80,780 +84,842 @@
 class PoisseuilleInflow : public dealii::Function<2>
 {
 public:
-    PoisseuilleInflow ( double max_inflow_velocity = 1.5 , double channel_height = 0.41 )
-        :
-        Function<2> ( 3 ),
-        max_inflow_velocity ( max_inflow_velocity ),
-        H ( channel_height )
-    {
-    }
+  PoisseuilleInflow(double max_inflow_velocity = 1.5,
+                    double channel_height      = 0.41)
+    : Function<2>(3)
+    , max_inflow_velocity(max_inflow_velocity)
+    , H(channel_height)
+  {}
 
-    virtual double
-    value ( const dealii::Point<2> &p , const unsigned int component = 0 ) const;
+  virtual double
+  value(const dealii::Point<2> &p, const unsigned int component = 0) const;
 
-    virtual void
-    vector_value ( const dealii::Point<2> &p , dealii::Vector<double> &value ) const;
-    private:
-    double max_inflow_velocity;
-    double H;
+  virtual void
+  vector_value(const dealii::Point<2> &p, dealii::Vector<double> &value) const;
+
+private:
+  double max_inflow_velocity;
+  double H;
 };
 
-double PoisseuilleInflow::value ( const dealii::Point<2> &p , const unsigned int component ) const
+double
+PoisseuilleInflow::value(const dealii::Point<2> &p,
+                         const unsigned int      component) const
 {
-    Assert ( component < this->n_components , dealii::ExcIndexRange ( component , 0 , this->n_components ) )
-    if ( component == 0 )
-    {
-        double y = p ( 1 );
-        if ( p ( 0 ) == 0 && y <= 0.41 )
-        {
-            double t = get_time ();
-            return 4 * max_inflow_velocity * y * ( H - y ) * std::sin ( M_PI * t * 0.125 ) / ( H * H );
-        }
-    }
-    return 0;
+  Assert(component < this->n_components,
+         dealii::ExcIndexRange(component,
+                               0,
+                               this->n_components)) if (component == 0)
+  {
+    double y = p(1);
+    if (p(0) == 0 && y <= 0.41)
+      {
+        double t = get_time();
+        return 4 * max_inflow_velocity * y * (H - y) *
+               std::sin(M_PI * t * 0.125) / (H * H);
+      }
+  }
+  return 0;
 }
 
-void PoisseuilleInflow::vector_value ( const dealii::Point<2> &p , dealii::Vector<double> &values ) const
+void
+PoisseuilleInflow::vector_value(const dealii::Point<2> &p,
+                                dealii::Vector<double> &values) const
 {
-    for ( unsigned int c = 0 ; c < this->n_components ; c++ )
+  for (unsigned int c = 0; c < this->n_components; c++)
     {
-        values ( c ) = value ( p , c );
+      values(c) = value(p, c);
     }
 }
 
 // note that the exact solution is unknown and the force term (rhs) is zero.
 
-// This class describes the solution of the nonlinear Navier-Stokes equation with
-// space-time slab tensor-product elements and Newton linearization
+// This class describes the solution of the nonlinear Navier-Stokes equation
+// with space-time slab tensor-product elements and Newton linearization
 class Step4
 {
 public:
-    Step4 ( unsigned int temporal_degree );
-    void
-    run ();
+  Step4(unsigned int temporal_degree);
+  void
+  run();
 
 private:
-    void
-    make_grid ();
-    void
-    time_marching ();
-    void
-    setup_system_on_slab ();
-    void
-    assemble_residual_on_slab ();
-    void
-    assemble_system_on_slab ();
-    void
-    solve_Newton_problem_on_slab ();
-    void
-    output_results_on_slab ();
+  void
+  make_grid();
+  void
+  time_marching();
+  void
+  setup_system_on_slab();
+  void
+  assemble_residual_on_slab();
+  void
+  assemble_system_on_slab();
+  void
+  solve_Newton_problem_on_slab();
+  void
+  output_results_on_slab();
 
-    // we need to know the MPI communicator
-    MPI_Comm mpi_comm;
+  // we need to know the MPI communicator
+  MPI_Comm mpi_comm;
 
-    dealii::ConditionalOStream pout;
-    /////////////////////////////////////////////
-    // space-time collections of slab objects
-    /////////////////////////////////////////////
-    idealii::spacetime::parallel::distributed::fixed::Triangulation<2> triangulation;
-    idealii::spacetime::DoFHandler<2> dof_handler;
-    idealii::spacetime::TrilinosVector solution;
+  dealii::ConditionalOStream pout;
+  /////////////////////////////////////////////
+  // space-time collections of slab objects
+  /////////////////////////////////////////////
+  idealii::spacetime::parallel::distributed::fixed::Triangulation<2>
+                                     triangulation;
+  idealii::spacetime::DoFHandler<2>  dof_handler;
+  idealii::spacetime::TrilinosVector solution;
 
-    // The space-time finite element description
-    idealii::spacetime::DG_FiniteElement<2> fe;
+  // The space-time finite element description
+  idealii::spacetime::DG_FiniteElement<2> fe;
 
-    ////////////////////////////////////////////
-    // objects needed on a single slab
-    ////////////////////////////////////////////
-    dealii::SparsityPattern slab_sparsity_pattern;
-    std::shared_ptr<dealii::AffineConstraints<double>> slab_zero_constraints;
-    dealii::TrilinosWrappers::SparseMatrix slab_system_matrix;
-    dealii::TrilinosWrappers::MPI::Vector slab_system_rhs;
-    dealii::TrilinosWrappers::MPI::Vector slab_initial_value;
-    unsigned int slab;
+  ////////////////////////////////////////////
+  // objects needed on a single slab
+  ////////////////////////////////////////////
+  dealii::SparsityPattern                            slab_sparsity_pattern;
+  std::shared_ptr<dealii::AffineConstraints<double>> slab_zero_constraints;
+  dealii::TrilinosWrappers::SparseMatrix             slab_system_matrix;
+  dealii::TrilinosWrappers::MPI::Vector              slab_system_rhs;
+  dealii::TrilinosWrappers::MPI::Vector              slab_initial_value;
+  unsigned int                                       slab;
 
-    dealii::TrilinosWrappers::MPI::Vector slab_newton_update;
-    dealii::TrilinosWrappers::MPI::Vector slab_owned_tmp;
-    dealii::TrilinosWrappers::MPI::Vector slab_relevant_tmp;
+  dealii::TrilinosWrappers::MPI::Vector slab_newton_update;
+  dealii::TrilinosWrappers::MPI::Vector slab_owned_tmp;
+  dealii::TrilinosWrappers::MPI::Vector slab_relevant_tmp;
 
-    dealii::IndexSet slab_locally_owned_dofs;
-    dealii::IndexSet slab_locally_relevant_dofs;
+  dealii::IndexSet slab_locally_owned_dofs;
+  dealii::IndexSet slab_locally_relevant_dofs;
 
-    dealii::IndexSet space_locally_owned_dofs;
-    dealii::IndexSet space_locally_relevant_dofs;
+  dealii::IndexSet space_locally_owned_dofs;
+  dealii::IndexSet space_locally_relevant_dofs;
 
-    ////////////////////////////////////////////////////////////
-    // Struct holding all iterators over the space-time objects.
-    ////////////////////////////////////////////////////////////
-    struct
-    {
-        idealii::slab::parallel::distributed::TriaIterator<2> tria;
-        idealii::slab::DoFHandlerIterator<2> dof;
-        idealii::slab::TrilinosVectorIterator solution;
-    } slab_its;
+  ////////////////////////////////////////////////////////////
+  // Struct holding all iterators over the space-time objects.
+  ////////////////////////////////////////////////////////////
+  struct
+  {
+    idealii::slab::parallel::distributed::TriaIterator<2> tria;
+    idealii::slab::DoFHandlerIterator<2>                  dof;
+    idealii::slab::TrilinosVectorIterator                 solution;
+  } slab_its;
 };
 
-Step4::Step4 ( unsigned int temporal_degree )
-    :
-    mpi_comm ( MPI_COMM_WORLD ),
-    pout ( std::cout , dealii::Utilities::MPI::this_mpi_process ( mpi_comm ) == 0 ),
-    triangulation (),
-    dof_handler ( &triangulation ),
-    fe ( std::make_shared < dealii::FESystem< 2 >>
-             ( dealii::FE_Q < 2 > ( 2 ) , 2 , dealii::FE_Q < 2 > ( 1 ) , 1 ) ,
-         temporal_degree,
-         idealii::spacetime::DG_FiniteElement<2>::support_type::Legendre
-    ),
-    slab ( 0 )
+Step4::Step4(unsigned int temporal_degree)
+  : mpi_comm(MPI_COMM_WORLD)
+  , pout(std::cout, dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+  , triangulation()
+  , dof_handler(&triangulation)
+  , fe(std::make_shared<dealii::FESystem<2>>(dealii::FE_Q<2>(2),
+                                             2,
+                                             dealii::FE_Q<2>(1),
+                                             1),
+       temporal_degree,
+       idealii::spacetime::DG_FiniteElement<2>::support_type::Legendre)
+  , slab(0)
+{}
+
+void
+Step4::run()
 {
+  make_grid();
+  time_marching();
 }
 
-void Step4::run ()
+void
+Step4::make_grid()
 {
-    make_grid ();
-    time_marching ();
+  // construct an MPI parallel triangulation with the provided MPI communicator
+  auto space_tria =
+    std::make_shared<dealii::parallel::distributed::Triangulation<2>>(mpi_comm);
+  dealii::GridIn<2> grid_in;
+  grid_in.attach_triangulation(*space_tria);
+  std::ifstream input_file("nsbench4.inp");
+  grid_in.read_ucd(input_file);
+  dealii::Point<2>                          p(0.2, 0.2);
+  static const dealii::SphericalManifold<2> boundary(p);
+  dealii::GridTools::copy_boundary_to_manifold_id(*space_tria);
+  space_tria->set_manifold(80, boundary);
+  const unsigned int M = 256;
+  triangulation.generate(space_tria, M, 0, 8.);
+  triangulation.refine_global(2, 0);
+  dof_handler.generate();
 }
 
-void Step4::make_grid ()
+void
+Step4::time_marching()
 {
-    //construct an MPI parallel triangulation with the provided MPI communicator
-    auto space_tria = std::make_shared < dealii::parallel::distributed::Triangulation < 2 >> ( mpi_comm );
-    dealii::GridIn < 2 > grid_in;
-    grid_in.attach_triangulation ( *space_tria );
-    std::ifstream input_file ( "nsbench4.inp" );
-    grid_in.read_ucd ( input_file );
-    dealii::Point < 2 > p ( 0.2 , 0.2 );
-    static const dealii::SphericalManifold<2> boundary ( p );
-    dealii::GridTools::copy_boundary_to_manifold_id ( *space_tria );
-    space_tria->set_manifold ( 80 , boundary );
-    const unsigned int M = 256;
-    triangulation.generate ( space_tria , M , 0 , 8. );
-    triangulation.refine_global ( 2 , 0 );
-    dof_handler.generate ();
-}
+  idealii::TimeIteratorCollection<2> tic = idealii::TimeIteratorCollection<2>();
 
-void Step4::time_marching ()
-{
-    idealii::TimeIteratorCollection < 2 > tic = idealii::TimeIteratorCollection<2> ();
+  solution.reinit(triangulation.M());
 
-    solution.reinit ( triangulation.M () );
-
-    slab_its.tria = triangulation.begin ();
-    slab_its.dof = dof_handler.begin ();
-    slab_its.solution = solution.begin ();
-    slab = 0;
-    tic.add_iterator ( &slab_its.tria , &triangulation );
-    tic.add_iterator ( &slab_its.dof , &dof_handler );
-    tic.add_iterator ( &slab_its.solution , &solution );
-    pout << "*******Starting time-stepping*********" << std::endl;
-    for ( ; !tic.at_end () ; tic.increment () )
+  slab_its.tria     = triangulation.begin();
+  slab_its.dof      = dof_handler.begin();
+  slab_its.solution = solution.begin();
+  slab              = 0;
+  tic.add_iterator(&slab_its.tria, &triangulation);
+  tic.add_iterator(&slab_its.dof, &dof_handler);
+  tic.add_iterator(&slab_its.solution, &solution);
+  pout << "*******Starting time-stepping*********" << std::endl;
+  for (; !tic.at_end(); tic.increment())
     {
-        pout << "Starting time-step ("
-             << slab_its.tria->startpoint () << ","
-             << slab_its.tria->endpoint () << ")"
-             << std::endl;
+      pout << "Starting time-step (" << slab_its.tria->startpoint() << ","
+           << slab_its.tria->endpoint() << ")" << std::endl;
 
-        pout << "setup system" << std::endl;
-        setup_system_on_slab ();
-        solve_Newton_problem_on_slab ();
-        output_results_on_slab ();
-        // As in step-3 we need to extract the solution at the final time point as the
-        // final DoF is not in the same location for Legendre support points
-        idealii::slab::VectorTools::extract_subvector_at_time_point ( *slab_its.dof ,
-                                                                      *slab_its.solution ,
-                                                                      slab_initial_value ,
-                                                                      slab_its.tria->endpoint () );
-        slab++;
+      pout << "setup system" << std::endl;
+      setup_system_on_slab();
+      solve_Newton_problem_on_slab();
+      output_results_on_slab();
+      // As in step-3 we need to extract the solution at the final time point as
+      // the final DoF is not in the same location for Legendre support points
+      idealii::slab::VectorTools::extract_subvector_at_time_point(
+        *slab_its.dof,
+        *slab_its.solution,
+        slab_initial_value,
+        slab_its.tria->endpoint());
+      slab++;
     }
 }
 
-void Step4::setup_system_on_slab ()
+void
+Step4::setup_system_on_slab()
 {
-    slab_its.dof->distribute_dofs ( fe );
+  slab_its.dof->distribute_dofs(fe);
 
-    dealii::DoFRenumbering::component_wise ( *slab_its.dof->spatial () );
+  dealii::DoFRenumbering::component_wise(*slab_its.dof->spatial());
 
-    pout << "Number of degrees of freedom: \n\t"
-         << slab_its.dof->n_dofs_space () << " (space) * "
-         << slab_its.dof->n_dofs_time ()  << " (time) = "
-         << slab_its.dof->n_dofs_spacetime () << std::endl;
+  pout << "Number of degrees of freedom: \n\t" << slab_its.dof->n_dofs_space()
+       << " (space) * " << slab_its.dof->n_dofs_time()
+       << " (time) = " << slab_its.dof->n_dofs_spacetime() << std::endl;
 
-    // we need to know the spatial set of degrees of freedom owned by the current MPI processor
-    space_locally_owned_dofs = slab_its.dof->spatial ()->locally_owned_dofs ();
-    // and beloging to elements owned by the processor
-    dealii::DoFTools::extract_locally_relevant_dofs ( *slab_its.dof->spatial () , space_locally_relevant_dofs );
+  // we need to know the spatial set of degrees of freedom owned by the current
+  // MPI processor
+  space_locally_owned_dofs = slab_its.dof->spatial()->locally_owned_dofs();
+  // and beloging to elements owned by the processor
+  dealii::DoFTools::extract_locally_relevant_dofs(*slab_its.dof->spatial(),
+                                                  space_locally_relevant_dofs);
 
-    // The same holds for the set of space-time degrees of freedom
-    slab_locally_owned_dofs = slab_its.dof->locally_owned_dofs ();
-    slab_locally_relevant_dofs = idealii::slab::DoFTools::extract_locally_relevant_dofs ( *slab_its.dof );
+  // The same holds for the set of space-time degrees of freedom
+  slab_locally_owned_dofs = slab_its.dof->locally_owned_dofs();
+  slab_locally_relevant_dofs =
+    idealii::slab::DoFTools::extract_locally_relevant_dofs(*slab_its.dof);
 
-    slab_owned_tmp.reinit ( slab_locally_owned_dofs , mpi_comm );
-    slab_relevant_tmp.reinit ( slab_locally_owned_dofs , slab_locally_relevant_dofs , mpi_comm );
-    slab_newton_update.reinit ( slab_locally_owned_dofs , mpi_comm );
-    // On the first slab the initial value has to be set to the correct set of spatially relevant
-    // dofs
-    if ( slab == 0 )
+  slab_owned_tmp.reinit(slab_locally_owned_dofs, mpi_comm);
+  slab_relevant_tmp.reinit(slab_locally_owned_dofs,
+                           slab_locally_relevant_dofs,
+                           mpi_comm);
+  slab_newton_update.reinit(slab_locally_owned_dofs, mpi_comm);
+  // On the first slab the initial value has to be set to the correct set of
+  // spatially relevant dofs
+  if (slab == 0)
     {
-        slab_initial_value.reinit ( space_locally_owned_dofs , space_locally_relevant_dofs , mpi_comm );
-        slab_initial_value = 0;
+      slab_initial_value.reinit(space_locally_owned_dofs,
+                                space_locally_relevant_dofs,
+                                mpi_comm);
+      slab_initial_value = 0;
     }
 
-    // We need two sets of constraints
-    // The correct boundary conditions are prescribed on the initial Newton guess
-    // and so all Dirichlet boundary conditions on the Newton update need to be
-    // zero to keep the solution unchanged at Gamma_D
-    slab_zero_constraints = std::make_shared<dealii::AffineConstraints<double>> ();
-    auto slab_initial_constraints = std::make_shared<dealii::AffineConstraints<double>> ();
-    auto zero = dealii::Functions::ZeroFunction < 2 > ( 3 );
-    auto inflow = PoisseuilleInflow ();
-    std::vector<bool> component_mask ( 3 , true );
-    component_mask[2] = false;
+  // We need two sets of constraints
+  // The correct boundary conditions are prescribed on the initial Newton guess
+  // and so all Dirichlet boundary conditions on the Newton update need to be
+  // zero to keep the solution unchanged at Gamma_D
+  slab_zero_constraints = std::make_shared<dealii::AffineConstraints<double>>();
+  auto slab_initial_constraints =
+    std::make_shared<dealii::AffineConstraints<double>>();
+  auto              zero   = dealii::Functions::ZeroFunction<2>(3);
+  auto              inflow = PoisseuilleInflow();
+  std::vector<bool> component_mask(3, true);
+  component_mask[2] = false;
 
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              0 ,
-                                                              inflow ,
-                                                              slab_initial_constraints ,
-                                                              component_mask );
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    *slab_its.dof, 0, inflow, slab_initial_constraints, component_mask);
 
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              2 ,
-                                                              zero ,
-                                                              slab_initial_constraints ,
-                                                              component_mask );
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    *slab_its.dof, 2, zero, slab_initial_constraints, component_mask);
 
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              80 ,
-                                                              zero ,
-                                                              slab_initial_constraints ,
-                                                              component_mask );
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    *slab_its.dof, 80, zero, slab_initial_constraints, component_mask);
 
-    slab_initial_constraints->close ();
+  slab_initial_constraints->close();
 
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              0 ,
-                                                              zero ,
-                                                              slab_zero_constraints ,
-                                                              component_mask );
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    *slab_its.dof, 0, zero, slab_zero_constraints, component_mask);
 
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              2 ,
-                                                              zero ,
-                                                              slab_zero_constraints ,
-                                                              component_mask );
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    *slab_its.dof, 2, zero, slab_zero_constraints, component_mask);
 
-    idealii::slab::VectorTools::interpolate_boundary_values ( *slab_its.dof ,
-                                                              80 ,
-                                                              zero ,
-                                                              slab_zero_constraints ,
-                                                              component_mask );
+  idealii::slab::VectorTools::interpolate_boundary_values(
+    *slab_its.dof, 80, zero, slab_zero_constraints, component_mask);
 
-    slab_zero_constraints->close ();
-    std::map<dealii::types::global_dof_index,double> initial_bc;
+  slab_zero_constraints->close();
+  std::map<dealii::types::global_dof_index, double> initial_bc;
 
-    dealii::IndexSet::ElementIterator lri = space_locally_owned_dofs.begin ();
-    dealii::IndexSet::ElementIterator lre = space_locally_owned_dofs.end ();
-    for ( ; lri != lre ; lri++ )
+  dealii::IndexSet::ElementIterator lri = space_locally_owned_dofs.begin();
+  dealii::IndexSet::ElementIterator lre = space_locally_owned_dofs.end();
+  for (; lri != lre; lri++)
     {
-        for ( unsigned int ii = 0 ; ii < slab_its.dof->n_dofs_time () ; ii++ )
+      for (unsigned int ii = 0; ii < slab_its.dof->n_dofs_time(); ii++)
         {
-            slab_owned_tmp[*lri + slab_its.dof->n_dofs_space () * ii] = slab_initial_value[*lri];
+          slab_owned_tmp[*lri + slab_its.dof->n_dofs_space() * ii] =
+            slab_initial_value[*lri];
         }
     }
-    slab_initial_constraints->distribute ( slab_owned_tmp );
+  slab_initial_constraints->distribute(slab_owned_tmp);
 
-    // The spatial pressure-pressure coupling block is empty
-    // and the sparsity pattern can be empty in these blocks
-    dealii::Table < 2 , dealii::DoFTools::Coupling > coupling_space ( 2 + 1 , 2 + 1 );
-    // init with no coupling
-    coupling_space.fill ( dealii::DoFTools::none );
-    // coupling of velocities
-    for ( unsigned int i = 0 ; i < 2 ; i++ )
+  // The spatial pressure-pressure coupling block is empty
+  // and the sparsity pattern can be empty in these blocks
+  dealii::Table<2, dealii::DoFTools::Coupling> coupling_space(2 + 1, 2 + 1);
+  // init with no coupling
+  coupling_space.fill(dealii::DoFTools::none);
+  // coupling of velocities
+  for (unsigned int i = 0; i < 2; i++)
     {
-        for ( unsigned int j = 0 ; j < 2 ; j++ )
+      for (unsigned int j = 0; j < 2; j++)
         {
-            coupling_space[i][j] = dealii::DoFTools::always;
+          coupling_space[i][j] = dealii::DoFTools::always;
         }
     }
-    // coupling of velocity and pressure
-    for ( unsigned int i = 0 ; i < 2 ; i++ )
+  // coupling of velocity and pressure
+  for (unsigned int i = 0; i < 2; i++)
     {
-        coupling_space[i][2] = dealii::DoFTools::always;
-        coupling_space[2][i] = dealii::DoFTools::always;
+      coupling_space[i][2] = dealii::DoFTools::always;
+      coupling_space[2][i] = dealii::DoFTools::always;
     }
 
-    dealii::DynamicSparsityPattern dsp ( slab_its.dof->n_dofs_spacetime () );
-    idealii::slab::DoFTools::make_upwind_sparsity_pattern ( *slab_its.dof , coupling_space , dsp , slab_zero_constraints );
+  dealii::DynamicSparsityPattern dsp(slab_its.dof->n_dofs_spacetime());
+  idealii::slab::DoFTools::make_upwind_sparsity_pattern(*slab_its.dof,
+                                                        coupling_space,
+                                                        dsp,
+                                                        slab_zero_constraints);
 
-    // To save memory we distribute the sparsity pattern to only hold the locally
-    // needed set of space-time degrees of freedom
-    dealii::SparsityTools::distribute_sparsity_pattern (
-            dsp ,
-            slab_locally_owned_dofs ,
-            mpi_comm ,
-            slab_locally_relevant_dofs );
+  // To save memory we distribute the sparsity pattern to only hold the locally
+  // needed set of space-time degrees of freedom
+  dealii::SparsityTools::distribute_sparsity_pattern(
+    dsp, slab_locally_owned_dofs, mpi_comm, slab_locally_relevant_dofs);
 
-    // reinit the system matrix and vectors to hold only local information
-    slab_system_matrix.reinit ( slab_locally_owned_dofs , slab_locally_owned_dofs , dsp );
+  // reinit the system matrix and vectors to hold only local information
+  slab_system_matrix.reinit(slab_locally_owned_dofs,
+                            slab_locally_owned_dofs,
+                            dsp);
 
-    slab_its.solution->reinit ( slab_locally_owned_dofs , slab_locally_relevant_dofs , mpi_comm );
-    slab_system_rhs.reinit ( slab_locally_owned_dofs , mpi_comm );
-    *slab_its.solution = slab_owned_tmp;
+  slab_its.solution->reinit(slab_locally_owned_dofs,
+                            slab_locally_relevant_dofs,
+                            mpi_comm);
+  slab_system_rhs.reinit(slab_locally_owned_dofs, mpi_comm);
+  *slab_its.solution = slab_owned_tmp;
 }
 
-void Step4::assemble_system_on_slab ()
+void
+Step4::assemble_system_on_slab()
 {
+  slab_system_matrix = 0;
+  idealii::spacetime::QGauss<2> quad(fe.spatial()->degree + 3,
+                                     fe.temporal()->degree + 2);
 
-    slab_system_matrix = 0;
-    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 3 , fe.temporal ()->degree + 2 );
+  idealii::spacetime::FEValues<2> fe_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    idealii::spacetime::FEValues < 2 > fe_values_spacetime (fe , quad ,
-            dealii::update_values |
-            dealii::update_gradients |
-            dealii::update_quadrature_points |
-            dealii::update_JxW_values );
+  idealii::spacetime::FEJumpValues<2> fe_jump_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    idealii::spacetime::FEJumpValues < 2 > fe_jump_values_spacetime (fe , quad ,
-            dealii::update_values |
-            dealii::update_gradients |
-            dealii::update_quadrature_points |
-            dealii::update_JxW_values );
+  const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
 
-    const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
+  auto N = slab_its.tria->temporal()->n_global_active_cells();
+  dealii::FullMatrix<double> cell_matrix(N * dofs_per_spacetime_cell,
+                                         N * dofs_per_spacetime_cell);
 
-    auto N = slab_its.tria->temporal ()->n_global_active_cells ();
-    dealii::FullMatrix<double> cell_matrix ( N * dofs_per_spacetime_cell , N * dofs_per_spacetime_cell );
+  std::vector<dealii::types::global_dof_index> local_spacetime_dof_index(
+    N * dofs_per_spacetime_cell);
 
-    std::vector < dealii::types::global_dof_index > local_spacetime_dof_index ( N * dofs_per_spacetime_cell );
+  unsigned int n;
+  unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
+  unsigned int n_quad_space     = quad.spatial()->size();
 
-    unsigned int n;
-    unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
-    unsigned int n_quad_space = quad.spatial ()->size ();
+  dealii::FEValuesExtractors::Vector velocity(0);
+  dealii::FEValuesExtractors::Scalar pressure(2);
+  // set the kinematic viscosity
+  double nu_f = 1.0e-3;
 
-    dealii::FEValuesExtractors::Vector velocity ( 0 );
-    dealii::FEValuesExtractors::Scalar pressure ( 2 );
-    // set the kinematic viscosity
-    double nu_f = 1.0e-3;
+  std::vector<dealii::Vector<double>> old_solution_values(
+    n_quad_spacetime, dealii::Vector<double>(3));
 
-    std::vector<dealii::Vector<double>> old_solution_values ( n_quad_spacetime , dealii::Vector<double> ( 3 ) );
-
-    std::vector < std::vector<dealii::Tensor<1,2> > > old_solution_grads ( n_quad_spacetime ,
-                                                                           std::vector<dealii::Tensor<1,2>> ( 3 ) );
-    for ( const auto &cell_space : slab_its.dof->spatial ()->active_cell_iterators () )
+  std::vector<std::vector<dealii::Tensor<1, 2>>> old_solution_grads(
+    n_quad_spacetime, std::vector<dealii::Tensor<1, 2>>(3));
+  for (const auto &cell_space :
+       slab_its.dof->spatial()->active_cell_iterators())
     {
-        // We only can calculate the contributions of processor local cells
-        // Apart from that, only the additional convection term is new
-        if ( cell_space->is_locally_owned () )
+      // We only can calculate the contributions of processor local cells
+      // Apart from that, only the additional convection term is new
+      if (cell_space->is_locally_owned())
         {
-            fe_values_spacetime.reinit_space ( cell_space );
-            fe_jump_values_spacetime.reinit_space ( cell_space );
+          fe_values_spacetime.reinit_space(cell_space);
+          fe_jump_values_spacetime.reinit_space(cell_space);
 
-            cell_matrix = 0;
-            for ( const auto &cell_time : slab_its.dof->temporal ()->active_cell_iterators () )
+          cell_matrix = 0;
+          for (const auto &cell_time :
+               slab_its.dof->temporal()->active_cell_iterators())
             {
-                n = cell_time->index ();
-                fe_values_spacetime.reinit_time ( cell_time );
-                fe_jump_values_spacetime.reinit_time ( cell_time );
-                fe_values_spacetime.get_local_dof_indices ( local_spacetime_dof_index );
+              n = cell_time->index();
+              fe_values_spacetime.reinit_time(cell_time);
+              fe_jump_values_spacetime.reinit_time(cell_time);
+              fe_values_spacetime.get_local_dof_indices(
+                local_spacetime_dof_index);
 
-                fe_values_spacetime.get_function_values( *slab_its.solution, old_solution_values );
+              fe_values_spacetime.get_function_values(*slab_its.solution,
+                                                      old_solution_values);
 
-                fe_values_spacetime.get_function_space_gradients( *slab_its.solution , old_solution_grads );
-                for ( unsigned int q = 0 ; q < n_quad_spacetime ; ++q )
+              fe_values_spacetime.get_function_space_gradients(
+                *slab_its.solution, old_solution_grads);
+              for (unsigned int q = 0; q < n_quad_spacetime; ++q)
                 {
-
-                    dealii::Tensor < 1 , 2 > v;
-                    dealii::Tensor < 2 , 2 > grad_v;
-                    for ( int c = 0 ; c < 2 ; c++ )
+                  dealii::Tensor<1, 2> v;
+                  dealii::Tensor<2, 2> grad_v;
+                  for (int c = 0; c < 2; c++)
                     {
-                        v[c] = old_solution_values[q] ( c );
-                        for ( int d = 0 ; d < 2 ; d++ )
+                      v[c] = old_solution_values[q](c);
+                      for (int d = 0; d < 2; d++)
                         {
-                            grad_v[c][d] = old_solution_grads[q][c][d];
+                          grad_v[c][d] = old_solution_grads[q][c][d];
                         }
                     }
-                    for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
+                  for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                     {
-
-                        for ( unsigned int j = 0 ; j < dofs_per_spacetime_cell ; ++j )
+                      for (unsigned int j = 0; j < dofs_per_spacetime_cell; ++j)
                         {
+                          // (convection term)
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + n * dofs_per_spacetime_cell) +=
+                            fe_values_spacetime.vector_value(velocity, i, q) *
+                            (fe_values_spacetime.vector_space_grad(velocity,
+                                                                   j,
+                                                                   q) *
+                               v +
+                             grad_v * fe_values_spacetime.vector_value(velocity,
+                                                                       j,
+                                                                       q)) *
+                            fe_values_spacetime.JxW(q);
 
-                            // (convection term)
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + n * dofs_per_spacetime_cell )
-                            += fe_values_spacetime.vector_value ( velocity , i , q ) *
-                               (
-                                   fe_values_spacetime.vector_space_grad ( velocity , j , q ) * v
-                                   + grad_v * fe_values_spacetime.vector_value ( velocity , j , q )
-                               ) * fe_values_spacetime.JxW ( q );
+                          // (phi, dt v)
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + n * dofs_per_spacetime_cell) +=
+                            fe_values_spacetime.vector_value(velocity, i, q) *
+                            fe_values_spacetime.vector_dt(velocity, j, q) *
+                            fe_values_spacetime.JxW(q);
 
-                            // (phi, dt v)
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + n * dofs_per_spacetime_cell )
-                            += fe_values_spacetime.vector_value ( velocity , i , q )
-                             * fe_values_spacetime.vector_dt ( velocity , j , q )
-                             * fe_values_spacetime.JxW ( q );
+                          // (grad phi, grad v)
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + n * dofs_per_spacetime_cell) +=
+                            dealii::scalar_product(
+                              fe_values_spacetime.vector_space_grad(velocity,
+                                                                    i,
+                                                                    q),
+                              fe_values_spacetime.vector_space_grad(velocity,
+                                                                    j,
+                                                                    q)) *
+                            fe_values_spacetime.JxW(q) * nu_f;
 
-                            // (grad phi, grad v)
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + n * dofs_per_spacetime_cell )
-                            += dealii::scalar_product (
-                                    fe_values_spacetime.vector_space_grad ( velocity , i , q ) ,
-                                    fe_values_spacetime.vector_space_grad ( velocity , j , q )
-                                )
-                                * fe_values_spacetime.JxW ( q ) * nu_f;
+                          // (pressure gradient)
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + n * dofs_per_spacetime_cell) -=
+                            fe_values_spacetime.vector_divergence(velocity,
+                                                                  i,
+                                                                  q) *
+                            fe_values_spacetime.scalar_value(pressure, j, q) *
+                            fe_values_spacetime.JxW(q);
 
-                            // (pressure gradient)
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + n * dofs_per_spacetime_cell )
-                            -= fe_values_spacetime.vector_divergence ( velocity , i , q )
-                             * fe_values_spacetime.scalar_value ( pressure , j , q )
-                             * fe_values_spacetime.JxW ( q );
+                          // (div free constraint)
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + n * dofs_per_spacetime_cell) +=
+                            fe_values_spacetime.scalar_value(pressure, i, q) *
+                            fe_values_spacetime.vector_divergence(velocity,
+                                                                  j,
+                                                                  q) *
+                            fe_values_spacetime.JxW(q);
 
-                            // (div free constraint)
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + n * dofs_per_spacetime_cell )
-                            += fe_values_spacetime.scalar_value ( pressure , i , q )
-                             * fe_values_spacetime.vector_divergence ( velocity , j , q )
-                             * fe_values_spacetime.JxW ( q );
+                        } // dofs j
+                    }     // dofs i
+                }         // quad
 
-                        } //dofs j
-                    } //dofs i
-                } //quad
-
-                for ( unsigned int q = 0 ; q < n_quad_space ; ++q )
+              for (unsigned int q = 0; q < n_quad_space; ++q)
                 {
-                    for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
+                  for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                     {
-                        for ( unsigned int j = 0 ; j < dofs_per_spacetime_cell ; ++j )
+                      for (unsigned int j = 0; j < dofs_per_spacetime_cell; ++j)
                         {
-                            // (v^+, u^+)
-                            cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                          j + n * dofs_per_spacetime_cell )
-                              += fe_jump_values_spacetime.vector_value_plus ( velocity , i , q )
-                               * fe_jump_values_spacetime.vector_value_plus ( velocity , j , q )
-                               * fe_jump_values_spacetime.JxW ( q );
+                          // (v^+, u^+)
+                          cell_matrix(i + n * dofs_per_spacetime_cell,
+                                      j + n * dofs_per_spacetime_cell) +=
+                            fe_jump_values_spacetime.vector_value_plus(velocity,
+                                                                       i,
+                                                                       q) *
+                            fe_jump_values_spacetime.vector_value_plus(velocity,
+                                                                       j,
+                                                                       q) *
+                            fe_jump_values_spacetime.JxW(q);
 
-                            // -(v^-, u^+)
-                            if ( n > 0 )
+                          // -(v^-, u^+)
+                          if (n > 0)
                             {
-                                cell_matrix ( i + n * dofs_per_spacetime_cell ,
-                                              j + ( n - 1 ) * dofs_per_spacetime_cell )
-                                -= fe_jump_values_spacetime.vector_value_plus ( velocity , i , q )
-                                 * fe_jump_values_spacetime.vector_value_minus ( velocity , j , q )
-                                 * fe_jump_values_spacetime.JxW ( q );
+                              cell_matrix(i + n * dofs_per_spacetime_cell,
+                                          j + (n - 1) *
+                                                dofs_per_spacetime_cell) -=
+                                fe_jump_values_spacetime.vector_value_plus(
+                                  velocity, i, q) *
+                                fe_jump_values_spacetime.vector_value_minus(
+                                  velocity, j, q) *
+                                fe_jump_values_spacetime.JxW(q);
                             }
-                        } //dofs j
-                    } //dofs i
+                        } // dofs j
+                    }     // dofs i
                 }
 
-            } //cell time
-            slab_zero_constraints->distribute_local_to_global (
-                    cell_matrix , local_spacetime_dof_index , slab_system_matrix );
+            } // cell time
+          slab_zero_constraints->distribute_local_to_global(
+            cell_matrix, local_spacetime_dof_index, slab_system_matrix);
         }
-    } //cell space
+    } // cell space
 
-    // We need to communicate local contributions to other processors after assembly
-    slab_system_matrix.compress ( dealii::VectorOperation::add );
+  // We need to communicate local contributions to other processors after
+  // assembly
+  slab_system_matrix.compress(dealii::VectorOperation::add);
 }
 
 // For the Newton iteration we also need to assemble the residual vector
 // this depends on the current slab solution/iterate.
 // Currently evaluation of the solution is done by hand and functions to
 // simplify this in ideal.II are work in progress
-void Step4::assemble_residual_on_slab ()
+void
+Step4::assemble_residual_on_slab()
 {
-    slab_system_rhs = 0;
-    idealii::spacetime::QGauss < 2 > quad ( fe.spatial ()->degree + 3 , fe.temporal ()->degree + 2 );
+  slab_system_rhs = 0;
+  idealii::spacetime::QGauss<2> quad(fe.spatial()->degree + 3,
+                                     fe.temporal()->degree + 2);
 
-    idealii::spacetime::FEValues < 2 > fe_values_spacetime (fe , quad ,
-                                                            dealii::update_values |
-                                                            dealii::update_gradients |
-                                                            dealii::update_quadrature_points |
-                                                            dealii::update_JxW_values );
+  idealii::spacetime::FEValues<2> fe_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    idealii::spacetime::FEJumpValues < 2 > fe_jump_values_spacetime (fe , quad ,
-                                                                     dealii::update_values |
-                                                                     dealii::update_gradients |
-                                                                     dealii::update_quadrature_points |
-                                                                     dealii::update_JxW_values );
+  idealii::spacetime::FEJumpValues<2> fe_jump_values_spacetime(
+    fe,
+    quad,
+    dealii::update_values | dealii::update_gradients |
+      dealii::update_quadrature_points | dealii::update_JxW_values);
 
-    const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
+  const unsigned int dofs_per_spacetime_cell = fe.dofs_per_cell;
 
-    auto N = slab_its.tria->temporal ()->n_global_active_cells ();
-    dealii::Vector<double> cell_rhs ( N * dofs_per_spacetime_cell );
+  auto                   N = slab_its.tria->temporal()->n_global_active_cells();
+  dealii::Vector<double> cell_rhs(N * dofs_per_spacetime_cell);
 
-    std::vector < dealii::types::global_dof_index > local_spacetime_dof_index ( N * dofs_per_spacetime_cell );
+  std::vector<dealii::types::global_dof_index> local_spacetime_dof_index(
+    N * dofs_per_spacetime_cell);
 
-    unsigned int n;
-    unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
-    unsigned int n_quad_space = quad.spatial ()->size ();
+  unsigned int n;
+  unsigned int n_quad_spacetime = fe_values_spacetime.n_quadrature_points;
+  unsigned int n_quad_space     = quad.spatial()->size();
 
-    dealii::FEValuesExtractors::Vector velocity ( 0 );
-    dealii::FEValuesExtractors::Scalar pressure ( 2 );
-    // set the kinematic viscosity
-    double nu_f = 1.0e-3;
+  dealii::FEValuesExtractors::Vector velocity(0);
+  dealii::FEValuesExtractors::Scalar pressure(2);
+  // set the kinematic viscosity
+  double nu_f = 1.0e-3;
 
-    std::vector<dealii::Vector<double>> old_solution_values ( n_quad_spacetime , dealii::Vector<double> ( 3 ) );
+  std::vector<dealii::Vector<double>> old_solution_values(
+    n_quad_spacetime, dealii::Vector<double>(3));
 
-    std::vector<dealii::Vector<double>> old_solution_dt ( n_quad_spacetime , dealii::Vector<double> ( 3 ) );
+  std::vector<dealii::Vector<double>> old_solution_dt(
+    n_quad_spacetime, dealii::Vector<double>(3));
 
-    std::vector < std::vector<dealii::Tensor<1,2> > >
-        old_solution_grads ( n_quad_spacetime , std::vector<dealii::Tensor<1,2>> ( 3 ) );
+  std::vector<std::vector<dealii::Tensor<1, 2>>> old_solution_grads(
+    n_quad_spacetime, std::vector<dealii::Tensor<1, 2>>(3));
 
-    std::vector<dealii::Tensor<1,2>> solution_minus ( n_quad_space );
+  std::vector<dealii::Tensor<1, 2>> solution_minus(n_quad_space);
 
-    std::vector<dealii::Tensor<1,2>> solution_plus ( n_quad_space );
+  std::vector<dealii::Tensor<1, 2>> solution_plus(n_quad_space);
 
-    std::vector<dealii::Vector<double>> old_solution_plus ( n_quad_space , dealii::Vector<double> ( 3 ) );
+  std::vector<dealii::Vector<double>> old_solution_plus(
+    n_quad_space, dealii::Vector<double>(3));
 
-    std::vector<dealii::Vector<double>> old_solution_minus ( n_quad_space , dealii::Vector<double> ( 3 ) );
+  std::vector<dealii::Vector<double>> old_solution_minus(
+    n_quad_space, dealii::Vector<double>(3));
 
-    for ( const auto &cell_space : slab_its.dof->spatial ()->active_cell_iterators () )
+  for (const auto &cell_space :
+       slab_its.dof->spatial()->active_cell_iterators())
     {
-        // We only can calculate the contributions of processor local cells
-        if ( cell_space->is_locally_owned () )
+      // We only can calculate the contributions of processor local cells
+      if (cell_space->is_locally_owned())
         {
-            fe_values_spacetime.reinit_space ( cell_space );
-            fe_jump_values_spacetime.reinit_space ( cell_space );
+          fe_values_spacetime.reinit_space(cell_space);
+          fe_jump_values_spacetime.reinit_space(cell_space);
 
-            cell_rhs = 0;
-            for ( const auto &cell_time : slab_its.dof->temporal ()->active_cell_iterators () )
+          cell_rhs = 0;
+          for (const auto &cell_time :
+               slab_its.dof->temporal()->active_cell_iterators())
             {
-                n = cell_time->index ();
-                fe_values_spacetime.reinit_time ( cell_time );
-                fe_jump_values_spacetime.reinit_time ( cell_time );
-                fe_values_spacetime.get_local_dof_indices ( local_spacetime_dof_index );
+              n = cell_time->index();
+              fe_values_spacetime.reinit_time(cell_time);
+              fe_jump_values_spacetime.reinit_time(cell_time);
+              fe_values_spacetime.get_local_dof_indices(
+                local_spacetime_dof_index);
 
-                if ( n == 0 )
+              if (n == 0)
                 {
-                    fe_values_spacetime.spatial ()->get_function_values ( slab_initial_value ,
-                                                                          old_solution_minus );
+                  fe_values_spacetime.spatial()->get_function_values(
+                    slab_initial_value, old_solution_minus);
                 }
 
-                fe_values_spacetime.get_function_values( *slab_its.solution, old_solution_values );
+              fe_values_spacetime.get_function_values(*slab_its.solution,
+                                                      old_solution_values);
 
-                fe_values_spacetime.get_function_dt( *slab_its.solution , old_solution_dt );
+              fe_values_spacetime.get_function_dt(*slab_its.solution,
+                                                  old_solution_dt);
 
-                fe_values_spacetime.get_function_space_gradients( *slab_its.solution , old_solution_grads );
+              fe_values_spacetime.get_function_space_gradients(
+                *slab_its.solution, old_solution_grads);
 
-                for ( unsigned int q = 0 ; q < n_quad_spacetime ; ++q )
+              for (unsigned int q = 0; q < n_quad_spacetime; ++q)
                 {
+                  dealii::Tensor<1, 2> v;
+                  dealii::Tensor<1, 2> dt_v;
+                  dealii::Tensor<2, 2> grad_v;
 
-                    dealii::Tensor < 1 , 2 > v;
-                    dealii::Tensor < 1 , 2 > dt_v;
-                    dealii::Tensor < 2 , 2 > grad_v;
-
-                    const double p = old_solution_values[q] ( 2 );
-                    for ( int c = 0 ; c < 2 ; c++ )
+                  const double p = old_solution_values[q](2);
+                  for (int c = 0; c < 2; c++)
                     {
-                        v[c] = old_solution_values[q]( c );
-                        dt_v[c] = old_solution_dt[q]( c );
-                        for ( int d = 0 ; d < 2 ; d++ )
+                      v[c]    = old_solution_values[q](c);
+                      dt_v[c] = old_solution_dt[q](c);
+                      for (int d = 0; d < 2; d++)
                         {
-                            grad_v[c][d] = old_solution_grads[q][c][d];
+                          grad_v[c][d] = old_solution_grads[q][c][d];
                         }
                     }
-                    const double div_v = dealii::trace ( grad_v );
+                  const double div_v = dealii::trace(grad_v);
 
-                    for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
+                  for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                     {
+                      // (dt u, v)
+                      cell_rhs(i + n * dofs_per_spacetime_cell) -=
+                        fe_values_spacetime.vector_value(velocity, i, q) *
+                        dt_v * fe_values_spacetime.JxW(q);
 
-                        // (dt u, v)
-                        cell_rhs ( i+ n * dofs_per_spacetime_cell )
-                           -= fe_values_spacetime.vector_value ( velocity , i , q )
-                            * dt_v * fe_values_spacetime.JxW ( q );
+                      // convection
+                      cell_rhs(i + n * dofs_per_spacetime_cell) -=
+                        fe_values_spacetime.vector_value(velocity, i, q) *
+                        grad_v * v * fe_values_spacetime.JxW(q);
 
-                        // convection
-                        cell_rhs ( i + n * dofs_per_spacetime_cell )
-                           -= fe_values_spacetime.vector_value ( velocity , i , q )
-                            * grad_v * v * fe_values_spacetime.JxW ( q );
+                      // (grad u, grad v)
+                      cell_rhs(i + n * dofs_per_spacetime_cell) -=
+                        nu_f *
+                        dealii::scalar_product(
+                          fe_values_spacetime.vector_space_grad(velocity, i, q),
+                          grad_v) *
+                        fe_values_spacetime.JxW(q);
 
-                        // (grad u, grad v)
-                        cell_rhs ( i + n * dofs_per_spacetime_cell )
-                           -= nu_f
-                           * dealii::scalar_product
-                           (
-                                   fe_values_spacetime.vector_space_grad ( velocity , i , q ) ,
-                                   grad_v
-                           )
-                           * fe_values_spacetime.JxW ( q );
+                      // (pressure gradient)
+                      cell_rhs(i + n * dofs_per_spacetime_cell) +=
+                        fe_values_spacetime.vector_divergence(velocity, i, q) *
+                        p * fe_values_spacetime.JxW(q);
 
-                        // (pressure gradient)
-                        cell_rhs ( i + n * dofs_per_spacetime_cell )
-                           += fe_values_spacetime.vector_divergence ( velocity , i , q )
-                            * p * fe_values_spacetime.JxW ( q );
+                      // (div free constraint)
+                      cell_rhs(i + n * dofs_per_spacetime_cell) -=
+                        fe_values_spacetime.scalar_value(pressure, i, q) *
+                        div_v * fe_values_spacetime.JxW(q);
 
-                        // (div free constraint)
-                        cell_rhs ( i + n * dofs_per_spacetime_cell )
-                           -= fe_values_spacetime.scalar_value ( pressure , i , q )
-                            * div_v * fe_values_spacetime.JxW ( q );
+                    } // dofs i
+                }     // quad
 
-                    } //dofs i
-                } //quad
+              fe_jump_values_spacetime.get_function_values_plus(
+                *slab_its.solution, old_solution_plus);
 
-                fe_jump_values_spacetime.get_function_values_plus(*slab_its.solution , old_solution_plus);
+              dealii::Tensor<1, 2> v_plus;
+              dealii::Tensor<1, 2> v_minus;
 
-                dealii::Tensor<1,2> v_plus;
-                dealii::Tensor<1,2> v_minus;
-
-                for ( unsigned int q = 0 ; q < n_quad_space ; ++q )
+              for (unsigned int q = 0; q < n_quad_space; ++q)
                 {
-                    for ( unsigned int c = 0 ; c < 2 ; ++c){
-                        v_plus[c] = old_solution_plus[q](c);
-                        v_minus[c] = old_solution_minus[q](c);
+                  for (unsigned int c = 0; c < 2; ++c)
+                    {
+                      v_plus[c]  = old_solution_plus[q](c);
+                      v_minus[c] = old_solution_minus[q](c);
                     }
 
-                    for ( unsigned int i = 0 ; i < dofs_per_spacetime_cell ; ++i )
+                  for (unsigned int i = 0; i < dofs_per_spacetime_cell; ++i)
                     {
-                        // (v^+, u^+)
-                        cell_rhs ( i + n * dofs_per_spacetime_cell )
-                            -= fe_jump_values_spacetime.vector_value_plus ( velocity , i , q )
-                             * v_plus * fe_jump_values_spacetime.JxW ( q );
+                      // (v^+, u^+)
+                      cell_rhs(i + n * dofs_per_spacetime_cell) -=
+                        fe_jump_values_spacetime.vector_value_plus(velocity,
+                                                                   i,
+                                                                   q) *
+                        v_plus * fe_jump_values_spacetime.JxW(q);
 
-                        // -(v^-, u^+)
-                        cell_rhs ( i + n * dofs_per_spacetime_cell )
-                            += fe_jump_values_spacetime.vector_value_plus ( velocity , i , q )
-                             * v_minus * fe_jump_values_spacetime.JxW ( q );
+                      // -(v^-, u^+)
+                      cell_rhs(i + n * dofs_per_spacetime_cell) +=
+                        fe_jump_values_spacetime.vector_value_plus(velocity,
+                                                                   i,
+                                                                   q) *
+                        v_minus * fe_jump_values_spacetime.JxW(q);
 
-                    } //dofs i
-                } // quad_space
-                if ( n < N - 1 )
+                    } // dofs i
+                }     // quad_space
+              if (n < N - 1)
                 {
-                    fe_jump_values_spacetime.get_function_values_minus(*slab_its.solution,old_solution_minus);
+                  fe_jump_values_spacetime.get_function_values_minus(
+                    *slab_its.solution, old_solution_minus);
                 }
-            } //cell time
-            slab_zero_constraints->distribute_local_to_global ( cell_rhs , local_spacetime_dof_index ,
-                                                                slab_system_rhs );
+            } // cell time
+          slab_zero_constraints->distribute_local_to_global(
+            cell_rhs, local_spacetime_dof_index, slab_system_rhs);
         }
-    } //cell space
+    } // cell space
 
-    // We need to communicate local contributions to other processors after assembly
-    slab_system_rhs.compress ( dealii::VectorOperation::add );
+  // We need to communicate local contributions to other processors after
+  // assembly
+  slab_system_rhs.compress(dealii::VectorOperation::add);
 }
 
-void Step4::solve_Newton_problem_on_slab ()
+void
+Step4::solve_Newton_problem_on_slab()
 {
-    pout << "Starting Newton solve" << std::endl;
-    // The interface needs a solver control that is more or less irrelevant
-    dealii::SolverControl sc ( 10000 , 1.0e-14 , false , false );
-    // When Trilinos is compiled with MUMPS we prefer it.
-    // If not installed switch to Amesos_Klu
-    dealii::TrilinosWrappers::SolverDirect::AdditionalData ad ( false , "Amesos_Mumps" );
-    auto solver = std::make_shared < dealii::TrilinosWrappers::SolverDirect > ( sc , ad );
+  pout << "Starting Newton solve" << std::endl;
+  // The interface needs a solver control that is more or less irrelevant
+  dealii::SolverControl sc(10000, 1.0e-14, false, false);
+  // When Trilinos is compiled with MUMPS we prefer it.
+  // If not installed switch to Amesos_Klu
+  dealii::TrilinosWrappers::SolverDirect::AdditionalData ad(false,
+                                                            "Amesos_Mumps");
+  auto                                                   solver =
+    std::make_shared<dealii::TrilinosWrappers::SolverDirect>(sc, ad);
 
-    ////////////////////////////////////////////
-    // Newton parameters
-    ////////////////////////////////////////////
-    double newton_lower_bound = 1.0e-10;
-    unsigned int max_newton_steps = 10;
-    unsigned int max_line_search_steps = 10;
-    double newton_rebuild_parameter = 0.1;
-    double newton_damping = 0.6;
+  ////////////////////////////////////////////
+  // Newton parameters
+  ////////////////////////////////////////////
+  double       newton_lower_bound       = 1.0e-10;
+  unsigned int max_newton_steps         = 10;
+  unsigned int max_line_search_steps    = 10;
+  double       newton_rebuild_parameter = 0.1;
+  double       newton_damping           = 0.6;
 
-    assemble_residual_on_slab ();
-    double newton_residual = slab_system_rhs.linfty_norm ();
-    double old_newton_residual;
-    double new_newton_residual;
+  assemble_residual_on_slab();
+  double newton_residual = slab_system_rhs.linfty_norm();
+  double old_newton_residual;
+  double new_newton_residual;
 
-    unsigned int newton_step = 1;
-    unsigned int line_search_step;
+  unsigned int newton_step = 1;
+  unsigned int line_search_step;
 
-    pout << "0\t" << newton_residual << std::endl;
-    while ( newton_residual > newton_lower_bound && newton_step <= max_newton_steps )
+  pout << "0\t" << newton_residual << std::endl;
+  while (newton_residual > newton_lower_bound &&
+         newton_step <= max_newton_steps)
     {
-        old_newton_residual = newton_residual;
-        assemble_residual_on_slab ();
-        newton_residual = slab_system_rhs.linfty_norm ();
+      old_newton_residual = newton_residual;
+      assemble_residual_on_slab();
+      newton_residual = slab_system_rhs.linfty_norm();
 
-        if ( newton_residual < newton_lower_bound )
+      if (newton_residual < newton_lower_bound)
         {
-            pout << "res\t" << newton_residual << std::endl;
+          pout << "res\t" << newton_residual << std::endl;
+          break;
+        }
+
+      if (newton_residual / old_newton_residual > newton_rebuild_parameter)
+        {
+          solver = nullptr;
+          solver =
+            std::make_shared<dealii::TrilinosWrappers::SolverDirect>(sc, ad);
+          assemble_system_on_slab();
+
+          solver->initialize(slab_system_matrix);
+        }
+
+      solver->solve(slab_newton_update, slab_system_rhs);
+      slab_zero_constraints->distribute(slab_newton_update);
+      slab_owned_tmp = *slab_its.solution;
+      for (line_search_step = 0; line_search_step < max_line_search_steps;
+           line_search_step++)
+        {
+          slab_owned_tmp += slab_newton_update;
+          *slab_its.solution = slab_owned_tmp;
+          assemble_residual_on_slab();
+
+          new_newton_residual = slab_system_rhs.linfty_norm();
+          if (new_newton_residual < newton_residual)
             break;
+          else
+            slab_owned_tmp -= slab_newton_update;
+
+          slab_newton_update *= newton_damping;
         }
 
-        if ( newton_residual / old_newton_residual > newton_rebuild_parameter )
-        {
-            solver = nullptr;
-            solver = std::make_shared < dealii::TrilinosWrappers::SolverDirect > ( sc , ad );
-            assemble_system_on_slab ();
+      pout << std::setprecision(5) << newton_step << "\t" << std::scientific
+           << newton_residual << "\t" << std::scientific
+           << newton_residual / old_newton_residual << "\t";
 
-            solver->initialize ( slab_system_matrix );
-        }
+      if (newton_residual / old_newton_residual > newton_rebuild_parameter)
+        pout << "r\t";
+      else
+        pout << " \t";
 
-        solver->solve ( slab_newton_update , slab_system_rhs );
-        slab_zero_constraints->distribute ( slab_newton_update );
-        slab_owned_tmp = *slab_its.solution;
-        for ( line_search_step = 0 ; line_search_step < max_line_search_steps ; line_search_step++ )
-        {
-            slab_owned_tmp += slab_newton_update;
-            *slab_its.solution = slab_owned_tmp;
-            assemble_residual_on_slab ();
+      pout << line_search_step << "\t" << std::scientific << std::endl;
 
-            new_newton_residual = slab_system_rhs.linfty_norm ();
-            if ( new_newton_residual < newton_residual )
-                break;
-            else
-                slab_owned_tmp -= slab_newton_update;
-
-            slab_newton_update *= newton_damping;
-        }
-
-        pout << std::setprecision ( 5 ) << newton_step << "\t" << std::scientific << newton_residual << "\t"
-        << std::scientific
-        << newton_residual / old_newton_residual << "\t";
-
-        if ( newton_residual / old_newton_residual > newton_rebuild_parameter )
-            pout << "r\t";
-        else
-            pout << " \t";
-
-        pout << line_search_step << "\t" << std::scientific << std::endl;
-
-        newton_step++;
+      newton_step++;
     }
-
 }
 
-void Step4::output_results_on_slab ()
+void
+Step4::output_results_on_slab()
 {
-    auto n_dofs = slab_its.dof->n_dofs_time ();
-    std::vector < std::string > field_names;
-    std::vector < dealii::DataComponentInterpretation::DataComponentInterpretation > dci;
-    for ( unsigned int i = 0 ; i < 2 ; i++ )
+  auto                     n_dofs = slab_its.dof->n_dofs_time();
+  std::vector<std::string> field_names;
+  std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+    dci;
+  for (unsigned int i = 0; i < 2; i++)
     {
-        field_names.push_back ( "velocity" );
-        dci.push_back ( dealii::DataComponentInterpretation::component_is_part_of_vector );
+      field_names.push_back("velocity");
+      dci.push_back(
+        dealii::DataComponentInterpretation::component_is_part_of_vector);
     }
-    field_names.push_back ( "pressure" );
-    dci.push_back ( dealii::DataComponentInterpretation::component_is_scalar );
+  field_names.push_back("pressure");
+  dci.push_back(dealii::DataComponentInterpretation::component_is_scalar);
 
-    dealii::TrilinosWrappers::MPI::Vector tmp = *slab_its.solution;
-    for ( unsigned i = 0 ; i < n_dofs ; i++ )
+  dealii::TrilinosWrappers::MPI::Vector tmp = *slab_its.solution;
+  for (unsigned i = 0; i < n_dofs; i++)
     {
-        dealii::DataOut < 2 > data_out;
-        data_out.attach_dof_handler ( *slab_its.dof->spatial () );
-        dealii::TrilinosWrappers::MPI::Vector local_solution;
-        local_solution.reinit ( space_locally_owned_dofs , space_locally_relevant_dofs , mpi_comm );
+      dealii::DataOut<2> data_out;
+      data_out.attach_dof_handler(*slab_its.dof->spatial());
+      dealii::TrilinosWrappers::MPI::Vector local_solution;
+      local_solution.reinit(space_locally_owned_dofs,
+                            space_locally_relevant_dofs,
+                            mpi_comm);
 
-        idealii::slab::VectorTools::extract_subvector_at_time_dof ( tmp , local_solution , i );
-        data_out.add_data_vector ( local_solution , field_names , dealii::DataOut < 2 > ::type_dof_data , dci );
-        data_out.build_patches ( 2 );
-        std::ostringstream filename;
-        filename << "newton_navierstokes_solution_dG(" << fe.temporal ()->degree << ")_t_" << slab * n_dofs + i
-        << ".vtu";
-        // instead of a vtk we use the parallel write function
-        data_out.write_vtu_in_parallel ( filename.str ().c_str () , mpi_comm );
+      idealii::slab::VectorTools::extract_subvector_at_time_dof(tmp,
+                                                                local_solution,
+                                                                i);
+      data_out.add_data_vector(local_solution,
+                               field_names,
+                               dealii::DataOut<2>::type_dof_data,
+                               dci);
+      data_out.build_patches(2);
+      std::ostringstream filename;
+      filename << "newton_navierstokes_solution_dG(" << fe.temporal()->degree
+               << ")_t_" << slab * n_dofs + i << ".vtu";
+      // instead of a vtk we use the parallel write function
+      data_out.write_vtu_in_parallel(filename.str().c_str(), mpi_comm);
     }
 }
-int main ( int argc , char *argv[] )
+int
+main(int argc, char *argv[])
 {
-    //With MPI we need to begin with an InitFinalize call.
-    dealii::Utilities::MPI::MPI_InitFinalize mpi ( argc , argv , MPIX_THREADS );
-    // temporal finite element order
-    // WARNING do not change as evaluation of temporal derivative of a given
-    // space-time fe vector is not implemented yet.
-    unsigned int r = 1;
-    Step4 problem ( r );
-    problem.run ();
+  // With MPI we need to begin with an InitFinalize call.
+  dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, MPIX_THREADS);
+  // temporal finite element order
+  // WARNING do not change as evaluation of temporal derivative of a given
+  // space-time fe vector is not implemented yet.
+  unsigned int r = 1;
+  Step4        problem(r);
+  problem.run();
 }
-

--- a/include/ideal.II/base/idealii.hh
+++ b/include/ideal.II/base/idealii.hh
@@ -19,99 +19,96 @@
  */
 namespace idealii
 {
-    void
-    print_version_info ();
+  void
+  print_version_info();
+
+  /**
+   * @brief Namespace for slab objects.
+   *
+   * Namespace containing all classes that describe objects
+   * operating on a tensor product between a onedimensional
+   * temporal triangulation and an n-dimensional spatial triangulation.
+   */
+  namespace slab
+  {
+    /**
+     * @brief Namespace for MPI parallel objects in space.
+     */
+    namespace parallel
+    {
+      /**
+       * @brief Namespace where the processor local triangulations share a common coarse object.
+       */
+      namespace distributed
+      {}
+    } // namespace parallel
+    /**
+     * @brief Collection of functions working on degrees of freedom.
+     *
+     * These functions provide utilities for calculating
+     * spacetime variants of normally stationary objects provided by deal.II.
+     *
+     * In detail this means spreading stationary information over all temporal
+     * degrees of freedom in this slab. Examples are:
+     * - Offsetting hanging node constraints to each temporal dof.
+     * - Building tensor products of spatial and temporal sparsity patterns to
+     * obtain a spacetime pattern
+     */
+    namespace DoFTools
+    {}
 
     /**
-     * @brief Namespace for slab objects.
+     * @brief Collection of functions working on space-time slab Vectors.
      *
-     * Namespace containing all classes that describe objects
-     * operating on a tensor product between a onedimensional
-     * temporal triangulation and an n-dimensional spatial triangulation.
+     * These functions provide utilities for manipulating space-time indexed
+     * vectors of normally stationary objects provided by deal.II.
+     *
+     * Examples are:
+     * - interpolation of spatial boundary values to all corresponding
+     * space-time dofs
+     * - evaluation of space-time vectors at a specific time points of time dof.
      */
-    namespace slab
-    {
-        /**
-         * @brief Namespace for MPI parallel objects in space.
-         */
-        namespace parallel
-        {
-            /**
-             * @brief Namespace where the processor local triangulations share a common coarse object.
-             */
-            namespace distributed
-            {
-            }
-        }
-        /**
-         * @brief Collection of functions working on degrees of freedom.
-         *
-         * These functions provide utilities for calculating
-         * spacetime variants of normally stationary objects provided by deal.II.
-         *
-         * In detail this means spreading stationary information over all temporal degrees of freedom
-         * in this slab.
-         * Examples are:
-         * - Offsetting hanging node constraints to each temporal dof.
-         * - Building tensor products of spatial and temporal sparsity patterns to obtain a spacetime pattern
-         */
-        namespace DoFTools
-        {
-        }
+    namespace VectorTools
+    {}
+  } // namespace slab
 
-        /**
-         * @brief Collection of functions working on space-time slab Vectors.
-         *
-         * These functions provide utilities for manipulating space-time indexed
-         * vectors of normally stationary objects provided by deal.II.
-         *
-         * Examples are:
-         * - interpolation of spatial boundary values to all corresponding space-time dofs
-         * - evaluation of space-time vectors at a specific time points of time dof.
-         */
-        namespace VectorTools
-        {
-        }
-    }
-
+  /**
+   * @brief Namespace for general spacetime object and collections of slab objects.
+   *
+   * Namespace containing two types of classes.
+   *
+   * The first are general spacetime definitions independent of the actual
+   * triangulation. Examples are space-time finite element classes and
+   * quadrature formulae.
+   *
+   * The second are classes containing lists of slab:: classes or general
+   * objects related to a specific slab. Examples are triangulations, DoF
+   * handlers and vectors.
+   */
+  namespace spacetime
+  {
     /**
-     * @brief Namespace for general spacetime object and collections of slab objects.
-     *
-     * Namespace containing two types of classes.
-     *
-     * The first are general spacetime definitions independent of the actual triangulation.
-     * Examples are space-time finite element classes and quadrature formulae.
-     *
-     * The second are classes containing lists of slab:: classes or general objects
-     * related to a specific slab.
-     * Examples are triangulations, DoF handlers and vectors.
+     * @brief Namespace for tensor product triangulations with a single fixed spatial mesh.
      */
-    namespace spacetime
+    namespace fixed
+    {}
+    /**
+     * @brief Namespace for MPI parallel objects in space.
+     */
+    namespace parallel
     {
+      /**
+       * @brief Namespace where the processor local triangulations share a common coarse object.
+       */
+      namespace distributed
+      {
         /**
          * @brief Namespace for tensor product triangulations with a single fixed spatial mesh.
          */
         namespace fixed
-        {
-        }
-        /**
-         * @brief Namespace for MPI parallel objects in space.
-         */
-        namespace parallel
-        {
-            /**
-             * @brief Namespace where the processor local triangulations share a common coarse object.
-             */
-            namespace distributed
-            {
-                /**
-                 * @brief Namespace for tensor product triangulations with a single fixed spatial mesh.
-                 */
-                namespace fixed
-                {
-                }
-            }
-        }
-    }
-}
+        {}
+      } // namespace distributed
+    }   // namespace parallel
+  }     // namespace spacetime
+} // namespace idealii
 #endif /* INCLUDE_IDEAL_II_BASE_IDEALII1_HH_ */

--- a/include/ideal.II/base/quadrature_lib.hh
+++ b/include/ideal.II/base/quadrature_lib.hh
@@ -16,179 +16,184 @@
 #ifndef INCLUDE_IDEAL_II_BASE_QUADRATURE_LIB_HH_
 #define INCLUDE_IDEAL_II_BASE_QUADRATURE_LIB_HH_
 #include <ideal.II/base/spacetime_quadrature.hh>
+
 #include <deal.II/base/quadrature_lib.h>
 
 namespace idealii
 {
 
 
-    
-/**
- * The Gauss-Radau family of quadrature rules for numerical integration.
- *
- * This modification of the Gauss quadrature uses one of the two interval end
- * points as well. Being exact for polynomials of degree $2n-2$, this
- * formula is suboptimal by one degree.
- *
- * This formula is often used in the context of discontinuous Galerkin
- * discretizations of ODEs and the temporal part of PDEs.
- *
- * The quadrature points are the left interval end point plus the $n-1$
- * roots of the polynomial
- * \f[
- *   \frac{P_{n-1}(x)+P_n(x)}{1+x}
- * \f]
- * where $P_{n-1}$ and $P_n$ are Legendre polynomials.
- * The quadrature weights are
- * \f[
- *   w_0=\frac{2}{n^2}\quad\text{and}
- *   \quad w_i=\frac{1-x_i}{n^2(P_{n-1}(x_i))^2}\text{ for }i>0
- * \f]
- *
- * For the right Gauss-Radau formula the quadrature points are
- * $\tilde{x}_i=1-x_{n-i-1}$ and the weights are $\tilde{w}_i=w_{n-i-1}$,
- * with $(x_i,w_i)$ as quadrature points
- * and weights of the left Gauss-Radau formula.
- *
- * @see https://mathworld.wolfram.com/RadauQuadrature.html
- */
-    template<int dim>
-    class QGaussRadau :public dealii::Quadrature<dim>
+
+  /**
+   * The Gauss-Radau family of quadrature rules for numerical integration.
+   *
+   * This modification of the Gauss quadrature uses one of the two interval end
+   * points as well. Being exact for polynomials of degree $2n-2$, this
+   * formula is suboptimal by one degree.
+   *
+   * This formula is often used in the context of discontinuous Galerkin
+   * discretizations of ODEs and the temporal part of PDEs.
+   *
+   * The quadrature points are the left interval end point plus the $n-1$
+   * roots of the polynomial
+   * \f[
+   *   \frac{P_{n-1}(x)+P_n(x)}{1+x}
+   * \f]
+   * where $P_{n-1}$ and $P_n$ are Legendre polynomials.
+   * The quadrature weights are
+   * \f[
+   *   w_0=\frac{2}{n^2}\quad\text{and}
+   *   \quad w_i=\frac{1-x_i}{n^2(P_{n-1}(x_i))^2}\text{ for }i>0
+   * \f]
+   *
+   * For the right Gauss-Radau formula the quadrature points are
+   * $\tilde{x}_i=1-x_{n-i-1}$ and the weights are $\tilde{w}_i=w_{n-i-1}$,
+   * with $(x_i,w_i)$ as quadrature points
+   * and weights of the left Gauss-Radau formula.
+   *
+   * @see https://mathworld.wolfram.com/RadauQuadrature.html
+   */
+  template <int dim>
+  class QGaussRadau : public dealii::Quadrature<dim>
+  {
+  public:
+    /*
+     * EndPoint is used to specify which of the two endpoints of the
+     * unit interval is used as quadrature point
+     */
+    enum EndPoint
+    {
+      /**
+       * Left end point.
+       */
+      left,
+      /**
+       * Right end point.
+       */
+      right
+    };
+
+    /// Generate a formula wit <tt>n</tt> quadrature points
+    QGaussRadau(const unsigned int n, EndPoint end_point = QGaussRadau::left);
+    /**
+     * Move constructor. We cannot rely on the move constructor for
+     * `Quadrature`, since it does not know about the additional member
+     * `end_point` of this class.
+     */
+    QGaussRadau(QGaussRadau<dim> &&) noexcept = default;
+
+  private:
+    const EndPoint end_point;
+  };
+
+  /**
+   * @brief 1D right box rule.
+   *
+   * The quadrature with generalized support point 1 and weight 1.
+   * This produces a quadrature that is exact for constant polynomials.
+   *
+   * Although this is not necessarily desirable, using this formula for dG(0)
+   * elements in time leads to the backward Euler method.
+   *
+   */
+  class QRightBox : public QGaussRadau<1>
+  {
+  public:
+    /**
+     * @brief Default constructor.
+     *
+     * Constructs the quadrature formula with weight[0] = 1.0 and
+     * quadrature_points[0] = dealii::Point<1>(1.0)
+     */
+    QRightBox();
+  };
+
+  /**
+   * @brief 1D left box rule.
+   *
+   * The quadrature with generalized support point 0 and weight 1.
+   * This produces a quadrature that is exact for constant polynomials.
+   *
+   * Although this is not necessarily desirable, using this formula for dG(0)
+   * elements in time leads to the forward Euler method.
+   */
+  class QLeftBox : public QGaussRadau<1>
+  {
+  public:
+    /**
+     * @brief Default constructor.
+     *
+     * Constructs the quadrature formula with weight[0] = 1.0 and
+     * quadrature_points[0] = dealii::Point<1>(0.0)
+     */
+    QLeftBox();
+  };
+
+
+  namespace spacetime
+  {
+
+    /**
+     *	@brief A Gauss-Legende quadrature formula in space and time.
+     *
+     *
+     */
+    template <int dim>
+    class QGauss : public Quadrature<dim>
     {
     public:
-        /*
-         * EndPoint is used to specify which of the two endpoints of the 
-         * unit interval is used as quadrature point 
-         */
-        enum EndPoint
-        {
-            /**
-             * Left end point.
-             */
-            left,
-            /**
-             * Right end point.
-             */
-            right
-        };
-
-        /// Generate a formula wit <tt>n</tt> quadrature points
-        QGaussRadau(const unsigned int n,
-                    EndPoint           end_point = QGaussRadau::left);
-        /**
-         * Move constructor. We cannot rely on the move constructor for `Quadrature`,
-         * since it does not know about the additional member `end_point` of this class.
-         */             
-        QGaussRadau(QGaussRadau<dim> &&) noexcept = default;
-    private:
-        const EndPoint end_point;
+      /**
+       * @brief Generate a Gauss-Legendre quadrature in space and time
+       *
+       * Exact for polynomials of degree 2*@p n_spatial-1 in space and 2*@p
+       * n_temporal-1 in time.
+       * @param n_spatial Number of spatial quadrature points (in each space direction)
+       * @param n_temporal Number of temporal quadrature points
+       */
+      QGauss(unsigned int n_spatial, unsigned int n_temporal);
     };
 
     /**
-     * @brief 1D right box rule.
+     * @brief A Gauss-Legende quadrature formula in space and right box rule in time.
      *
-     * The quadrature with generalized support point 1 and weight 1.
-     * This produces a quadrature that is exact for constant polynomials.
-     *
-     * Although this is not necessarily desirable, using this formula for dG(0)
-     * elements in time leads to the backward Euler method.
-     *
+     * Applying this quadrature to a dG finite element degree of 0 in time
+     * results in the backward Euler method.
      */
-    class QRightBox : public QGaussRadau<1>
+    template <int dim>
+    class QGaussRightBox : public Quadrature<dim>
     {
     public:
-        /**
-         * @brief Default constructor.
-         *
-         * Constructs the quadrature formula with weight[0] = 1.0 and
-         * quadrature_points[0] = dealii::Point<1>(1.0)
-         */
-        QRightBox ();
+      /**
+       * @brief Generate a Gauss-Legende quadrature in space and a right box rule
+       * quadrature in time.
+       *
+       * Exact for polynomials of degree 2*@p n_spatial-1 in space and 0 in
+       * time.
+       * @param n_spatial Number of spatial quadrature points (in each space direction)
+       */
+      QGaussRightBox(unsigned int n_spatial);
     };
-
     /**
-     * @brief 1D left box rule.
+     * @brief A Gauss-Legende quadrature formula in space and left box rule in time.
      *
-     * The quadrature with generalized support point 0 and weight 1.
-     * This produces a quadrature that is exact for constant polynomials.
-     *
-     * Although this is not necessarily desirable, using this formula for dG(0)
-     * elements in time leads to the forward Euler method.
+     * Applying this quadrature to a dG finite element degree of 0 in time
+     * results in the forward Euler method.
      */
-    class QLeftBox : public QGaussRadau<1>
+    template <int dim>
+    class QGaussLeftBox : public Quadrature<dim>
     {
     public:
-        /**
-         * @brief Default constructor.
-         *
-         * Constructs the quadrature formula with weight[0] = 1.0 and
-         * quadrature_points[0] = dealii::Point<1>(0.0)
-         */
-        QLeftBox ();
+      /**
+       * @brief Generate a Gauss-Legende quadrature in space and a left box rule
+       * quadrature in time.
+       *
+       * Exact for polynomials of degree 2*@p n_spatial-1 in space and 0 in
+       * time.
+       * @param n_spatial Number of spatial quadrature points (in each space direction)
+       */
+      QGaussLeftBox(unsigned int n_spatial);
     };
-
-    
-    namespace spacetime
-    {
-
-        /**
-         *	@brief A Gauss-Legende quadrature formula in space and time.
-         *
-         *
-         */
-        template<int dim>
-        class QGauss : public Quadrature<dim>
-        {
-        public:
-            /**
-             * @brief Generate a Gauss-Legendre quadrature in space and time
-             *
-             * Exact for polynomials of degree 2*@p n_spatial-1 in space and 2*@p n_temporal-1 in time.
-             * @param n_spatial Number of spatial quadrature points (in each space direction)
-             * @param n_temporal Number of temporal quadrature points
-             */
-            QGauss ( unsigned int n_spatial , unsigned int n_temporal );
-        };
-
-        /**
-         * @brief A Gauss-Legende quadrature formula in space and right box rule in time.
-         *
-         * Applying this quadrature to a dG finite element degree of 0 in time
-         * results in the backward Euler method.
-         */
-        template<int dim>
-        class QGaussRightBox : public Quadrature<dim>
-        {
-        public:
-            /**
-             * @brief Generate a Gauss-Legende quadrature in space and a right box rule
-             * quadrature in time.
-             *
-             * Exact for polynomials of degree 2*@p n_spatial-1 in space and 0 in time.
-             * @param n_spatial Number of spatial quadrature points (in each space direction)
-             */
-            QGaussRightBox ( unsigned int n_spatial );
-        };
-        /**
-         * @brief A Gauss-Legende quadrature formula in space and left box rule in time.
-         *
-         * Applying this quadrature to a dG finite element degree of 0 in time
-         * results in the forward Euler method.
-         */
-        template<int dim>
-        class QGaussLeftBox : public Quadrature<dim>
-        {
-        public:
-            /**
-             * @brief Generate a Gauss-Legende quadrature in space and a left box rule
-             * quadrature in time.
-             *
-             * Exact for polynomials of degree 2*@p n_spatial-1 in space and 0 in time.
-             * @param n_spatial Number of spatial quadrature points (in each space direction)
-             */
-            QGaussLeftBox ( unsigned int n_spatial );
-        };
-    }
-}
+  } // namespace spacetime
+} // namespace idealii
 
 #endif /* INCLUDE_IDEAL_II_BASE_QUADRATURE_LIB_HH_ */

--- a/include/ideal.II/base/spacetime_quadrature.hh
+++ b/include/ideal.II/base/spacetime_quadrature.hh
@@ -20,42 +20,43 @@
 
 namespace idealii::spacetime
 {
+  /**
+   * @brief The base class for quadrature formulae in space and time.
+   *
+   * This is simply a convenience class that holds shared pointers to a spatial
+   * and a temporal quadrature formula.
+   *
+   * Therefore, it can be used with any user supplied formula.
+   * For common combinations like Gauss-Legendre in space and time derived
+   * classes may exist to simplify construction.
+   */
+  template <int dim>
+  class Quadrature
+  {
+  public:
     /**
-     * @brief The base class for quadrature formulae in space and time.
-     *
-     * This is simply a convenience class that holds shared pointers to a spatial
-     * and a temporal quadrature formula.
-     *
-     * Therefore, it can be used with any user supplied formula.
-     * For common combinations like Gauss-Legendre in space and time derived classes
-     * may exist to simplify construction.
+     * @brief Construct a spacetime quadrature formula by supplying shared pointers to
+     * a spatial and a temporal quadrature formula.
      */
-    template<int dim>
-    class Quadrature
-    {
-    public:
-        /**
-         * @brief Construct a spacetime quadrature formula by supplying shared pointers to
-         * a spatial and a temporal quadrature formula.
-         */
-        Quadrature ( std::shared_ptr<dealii::Quadrature<dim>> quad_space ,
-                     std::shared_ptr<dealii::Quadrature<1>> quad_time );
-        /**
-         * @brief The underlying spatial quadrature formula
-         * @return A shared pointer to the spatial quadrature formula.
-         */
-        std::shared_ptr<dealii::Quadrature<dim>>
-        spatial ();
-        /**
-         * @brief The underlying temporal quadrature formula
-         * @return A shared pointer to the temporal quadrature formula.
-         */
-        std::shared_ptr<dealii::Quadrature<1>>
-        temporal ();
-    private:
-        std::shared_ptr<dealii::Quadrature<dim>> _quad_space;
-        std::shared_ptr<dealii::Quadrature<1>> _quad_time;
-    };
-}
+    Quadrature(std::shared_ptr<dealii::Quadrature<dim>> quad_space,
+               std::shared_ptr<dealii::Quadrature<1>>   quad_time);
+    /**
+     * @brief The underlying spatial quadrature formula
+     * @return A shared pointer to the spatial quadrature formula.
+     */
+    std::shared_ptr<dealii::Quadrature<dim>>
+    spatial();
+    /**
+     * @brief The underlying temporal quadrature formula
+     * @return A shared pointer to the temporal quadrature formula.
+     */
+    std::shared_ptr<dealii::Quadrature<1>>
+    temporal();
+
+  private:
+    std::shared_ptr<dealii::Quadrature<dim>> _quad_space;
+    std::shared_ptr<dealii::Quadrature<1>>   _quad_time;
+  };
+} // namespace idealii::spacetime
 
 #endif /* INCLUDE_IDEAL_II_BASE_SPACETIME_QUADRATURE_HH_ */

--- a/include/ideal.II/base/time_iterator.hh
+++ b/include/ideal.II/base/time_iterator.hh
@@ -16,153 +16,166 @@
 #ifndef INCLUDE_IDEAL_II_BASE_TIME_ITERATOR_HH_
 #define INCLUDE_IDEAL_II_BASE_TIME_ITERATOR_HH_
 
-#include <ideal.II/grid/spacetime_tria.hh>
 #include <ideal.II/distributed/spacetime_tria.hh>
-#include <ideal.II/dofs/spacetime_dof_handler.hh>
-#include <ideal.II/lac/spacetime_vector.hh>
-#include <ideal.II/lac/spacetime_trilinos_vector.hh>
 
-#include <vector>
+#include <ideal.II/dofs/spacetime_dof_handler.hh>
+
+#include <ideal.II/grid/spacetime_tria.hh>
+
+#include <ideal.II/lac/spacetime_trilinos_vector.hh>
+#include <ideal.II/lac/spacetime_vector.hh>
+
 #include <list>
 #include <memory>
+#include <vector>
 namespace idealii
 {
 
+  /**
+   * @brief A collection of slab iterators to simplify time marching.
+   *
+   * The second type of spacetime objects like spacetime::Triangulation,
+   * spacetime::DoFHandler and spacetime::Vector
+   * are simply doubly linked lists of objects corresponding to a specific slab.
+   *
+   * For forward or backward time marching these lists need to be traversed
+   * simultaneously. This class combines all iterator increments or decrements
+   * into a single function call.
+   */
+  template <int dim>
+  class TimeIteratorCollection
+  {
+  public:
     /**
-     * @brief A collection of slab iterators to simplify time marching.
+     * @brief Default constructor.
      *
-     * The second type of spacetime objects like spacetime::Triangulation,
-     * spacetime::DoFHandler and spacetime::Vector
-     * are simply doubly linked lists of objects corresponding to a specific slab.
-     *
-     * For forward or backward time marching these lists need to be traversed
-     * simultaneously. This class combines all iterator increments or decrements
-     * into a single function call.
+     * @note Any iterators have to be registered using one of the
+     * add_iterator functions.
      */
-    template<int dim>
-    class TimeIteratorCollection
+    TimeIteratorCollection();
+    /**
+     * @brief Add a slab::TriaIterator<dim> iterator.
+     *
+     * @param it A pointer to the slab::TriaIterator<dim>
+     * @param collection A pointer to the spacetime::Triangulation<dim> whose member list includes @p it
+     *
+     */
+    void
+    add_iterator(slab::TriaIterator<dim>       *it,
+                 spacetime::Triangulation<dim> *collection);
+
+#ifdef DEAL_II_WITH_MPI
+    /**
+     * @brief Add a parallel::distributed::slab::TriaIterator<dim> iterator.
+     *
+     * @param it A pointer to the parallel::distributed::slab::TriaIterator<dim>
+     * @param collection A pointer to the parallel::distributed::spacetime::Triangulation<dim> whose member list includes @p it
+     *
+     */
+    void
+    add_iterator(
+      slab::parallel::distributed::TriaIterator<dim>       *it,
+      spacetime::parallel::distributed::Triangulation<dim> *collection);
+#endif
+    /**
+     * @brief Add a slab::DoFHandlerIterator<dim> iterator.
+     *
+     * @param it A pointer to the slab::DoFHandlerIterator<dim>
+     * @param collection A pointer to the spacetime::DoFHandler<dim> whose member list includes @p it
+     *
+     */
+    void
+    add_iterator(slab::DoFHandlerIterator<dim> *it,
+                 spacetime::DoFHandler<dim>    *collection);
+
+    /**
+     * @brief Add a slab::VectorIterator<dim> iterator.
+     *
+     * @param it A pointer to the slab::VectorIterator<dim>
+     * @param collection A pointer to the spacetime::Vector<dim> whose member list includes @p it
+     *
+     */
+    void
+    add_iterator(slab::VectorIterator<double> *it,
+                 spacetime::Vector<double>    *collection);
+
+#ifdef DEAL_II_WITH_TRILINOS
+#  ifdef DEAL_II_WITH_MPI
+    /**
+     * @brief Add a slab::TrilinosVectorIterator<dim> iterator.
+     *
+     * @param it A pointer to the slab::TrilinosVectorIterator<dim>
+     * @param collection A pointer to the spacetime::TrilinosVector<dim> whose member list includes @p it
+     *
+     */
+    void
+    add_iterator(slab::TrilinosVectorIterator *it,
+                 spacetime::TrilinosVector    *collection);
+#  endif
+#endif
+    /**
+     * Increments all added iterators via their prefix increment operators.
+     */
+    void
+    increment();
+    /**
+     * Decrements all added iterators via their prefix decrement operators.
+     */
+    void
+    decrement();
+    /**
+     * For use as a stopping criterion in forward time marching.
+     * @return true: if at least one of the iterators is a the corresponding end()
+     * @return false: if none of the iterators is at the corresponding end()
+     */
+    bool
+    at_end();
+    /**
+     * For use as a stopping criterion in backward time marching.
+     * @return true: if at least one of the iterators is before the corresponding begin()
+     * @return false: if none of the iterators is before the corresponding begin()
+     */
+    bool
+    before_begin();
+
+  private:
+    struct
     {
-    public:
-        /**
-         * @brief Default constructor.
-         *
-         * @note Any iterators have to be registered using one of the
-         * add_iterator functions.
-         */
-        TimeIteratorCollection ();
-        /**
-         * @brief Add a slab::TriaIterator<dim> iterator.
-         *
-         * @param it A pointer to the slab::TriaIterator<dim>
-         * @param collection A pointer to the spacetime::Triangulation<dim> whose member list includes @p it
-         *
-         */
-        void
-        add_iterator ( slab::TriaIterator<dim> *it ,
-                       spacetime::Triangulation<dim> *collection );
+      std::vector<slab::TriaIterator<dim> *>       it_collection;
+      std::vector<spacetime::Triangulation<dim> *> obj_collection;
+    } tria;
 
 #ifdef DEAL_II_WITH_MPI
-        /**
-         * @brief Add a parallel::distributed::slab::TriaIterator<dim> iterator.
-         *
-         * @param it A pointer to the parallel::distributed::slab::TriaIterator<dim>
-         * @param collection A pointer to the parallel::distributed::spacetime::Triangulation<dim> whose member list includes @p it
-         *
-         */
-        void add_iterator(slab::parallel::distributed::TriaIterator<dim>* it, spacetime::parallel::distributed::Triangulation<dim>* collection);
+    struct
+    {
+      std::vector<slab::parallel::distributed::TriaIterator<dim> *>
+        it_collection;
+      std::vector<spacetime::parallel::distributed::Triangulation<dim> *>
+        obj_collection;
+    } par_dist_tria;
 #endif
-        /**
-         * @brief Add a slab::DoFHandlerIterator<dim> iterator.
-         *
-         * @param it A pointer to the slab::DoFHandlerIterator<dim>
-         * @param collection A pointer to the spacetime::DoFHandler<dim> whose member list includes @p it
-         *
-         */
-        void
-        add_iterator ( slab::DoFHandlerIterator<dim> *it ,
-                       spacetime::DoFHandler<dim> *collection );
-
-        /**
-         * @brief Add a slab::VectorIterator<dim> iterator.
-         *
-         * @param it A pointer to the slab::VectorIterator<dim>
-         * @param collection A pointer to the spacetime::Vector<dim> whose member list includes @p it
-         *
-         */
-        void
-        add_iterator ( slab::VectorIterator<double> *it ,
-                       spacetime::Vector<double> *collection );
+    struct
+    {
+      std::vector<slab::DoFHandlerIterator<dim> *> it_collection;
+      std::vector<spacetime::DoFHandler<dim> *>    obj_collection;
+    } dof;
+    struct
+    {
+      std::vector<slab::VectorIterator<double> *> it_collection;
+      std::vector<spacetime::Vector<double> *>    obj_collection;
+    } vector_double;
 
 #ifdef DEAL_II_WITH_TRILINOS
-#ifdef DEAL_II_WITH_MPI
-        /**
-         * @brief Add a slab::TrilinosVectorIterator<dim> iterator.
-         *
-         * @param it A pointer to the slab::TrilinosVectorIterator<dim>
-         * @param collection A pointer to the spacetime::TrilinosVector<dim> whose member list includes @p it
-         *
-         */
-        void add_iterator(slab::TrilinosVectorIterator* it, spacetime::TrilinosVector* collection);
+#  ifdef DEAL_II_WITH_MPI
+    struct
+    {
+      std::vector<slab::TrilinosVectorIterator *> it_collection;
+      std::vector<spacetime::TrilinosVector *>    obj_collection;
+    } trilinos_vector;
+#  endif
 #endif
-#endif
-        /**
-         * Increments all added iterators via their prefix increment operators.
-         */
-        void
-        increment ();
-        /**
-         * Decrements all added iterators via their prefix decrement operators.
-         */
-        void
-        decrement ();
-        /**
-         * For use as a stopping criterion in forward time marching.
-         * @return true: if at least one of the iterators is a the corresponding end()
-         * @return false: if none of the iterators is at the corresponding end()
-         */
-        bool
-        at_end ();
-        /**
-         * For use as a stopping criterion in backward time marching.
-         * @return true: if at least one of the iterators is before the corresponding begin()
-         * @return false: if none of the iterators is before the corresponding begin()
-         */
-        bool
-        before_begin ();
-    private:
-        struct
-        {
-            std::vector<slab::TriaIterator<dim>*> it_collection;
-            std::vector<spacetime::Triangulation<dim>*> obj_collection;
-        } tria;
+  };
 
-#ifdef DEAL_II_WITH_MPI
-        struct{
-            std::vector<slab::parallel::distributed::TriaIterator<dim>* > it_collection;
-            std::vector<spacetime::parallel::distributed::Triangulation<dim>*> obj_collection;
-        } par_dist_tria;
-#endif
-        struct
-        {
-            std::vector<slab::DoFHandlerIterator<dim>*> it_collection;
-            std::vector<spacetime::DoFHandler<dim>*> obj_collection;
-        } dof;
-        struct
-        {
-            std::vector<slab::VectorIterator<double>*> it_collection;
-            std::vector<spacetime::Vector<double>*> obj_collection;
-        } vector_double;
-
-#ifdef DEAL_II_WITH_TRILINOS
-#ifdef DEAL_II_WITH_MPI
-        struct{
-            std::vector<slab::TrilinosVectorIterator*> it_collection;
-            std::vector<spacetime::TrilinosVector*> obj_collection;
-        }trilinos_vector;
-#endif
-#endif
-    };
-
-}
+} // namespace idealii
 
 #endif /* INCLUDE_IDEAL_II_BASE_TIME_ITERATOR_HH_ */

--- a/include/ideal.II/distributed/fixed_tria.hh
+++ b/include/ideal.II/distributed/fixed_tria.hh
@@ -19,40 +19,48 @@
 #include <ideal.II/distributed/spacetime_tria.hh>
 
 #ifdef DEAL_II_WITH_MPI
-#include <memory>
-#include <list>
+#  include <list>
+#  include <memory>
 
-namespace idealii::spacetime::parallel::distributed::fixed{
+namespace idealii::spacetime::parallel::distributed::fixed
+{
+  /**
+   * @brief The spacetime triangulation object with a fixed MPI parallel dibstributed spatial mesh across time.
+   *
+   * In practice all pointers in the list point to the same
+   * slab::parallel::distributed::Triangulation object.
+   */
+  template <int dim>
+  class Triangulation
+    : public spacetime::parallel::distributed::Triangulation<dim>
+  {
+  public:
     /**
-     * @brief The spacetime triangulation object with a fixed MPI parallel dibstributed spatial mesh across time.
-     *
-     * In practice all pointers in the list point to the same slab::parallel::distributed::Triangulation object.
+     * @brief Constructor that initializes the underlying list object.
+     * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
      */
-    template<int dim>
-    class Triangulation: public spacetime::parallel::distributed::Triangulation<dim>{
-    public:
-        /**
-         * @brief Constructor that initializes the underlying list object.
-         * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
-         */
-        Triangulation ( unsigned int max_N_intervals_per_slab=0);
+    Triangulation(unsigned int max_N_intervals_per_slab = 0);
 
-        /**
-         * @brief Generate a list of M slab triangulations with matching temporal meshes pointing to the same
-         * spatial triangulation.
-         * @param space_tria The underlying spatial dealii::parallel::distributed::Triangulation to be used by all slabs.
-         * @param M The number of slabs to be created
-         * @param t0 The temporal startpoint. Defaults to 0.
-         * @param T The temporal endpoint. Defaults to 1.
-         */
-        void generate(std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> space_tria,
-                      unsigned int M,
-                      double t0=0.,
-                      double T=1.);
+    /**
+     * @brief Generate a list of M slab triangulations with matching temporal meshes pointing to the same
+     * spatial triangulation.
+     * @param space_tria The underlying spatial dealii::parallel::distributed::Triangulation to be used by all slabs.
+     * @param M The number of slabs to be created
+     * @param t0 The temporal startpoint. Defaults to 0.
+     * @param T The temporal endpoint. Defaults to 1.
+     */
+    void
+    generate(std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+                          space_tria,
+             unsigned int M,
+             double       t0 = 0.,
+             double       T  = 1.);
 
-        void refine_global(const unsigned int times_space = 1, const unsigned int times_time = 1);
-    };
-}
+    void
+    refine_global(const unsigned int times_space = 1,
+                  const unsigned int times_time  = 1);
+  };
+} // namespace idealii::spacetime::parallel::distributed::fixed
 
 #endif
 #endif /* INCLUDE_IDEAL_II_DISTRIBUTED_FIXED_TRIA_HH_ */

--- a/include/ideal.II/distributed/slab_tria.hh
+++ b/include/ideal.II/distributed/slab_tria.hh
@@ -19,108 +19,119 @@
 #include <deal.II/base/config.h>
 
 #ifdef DEAL_II_WITH_MPI
-#include <deal.II/distributed/tria.h>
-#include <memory>
-#include <list>
+#  include <deal.II/distributed/tria.h>
 
-namespace idealii::slab::parallel::distributed{
+#  include <list>
+#  include <memory>
+
+namespace idealii::slab::parallel::distributed
+{
+  /**
+   * @brief Actual Triangulation for a specific slab with an MPI distributed spatial mesh.
+   *
+   * This Triangulation handles a spatial dealii::parallel::distributed and
+   * a temporal dealii::Triangulation object internally.
+   *
+   */
+  template <int dim>
+  class Triangulation
+  {
+  public:
     /**
-     * @brief Actual Triangulation for a specific slab with an MPI distributed spatial mesh.
+     * @brief Construct an object with a given spatial triangulation and a single
+     * element in time.
      *
-     * This Triangulation handles a spatial dealii::parallel::distributed and
-     * a temporal dealii::Triangulation object internally.
-     *
+     * @param space_tria The spatial triangulation to be used.
+     * @param startpoint The startpoint of the temporal triangulation.
+     * @param endpoint The endpoint of the temporal triangulation.
      */
-    template<int dim>
-    class Triangulation{
-    public:
+    Triangulation(
+      std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+             space_tria,
+      double startpoint,
+      double endpoint);
 
-        /**
-         * @brief Construct an object with a given spatial triangulation and a single
-         * element in time.
-         *
-         * @param space_tria The spatial triangulation to be used.
-         * @param startpoint The startpoint of the temporal triangulation.
-         * @param endpoint The endpoint of the temporal triangulation.
-         */
-        Triangulation(
-                std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> space_tria,
-                double startpoint,
-                double endpoint);
-
-
-        /**
-         * @brief Construct an object with a given spatial triangulation and a given
-         * division of elements in time.
-         *
-         * @param space_tria. The spatial triangulation to be used.
-         * @param step_sizes. The sizes of the temporal elements
-         * @param startpoint. The startpoint of the temporal triangulation.
-         * @param endpoint. The endpoint of the temporal triangulation.
-         */
-        Triangulation (
-                std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> space_tria,
-                std::vector<double> step_sizes,
-                double startpoint , double endpoint );
-
-        /**
-         * @brief (shallow) copy constructor. Only the values for the start- and endpoint
-         * are actually copied. The underlying pointers will point to the same
-         * dealii::Triangulation objects as other.
-         *
-         * @param other The Triangulation to shallow copy.
-         *
-         * @warning This method is mainly needed for adding the Triangulations to the spacetime
-         * lists and should be used with utmost caution anywhere else.
-         *
-         *
-         */
-        Triangulation(const Triangulation& other);
-        /**
-         * @brief The underlying spatial triangulation.
-         */
-        std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> spatial();
-
-        /**
-         * @brief The underlying temporal triangulation.
-         */
-        std::shared_ptr<dealii::Triangulation<1>> temporal();
-
-        /**
-         * @brief The startpoint of the temporal triangulation.
-         */
-        double startpoint();
-
-        /**
-         * @brief The endpoint of the temporal triangulation.
-         */
-        double endpoint();
-
-        /**
-         * @brief Change the temporal triangulation to the given division
-         *
-         * @param step_sizes. The sizes of the temporal elements
-         * @param startpoint. The startpoint of the temporal triangulation.
-         * @param endpoint. The endpoint of the temporal triangulation.
-         *
-         * @warning Due to a call to clear() of the temporal triangulation no subscriptions can exist to it, such as DoFHandler.
-         */
-        void update_temporal_triangulation(
-                std::vector<double> step_sizes,
-                double startpoint,
-                double endpoint);
-    private:
-        std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> _spatial_tria;
-        std::shared_ptr<dealii::Triangulation<1>> _temporal_tria;
-        double _startpoint;
-        double _endpoint;
-    };
 
     /**
-     * @brief A shortened type for Iterators over a list of shared pointers to Triangulation<dim> objects
+     * @brief Construct an object with a given spatial triangulation and a given
+     * division of elements in time.
+     *
+     * @param space_tria. The spatial triangulation to be used.
+     * @param step_sizes. The sizes of the temporal elements
+     * @param startpoint. The startpoint of the temporal triangulation.
+     * @param endpoint. The endpoint of the temporal triangulation.
      */
-    template<int dim>
-    using TriaIterator = typename std::list<Triangulation<dim>>::iterator;
-}
+    Triangulation(
+      std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+                          space_tria,
+      std::vector<double> step_sizes,
+      double              startpoint,
+      double              endpoint);
+
+    /**
+     * @brief (shallow) copy constructor. Only the values for the start- and endpoint
+     * are actually copied. The underlying pointers will point to the same
+     * dealii::Triangulation objects as other.
+     *
+     * @param other The Triangulation to shallow copy.
+     *
+     * @warning This method is mainly needed for adding the Triangulations to the spacetime
+     * lists and should be used with utmost caution anywhere else.
+     *
+     *
+     */
+    Triangulation(const Triangulation &other);
+    /**
+     * @brief The underlying spatial triangulation.
+     */
+    std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+    spatial();
+
+    /**
+     * @brief The underlying temporal triangulation.
+     */
+    std::shared_ptr<dealii::Triangulation<1>>
+    temporal();
+
+    /**
+     * @brief The startpoint of the temporal triangulation.
+     */
+    double
+    startpoint();
+
+    /**
+     * @brief The endpoint of the temporal triangulation.
+     */
+    double
+    endpoint();
+
+    /**
+     * @brief Change the temporal triangulation to the given division
+     *
+     * @param step_sizes. The sizes of the temporal elements
+     * @param startpoint. The startpoint of the temporal triangulation.
+     * @param endpoint. The endpoint of the temporal triangulation.
+     *
+     * @warning Due to a call to clear() of the temporal triangulation no subscriptions can exist to it, such as DoFHandler.
+     */
+    void
+    update_temporal_triangulation(std::vector<double> step_sizes,
+                                  double              startpoint,
+                                  double              endpoint);
+
+  private:
+    std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+                                              _spatial_tria;
+    std::shared_ptr<dealii::Triangulation<1>> _temporal_tria;
+    double                                    _startpoint;
+    double                                    _endpoint;
+  };
+
+  /**
+   * @brief A shortened type for Iterators over a list of shared pointers to Triangulation<dim> objects
+   */
+  template <int dim>
+  using TriaIterator = typename std::list<Triangulation<dim>>::iterator;
+} // namespace idealii::slab::parallel::distributed
 #endif
 #endif /* INCLUDE_IDEAL_II_DISTRIBUTED_SLAB_TRIA_HH_ */

--- a/include/ideal.II/distributed/spacetime_tria.hh
+++ b/include/ideal.II/distributed/spacetime_tria.hh
@@ -19,66 +19,78 @@
 #include <ideal.II/distributed/slab_tria.hh>
 
 #ifdef DEAL_II_WITH_MPI
-#include <deal.II/grid/tria.h>
+#  include <deal.II/grid/tria.h>
 
-#include <memory>
-#include <list>
+#  include <list>
+#  include <memory>
 
-namespace idealii::spacetime::parallel::distributed{
+namespace idealii::spacetime::parallel::distributed
+{
+  /**
+   * @brief The spacetime triangulation object with MPI parallel distributed spatial meshes.
+   *
+   * In practice this is just a class around a list of shared pointers to
+   * slab::parallel::distributed::Triangulation objects to simplify generation
+   * and time marching.
+   * @note This is a virtual base class.
+   */
+  template <int dim>
+  class Triangulation
+  {
+  public:
     /**
-     * @brief The spacetime triangulation object with MPI parallel distributed spatial meshes.
-     *
-     * In practice this is just a class around a list of shared pointers to slab::parallel::distributed::Triangulation objects to
-     * simplify generation and time marching.
-     * @note This is a virtual base class.
+     * @brief Constructor that initializes the underlying list object.
+     * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
      */
-    template<int dim>
-    class Triangulation{
-    public:
-        /**
-         * @brief Constructor that initializes the underlying list object.
-         * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
-         */
-        Triangulation ( dealii::types::global_cell_index max_N_intervals_per_slab=0);
+    Triangulation(
+      dealii::types::global_cell_index max_N_intervals_per_slab = 0);
 
-        /**
-         * @brief Generate a list of M slab triangulations with matching temporal meshes and space_tria.
-         *
-         * @param space_tria The underlying spatial dealii::parallel::distributed::Triangulation.
-         * @param M The number of slabs to be created.
-         * @param t0 The temporal startpoint. Defaults to 0.
-         * @param T The temporal endpoint. Defaults to 1.
-         */
-        virtual void generate(std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> space_tria,
-                              unsigned int M,
-                              double t0=0.,
-                              double T=1.)=0;
+    /**
+     * @brief Generate a list of M slab triangulations with matching temporal meshes and space_tria.
+     *
+     * @param space_tria The underlying spatial dealii::parallel::distributed::Triangulation.
+     * @param M The number of slabs to be created.
+     * @param t0 The temporal startpoint. Defaults to 0.
+     * @param T The temporal endpoint. Defaults to 1.
+     */
+    virtual void
+    generate(std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+                          space_tria,
+             unsigned int M,
+             double       t0 = 0.,
+             double       T  = 1.) = 0;
 
-        /**
-         * @brief Return the number of slabs in the triangulation.
-         */
-        unsigned int M();
-        /**
-         * brief An iterator pointing to the first slab::parallel::distributed::Triangulation
-         */
-        slab::parallel::distributed::TriaIterator<dim> begin();
-        /**
-         * @brief An iterator pointing behind the slab slab::parallel::distributed::Triangulation
-         */
-        slab::parallel::distributed::TriaIterator<dim> end();
+    /**
+     * @brief Return the number of slabs in the triangulation.
+     */
+    unsigned int
+    M();
+    /**
+     * brief An iterator pointing to the first
+     * slab::parallel::distributed::Triangulation
+     */
+    slab::parallel::distributed::TriaIterator<dim>
+    begin();
+    /**
+     * @brief An iterator pointing behind the slab slab::parallel::distributed::Triangulation
+     */
+    slab::parallel::distributed::TriaIterator<dim>
+    end();
 
-        /**
-         * @brief Do uniform mesh refinement in time and space
-         * @param times_space Number of times the spatial meshes are refined.
-         * @param times_time Number of times the temporal meshes are refined.
-         */
-        virtual void refine_global(const unsigned int times_space = 1, const unsigned int times_time = 1)=0;
+    /**
+     * @brief Do uniform mesh refinement in time and space
+     * @param times_space Number of times the spatial meshes are refined.
+     * @param times_time Number of times the temporal meshes are refined.
+     */
+    virtual void
+    refine_global(const unsigned int times_space = 1,
+                  const unsigned int times_time  = 1) = 0;
 
-    protected:
-        dealii::types::global_cell_index max_N_intervals_per_slab;
-        std::list<slab::parallel::distributed::Triangulation<dim>> trias;
-    };
-}
+  protected:
+    dealii::types::global_cell_index max_N_intervals_per_slab;
+    std::list<slab::parallel::distributed::Triangulation<dim>> trias;
+  };
+} // namespace idealii::spacetime::parallel::distributed
 
 #endif
 #endif /* INCLUDE_IDEAL_II_DISTRIBUTED_SPACETIME_TRIA_HH_ */

--- a/include/ideal.II/dofs/slab_dof_handler.hh
+++ b/include/ideal.II/dofs/slab_dof_handler.hh
@@ -16,145 +16,146 @@
 #ifndef INCLUDE_IDEAL_II_DOFS_SLAB_DOF_HANDLER_HH_
 #define INCLUDE_IDEAL_II_DOFS_SLAB_DOF_HANDLER_HH_
 
-#include <ideal.II/grid/slab_tria.hh>
 #include <ideal.II/distributed/slab_tria.hh>
 
 #include <ideal.II/fe/fe_dg.hh>
 
+#include <ideal.II/grid/slab_tria.hh>
+
 #include <deal.II/dofs/dof_handler.h>
 
-#include <memory>
 #include <list>
+#include <memory>
 
 namespace idealii::slab
 {
+  /**
+   * @brief Actual DoFHandler for a specific slab.
+   *
+   * This DoFHandler actually handles a spatial and a temporal
+   * dealii::DoFHandler object internally.
+   *
+   * Currently it is restricted to dG elements in time i.e.
+   * spacetime::DG_FiniteElement.
+   */
+  template <int dim>
+  class DoFHandler
+  {
+  public:
     /**
-     * @brief Actual DoFHandler for a specific slab.
-     *
-     * This DoFHandler actually handles a spatial and a temporal
-     * dealii::DoFHandler object internally.
-     *
-     * Currently it is restricted to dG elements in time i.e. spacetime::DG_FiniteElement.
+     * @brief Constructor linking a slab::Triangulation.
+     * @param tria A shared pointer to a slab::Triangulation.
      */
-    template<int dim>
-    class DoFHandler
-    {
-    public:
-        /**
-         * @brief Constructor linking a slab::Triangulation.
-         * @param tria A shared pointer to a slab::Triangulation.
-         */
-        DoFHandler ( Triangulation<dim> &tria );
+    DoFHandler(Triangulation<dim> &tria);
 #ifdef DEAL_II_WITH_MPI
-        /**
-         * @brief Constructor linking a parallel::distributed::slab::Triangulation.
-         * @param tria A shared pointer to a parallel::distributed::slab::Triangulation.
-         */
-        DoFHandler (
-                slab::parallel::distributed::Triangulation<dim> &tria );
+    /**
+     * @brief Constructor linking a parallel::distributed::slab::Triangulation.
+     * @param tria A shared pointer to a parallel::distributed::slab::Triangulation.
+     */
+    DoFHandler(slab::parallel::distributed::Triangulation<dim> &tria);
 #endif
-        /**
-         * @brief (shallow) copy constructor. Only the index set and fe support type
-         * are actually copied. The underlying pointers will point to the same
-         * dealii::DoFHandler objects as other.
-         *
-         * @param other The DoFHandler to shallow copy.
-         *
-         * @warning This method is mainly needed for adding the DoFHandlers to the spacetime
-         * lists and should be used with utmost caution anywhere else.
-         *
-         */
+    /**
+     * @brief (shallow) copy constructor. Only the index set and fe support type
+     * are actually copied. The underlying pointers will point to the same
+     * dealii::DoFHandler objects as other.
+     *
+     * @param other The DoFHandler to shallow copy.
+     *
+     * @warning This method is mainly needed for adding the DoFHandlers to the spacetime
+     * lists and should be used with utmost caution anywhere else.
+     *
+     */
 
-        DoFHandler ( const DoFHandler<dim> &other );
-        /**
-         * @brief The underlying spatial dof handler.
-         * @return A shared pointer to the spatial dof handler.
-         */
-        std::shared_ptr<dealii::DoFHandler<dim>>
-        spatial ();
-
-        /**
-         * @brief The underlying temporal dof handler.
-         * @return A shared pointer to the temporal dof handler.
-         */
-        std::shared_ptr<dealii::DoFHandler<1>>
-        temporal ();
-
-        /**
-         * @brief Distribute DoFs in space and time.
-         *
-         * This function calls the function of the same name of the underlying
-         * dof handler objects with the matching spatial or temporal element in @p fe.
-         *
-         * @param fe The spacetime finite element to base the distribution on.
-         */
-        void
-        distribute_dofs ( spacetime::DG_FiniteElement<dim> fe );
-
-        /**
-         * @brief Total number of space-time degrees of fredom on this slab.
-         *
-         * @return The total number of space-time dofs, i.e. n_dofs_space()*n_dofs_time().
-         */
-        unsigned int
-        n_dofs_spacetime ();
-        /**
-         * @brief Number of spatial degrees of fredom on this slab.
-         *
-         * @return The number of dofs based on the spatial finite element and triangulation.
-         */
-        unsigned int
-        n_dofs_space ();
-        /**
-         * @brief Number of temporal degrees of fredom on this slab.
-         *
-         * @return The number of dofs based on the temporal finite element and  triangulation.
-         */
-        unsigned int
-        n_dofs_time ();
-
-        /**
-         * @brief Number of temporal dofs in a single element/interval.
-         *
-         * @return The number of temporal dofs i.e. (r+1) for dG(r) elements.
-         */
-        unsigned int
-        dofs_per_cell_time ();
-
-        /**
-         * @brief The underlying support type used for constructing the temporal finite element.
-         *
-         * @return The spacetime::DG_FiniteElement<dim>::support_type of the underlying finite element.
-         */
-        typename spacetime::DG_FiniteElement<dim>::support_type
-        fe_support_type ();
-
-        /**
-         * @brief Return the set of processor local dofs.
-         *
-         * Parallelization is done in space only. Therefore the local space-time dof indices
-         * are the local indices of the spatial DoFHandler shifted by the total number of
-         * spatial degrees of freedom.
-         * Note that the IndexSet is not contiguous and can therefore currently not be used
-         * with PETScWrapper classes.
-         *
-         * @return An IndexSet of the global dof indices owned by the current core.
-         */
-        const dealii::IndexSet&
-        locally_owned_dofs ();
-
-    private:
-        std::shared_ptr<dealii::DoFHandler<dim>> _spatial_dof;
-        std::shared_ptr<dealii::DoFHandler<1>> _temporal_dof;
-        typename spacetime::DG_FiniteElement<dim>::support_type _fe_support_type;
-        dealii::IndexSet _locally_owned_dofs;
-    };
+    DoFHandler(const DoFHandler<dim> &other);
+    /**
+     * @brief The underlying spatial dof handler.
+     * @return A shared pointer to the spatial dof handler.
+     */
+    std::shared_ptr<dealii::DoFHandler<dim>>
+    spatial();
 
     /**
-     * @brief A shortened type for iterators over a list of shared pointers to DoFHandler objects.
+     * @brief The underlying temporal dof handler.
+     * @return A shared pointer to the temporal dof handler.
      */
-    template<int dim>
-    using DoFHandlerIterator = typename std::list<DoFHandler<dim>>::iterator;
-}
+    std::shared_ptr<dealii::DoFHandler<1>>
+    temporal();
+
+    /**
+     * @brief Distribute DoFs in space and time.
+     *
+     * This function calls the function of the same name of the underlying
+     * dof handler objects with the matching spatial or temporal element in @p fe.
+     *
+     * @param fe The spacetime finite element to base the distribution on.
+     */
+    void
+    distribute_dofs(spacetime::DG_FiniteElement<dim> fe);
+
+    /**
+     * @brief Total number of space-time degrees of fredom on this slab.
+     *
+     * @return The total number of space-time dofs, i.e. n_dofs_space()*n_dofs_time().
+     */
+    unsigned int
+    n_dofs_spacetime();
+    /**
+     * @brief Number of spatial degrees of fredom on this slab.
+     *
+     * @return The number of dofs based on the spatial finite element and triangulation.
+     */
+    unsigned int
+    n_dofs_space();
+    /**
+     * @brief Number of temporal degrees of fredom on this slab.
+     *
+     * @return The number of dofs based on the temporal finite element and  triangulation.
+     */
+    unsigned int
+    n_dofs_time();
+
+    /**
+     * @brief Number of temporal dofs in a single element/interval.
+     *
+     * @return The number of temporal dofs i.e. (r+1) for dG(r) elements.
+     */
+    unsigned int
+    dofs_per_cell_time();
+
+    /**
+     * @brief The underlying support type used for constructing the temporal finite element.
+     *
+     * @return The spacetime::DG_FiniteElement<dim>::support_type of the underlying finite element.
+     */
+    typename spacetime::DG_FiniteElement<dim>::support_type
+    fe_support_type();
+
+    /**
+     * @brief Return the set of processor local dofs.
+     *
+     * Parallelization is done in space only. Therefore the local space-time dof
+     * indices are the local indices of the spatial DoFHandler shifted by the
+     * total number of spatial degrees of freedom.
+     * Note that the IndexSet is not contiguous and can therefore currently not be used
+     * with PETScWrapper classes.
+     *
+     * @return An IndexSet of the global dof indices owned by the current core.
+     */
+    const dealii::IndexSet &
+    locally_owned_dofs();
+
+  private:
+    std::shared_ptr<dealii::DoFHandler<dim>>                _spatial_dof;
+    std::shared_ptr<dealii::DoFHandler<1>>                  _temporal_dof;
+    typename spacetime::DG_FiniteElement<dim>::support_type _fe_support_type;
+    dealii::IndexSet                                        _locally_owned_dofs;
+  };
+
+  /**
+   * @brief A shortened type for iterators over a list of shared pointers to DoFHandler objects.
+   */
+  template <int dim>
+  using DoFHandlerIterator = typename std::list<DoFHandler<dim>>::iterator;
+} // namespace idealii::slab
 
 #endif /* INCLUDE_IDEAL_II_DOFS_SLAB_DOF_HANDLER_HH_ */

--- a/include/ideal.II/dofs/slab_dof_tools.hh
+++ b/include/ideal.II/dofs/slab_dof_tools.hh
@@ -8,499 +8,524 @@
 #ifndef INCLUDE_IDEAL_II_DOFS_SLAB_DOF_TOOLS_HH_
 #define INCLUDE_IDEAL_II_DOFS_SLAB_DOF_TOOLS_HH_
 
-#include <deal.II/base/types.h>
 #include <ideal.II/dofs/slab_dof_handler.hh>
 
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <ideal.II/fe/fe_dg.hh>
+
+#include <deal.II/base/types.h>
+
 #include <deal.II/dofs/dof_tools.h>
-#include "ideal.II/fe/fe_dg.hh"
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 namespace idealii::slab::DoFTools
 {
-    namespace internal
+  namespace internal
+  {
+    template <int dim>
+    void
+    upwind_temporal_pattern(DoFHandler<dim>                &dof,
+                            dealii::DynamicSparsityPattern &time_dsp)
     {
-        template<int dim>
-        void upwind_temporal_pattern (
-                DoFHandler<dim> &dof ,
-                dealii::DynamicSparsityPattern &time_dsp )
+      dealii::DoFTools::make_sparsity_pattern(*dof.temporal(), time_dsp);
+      if (dof.fe_support_type() ==
+          spacetime::DG_FiniteElement<dim>::support_type::Lobatto)
         {
-            dealii::DoFTools::make_sparsity_pattern ( *dof.temporal () ,
-                                                      time_dsp );
-            if ( dof.fe_support_type () == spacetime::DG_FiniteElement < dim
-                    > ::support_type::Lobatto )
+          for (dealii::types::global_dof_index ii = dof.dofs_per_cell_time();
+               ii < dof.n_dofs_time();
+               ii += dof.dofs_per_cell_time())
             {
-                for ( dealii::types::global_dof_index ii =
-                        dof.dofs_per_cell_time () ;
-                        ii < dof.n_dofs_time () ;
-                        ii += dof.dofs_per_cell_time () )
-                {
-                    time_dsp.add ( ii , ii - 1 );
-                }
+              time_dsp.add(ii, ii - 1);
             }
-            else if ( dof.fe_support_type() == spacetime::DG_FiniteElement<dim>::support_type::RadauLeft)
+        }
+      else if (dof.fe_support_type() ==
+               spacetime::DG_FiniteElement<dim>::support_type::RadauLeft)
+        {
+          for (dealii::types::global_dof_index ii = dof.dofs_per_cell_time();
+               ii < dof.n_dofs_time();
+               ii += dof.dofs_per_cell_time())
             {
-                for ( dealii::types::global_dof_index ii =
-                       dof.dofs_per_cell_time() ; 
-                       ii < dof.n_dofs_time() ;
-                       ii += dof.dofs_per_cell_time())
+              for (dealii::types::global_dof_index l = 0;
+                   l < dof.dofs_per_cell_time();
+                   l++)
                 {
-                    for (dealii::types::global_dof_index l = 0 ;
-                         l < dof.dofs_per_cell_time() ; l++)
-                        {
-                             time_dsp.add ( ii , ii - l - 1);
-                        }
-                }
-            }
-            else if ( dof.fe_support_type() == spacetime::DG_FiniteElement<dim>::support_type::RadauRight)
-            {
-                for ( dealii::types::global_dof_index ii =
-                       dof.dofs_per_cell_time() ; 
-                       ii < dof.n_dofs_time() ;
-                       ii += dof.dofs_per_cell_time())
-                {
-                    for (dealii::types::global_dof_index k = 0 ;
-                          k < dof.dofs_per_cell_time() ; k++)
-                        {
-                             time_dsp.add ( ii + k , ii -1);
-                        }
-                }
-            } 
-            else
-            {
-                //go over first DoF of each cell
-                for ( dealii::types::global_dof_index ii =
-                        dof.dofs_per_cell_time () ;
-                        ii < dof.n_dofs_time () ;
-                        ii += dof.dofs_per_cell_time () )
-                {
-                    //row offset
-                    for ( dealii::types::global_dof_index k = 0 ;
-                            k < dof.dofs_per_cell_time () ; k++ )
-                    {
-                        for ( dealii::types::global_dof_index l = 0 ;
-                                l < dof.dofs_per_cell_time () ; l++ )
-                        {
-                            time_dsp.add ( ii + k , ii - l - 1 );
-                        }
-                    }
+                  time_dsp.add(ii, ii - l - 1);
                 }
             }
         }
-        template<int dim>
-        void downwind_temporal_pattern (
-                DoFHandler<dim> &dof ,
-                dealii::DynamicSparsityPattern &time_dsp )
+      else if (dof.fe_support_type() ==
+               spacetime::DG_FiniteElement<dim>::support_type::RadauRight)
         {
-            dealii::DoFTools::make_sparsity_pattern ( *dof.temporal () ,
-                                                      time_dsp );
-            if ( dof.fe_support_type () == spacetime::DG_FiniteElement < dim
-                    > ::support_type::Lobatto )
+          for (dealii::types::global_dof_index ii = dof.dofs_per_cell_time();
+               ii < dof.n_dofs_time();
+               ii += dof.dofs_per_cell_time())
             {
-                for ( dealii::types::global_dof_index ii =
-                        dof.dofs_per_cell_time () ;
-                        ii < dof.n_dofs_time () ;
-                        ii += dof.dofs_per_cell_time () )
+              for (dealii::types::global_dof_index k = 0;
+                   k < dof.dofs_per_cell_time();
+                   k++)
                 {
-                    time_dsp.add ( ii-1 , ii );
+                  time_dsp.add(ii + k, ii - 1);
                 }
             }
-            else if ( dof.fe_support_type() == spacetime::DG_FiniteElement<dim>::support_type::RadauRight)
+        }
+      else
+        {
+          // go over first DoF of each cell
+          for (dealii::types::global_dof_index ii = dof.dofs_per_cell_time();
+               ii < dof.n_dofs_time();
+               ii += dof.dofs_per_cell_time())
             {
-                for ( dealii::types::global_dof_index ii =
-                       dof.dofs_per_cell_time() ; 
-                       ii < dof.n_dofs_time() ;
-                       ii += dof.dofs_per_cell_time())
+              // row offset
+              for (dealii::types::global_dof_index k = 0;
+                   k < dof.dofs_per_cell_time();
+                   k++)
                 {
-                    for (dealii::types::global_dof_index k = 0 ;
-                          k < dof.dofs_per_cell_time() ; k++)
-                        {
-                             time_dsp.add ( ii -1 , ii + k );
-                        }
-                }
-            } 
-            else if ( dof.fe_support_type() == spacetime::DG_FiniteElement<dim>::support_type::RadauLeft)
-            {
-                for ( dealii::types::global_dof_index ii =
-                       dof.dofs_per_cell_time() ; 
-                       ii < dof.n_dofs_time() ;
-                       ii += dof.dofs_per_cell_time())
-                {
-                    for (dealii::types::global_dof_index l = 0 ;
-                         l < dof.dofs_per_cell_time() ; l++)
-                        {
-                             time_dsp.add ( ii - l - 1 , ii );
-                        }
-                }
-            }
-            else 
-            {
-                //go over first DoF of each cell
-                for ( dealii::types::global_dof_index ii =
-                        dof.dofs_per_cell_time () ;
-                        ii < dof.n_dofs_time () ;
-                        ii += dof.dofs_per_cell_time () )
-                {
-                    //row offset
-                    for ( dealii::types::global_dof_index k = 0 ;
-                            k < dof.dofs_per_cell_time () ; k++ )
+                  for (dealii::types::global_dof_index l = 0;
+                       l < dof.dofs_per_cell_time();
+                       l++)
                     {
-                        for ( dealii::types::global_dof_index l = 0 ;
-                                l < dof.dofs_per_cell_time () ; l++ )
-                        {
-                            time_dsp.add ( ii - l - 1 , ii + k );
-                        }
+                      time_dsp.add(ii + k, ii - l - 1);
                     }
                 }
             }
         }
     }
-
-    /**
-     * @brief Construction of a sparsity pattern with lower off diagonal jump terms.
-     *
-     * This functions constructs the tensor product between
-     * a spatial sparsity pattern and a temporal upwind sparsity.
-     *
-     * The spatial pattern is constructed by calling the function make_sparsity_pattern()
-     * with the spatial DoFHandler of @p dof, the @p space_contraints and @p keep_constrained_dofs.
-     *
-     * The temporal pattern is initially constructed as a block-diagonal sparsity pattern
-     * by the corresponding deal.II method for the temporal DoFHandler of @p dof.
-     * If the number of temporal elements in this slab is greater than one, additional
-     * off diagonal entries for the jump terms between a temporal element and its direct
-     * left/earlier neighbor are added.
-     *
-     * For Gauss-Lobatto support points in time this is only a coupling between
-     * the initial temporal dof of the current element and
-     * the final temporal dof of the neighbor.
-     *
-     * For Gauss-Legendre support points in time this is the complete first lower off diagonal block.
-     *
-     * @param dof A shared pointer to the DoFHandler object to base the patterns on.
-     * @param st_dsp The dynamic sparsity pattern that will afterwards include the spacetime pattern.
-     * @param space_constraints The spatial constraints handed to the spatial pattern function
-     * @param keep_constrained_dofs When using distribute_local_to_global() of the spacetime constraints
-     * off diagonal entries of constrained dofs will not be written. So it is possible to not include these
-     * in the sparsity pattern. For more details see the functions in the dealii::DoFTools namespace.
-     */
-    template<int dim>
-    void make_upwind_sparsity_pattern (
-        DoFHandler<dim> &dof ,
-        dealii::DynamicSparsityPattern &st_dsp ,
-        std::shared_ptr<dealii::AffineConstraints<double>> space_constraints =
-            std::make_shared<dealii::AffineConstraints<double>> () ,
-        const bool keep_constrained_dofs = true )
+    template <int dim>
+    void
+    downwind_temporal_pattern(DoFHandler<dim>                &dof,
+                              dealii::DynamicSparsityPattern &time_dsp)
     {
-        dealii::DynamicSparsityPattern space_dsp ( dof.n_dofs_space () );
-        dealii::DoFTools::make_sparsity_pattern ( *dof.spatial () ,
-                                                  space_dsp ,
-                                                  *space_constraints ,
-                                                  keep_constrained_dofs );
-
-        dealii::DynamicSparsityPattern time_dsp ( dof.n_dofs_time () );
-        internal::upwind_temporal_pattern ( dof , time_dsp );
-
-        for ( auto &space_entry : space_dsp )
+      dealii::DoFTools::make_sparsity_pattern(*dof.temporal(), time_dsp);
+      if (dof.fe_support_type() ==
+          spacetime::DG_FiniteElement<dim>::support_type::Lobatto)
         {
-            for ( auto &time_entry : time_dsp )
+          for (dealii::types::global_dof_index ii = dof.dofs_per_cell_time();
+               ii < dof.n_dofs_time();
+               ii += dof.dofs_per_cell_time())
             {
-                st_dsp.add (
-                    time_entry.row () * dof.n_dofs_space () + space_entry.row () ,//test function
-                    time_entry.column () * dof.n_dofs_space () + space_entry.column ()// trial function
-                );
+              time_dsp.add(ii - 1, ii);
             }
         }
-    }
-    /**
-     * @brief Construction of a sparsity pattern with lower off diagonal jump terms.
-     *
-     * This functions works like the previous one butthe spatial pattern is constructed
-     * using the supplied couplings.
-     * @param space_couplings In coupled problems some components
-     * don't couple in the weak formulation and consequently don't needs
-     * entries in the sparsity pattern.
-     *
-     * An example would be the Stokes system where pressure ansatz function is not
-     * multiplied by the pressure test function, which leads to an empty diagonal block.
-     */
-    template<int dim>
-    void make_upwind_sparsity_pattern (
-            DoFHandler<dim> &dof ,
-            const dealii::Table<2,dealii::DoFTools::Coupling> &space_couplings ,
-            dealii::DynamicSparsityPattern &st_dsp ,
-            std::shared_ptr<dealii::AffineConstraints<double>> space_constraints =
-                std::make_shared<dealii::AffineConstraints<double>> () ,
-            const bool keep_constrained_dofs = true )
-    {
-        dealii::DynamicSparsityPattern space_dsp ( dof.n_dofs_space () );
-        dealii::DoFTools::make_sparsity_pattern ( *dof.spatial () ,
-                                                  space_couplings ,
-                                                  space_dsp ,
-                                                  *space_constraints ,
-                                                  keep_constrained_dofs );
-
-        dealii::DynamicSparsityPattern time_dsp ( dof.n_dofs_time () );
-        internal::upwind_temporal_pattern ( dof , time_dsp );
-
-        for ( auto &space_entry : space_dsp )
+      else if (dof.fe_support_type() ==
+               spacetime::DG_FiniteElement<dim>::support_type::RadauRight)
         {
-            for ( auto &time_entry : time_dsp )
+          for (dealii::types::global_dof_index ii = dof.dofs_per_cell_time();
+               ii < dof.n_dofs_time();
+               ii += dof.dofs_per_cell_time())
             {
-                st_dsp.add (
-                        time_entry.row () * dof.n_dofs_space () + space_entry.row () ,//test function
-                        time_entry.column () * dof.n_dofs_space () + space_entry.column ()// trial function
-                );
-            }
-        }
-    }
-
-    /**
-     * @brief Construction of a sparsity pattern with upper off diagonal jump terms.
-     *
-     * This functions constructs the tensor product between
-     * a spatial sparsity pattern and a temporal upwind sparsity.
-     *
-     * The spatial pattern is constructed by calling the function make_sparsity_pattern()
-     * with the spatial DoFHandler of @p dof, the @p space_contraints and @p keep_constrained_dofs.
-     *
-     * The temporal pattern is initially constructed as a block-diagonal sparsity pattern
-     * by the corresponding deal.II method for the temporal DoFHandler of @p dof.
-     * If the number of temporal elements in this slab is greater than one, additional
-     * off diagonal entries for the jump terms between a temporal element and its direct
-     * right/later neighbor are added.
-     *
-     * For Gauss-Lobatto support points in time this is only a coupling between
-     * the final temporal dof of the current element and
-     * the initial temporal dof of the neighbor.
-     *
-     * For Gauss-Legendre support points in time this is the complete first upper off diagonal block.
-     *
-     * @param dof A shared pointer to the DoFHandler object to base the patterns on.
-     * @param st_dsp The dynamic sparsity pattern that will afterwards include the spacetime pattern.
-     * @param space_constraints The spatial constraints handed to the spatial pattern function
-     * @param keep_constrained_dofs When using distribute_local_to_global() of the spacetime constraints
-     * off diagonal entries of constrained dofs will not be written. So it is possible to not include these
-     * in the sparsity pattern. For more details see the functions in the dealii::DoFTools namespace.
-     */
-    template<int dim>
-    void make_downwind_sparsity_pattern (
-        DoFHandler<dim> &dof ,
-        dealii::DynamicSparsityPattern &st_dsp ,
-        std::shared_ptr<dealii::AffineConstraints<double>> space_constraints =
-            std::make_shared<dealii::AffineConstraints<double>> () ,
-        const bool keep_constrained_dofs = true )
-    {
-        dealii::DynamicSparsityPattern space_dsp ( dof.n_dofs_space () );
-        dealii::DoFTools::make_sparsity_pattern ( *dof.spatial () ,
-                                                  space_dsp ,
-                                                  *space_constraints ,
-                                                  keep_constrained_dofs );
-
-        dealii::DynamicSparsityPattern time_dsp ( dof.n_dofs_time () );
-        internal::downwind_temporal_pattern ( dof , time_dsp );
-
-        for ( auto &space_entry : space_dsp )
-        {
-            for ( auto &time_entry : time_dsp )
-            {
-                st_dsp.add (
-                    time_entry.row () * dof.n_dofs_space () + space_entry.row () ,//test function
-                    time_entry.column () * dof.n_dofs_space () + space_entry.column ()// trial function
-                );
-            }
-        }
-    }
-    /**
-     * @brief Construction of a sparsity pattern with upper off diagonal jump terms.
-     *
-     * This functions works like the previous one but the spatial pattern is constructed
-     * using the supplied couplings.
-     * @param space_couplings In coupled problems some components
-     * don't couple in the weak formulation and consequently don't needs
-     * entries in the sparsity pattern.
-     *
-     * An example would be the Stokes system where pressure ansatz function is not
-     * multiplied by the pressure test function, which leads to an empty diagonal block.
-     */
-    template<int dim>
-    void make_downwind_sparsity_pattern (
-            DoFHandler<dim> &dof ,
-            const dealii::Table<2,dealii::DoFTools::Coupling> &space_couplings ,
-            dealii::DynamicSparsityPattern &st_dsp ,
-            std::shared_ptr<dealii::AffineConstraints<double>> space_constraints =
-                std::make_shared<dealii::AffineConstraints<double>> () ,
-            const bool keep_constrained_dofs = true )
-    {
-        dealii::DynamicSparsityPattern space_dsp ( dof.n_dofs_space () );
-        dealii::DoFTools::make_sparsity_pattern ( *dof.spatial () ,
-                                                  space_couplings ,
-                                                  space_dsp ,
-                                                  *space_constraints ,
-                                                  keep_constrained_dofs );
-
-        dealii::DynamicSparsityPattern time_dsp ( dof.n_dofs_time () );
-        internal::downwind_temporal_pattern ( dof , time_dsp );
-
-        for ( auto &space_entry : space_dsp )
-        {
-            for ( auto &time_entry : time_dsp )
-            {
-                st_dsp.add (
-                        time_entry.row () * dof.n_dofs_space () + space_entry.row () ,//test function
-                        time_entry.column () * dof.n_dofs_space () + space_entry.column ()// trial function
-                );
-            }
-        }
-    }
-
-    /**
-     * @brief Construction of space-time hanging node constraints.
-     *
-     * This function internally constructs spatial hanging node constraints based on
-     * the spatial part of @dof_handler.
-     *
-     * The spacetime constraints are then obtained by offsetting the constraints by
-     * the total number of dofs in the spatial dof handler.
-     *
-     * @param dof_handler
-     * @param spacetime_constraints
-     */
-    template<int dim,typename Number>
-    void make_hanging_node_constraints (
-            idealii::slab::DoFHandler<dim> &dof_handler ,
-            std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints )
-    {
-        auto space_constraints = std::make_shared<dealii::AffineConstraints<Number>> ();
-        dealii::DoFTools::make_hanging_node_constraints (
-            *dof_handler.spatial () ,
-            *space_constraints );
-
-        unsigned int n_space_dofs = dof_handler.n_dofs_space ();
-        for ( unsigned int time_dof = 0 ; time_dof < dof_handler.n_dofs_time () ; time_dof++ )
-        {
-
-            for ( unsigned int i = 0 ; i < n_space_dofs ; i++ )
-            {
-                if ( space_constraints->is_constrained ( i ) )
+              for (dealii::types::global_dof_index k = 0;
+                   k < dof.dofs_per_cell_time();
+                   k++)
                 {
-                    const std::vector<std::pair<dealii::types::global_dof_index,double>> *entries =
-                        space_constraints->get_constraint_entries ( i );
-                    spacetime_constraints->add_line ( i + time_dof * n_space_dofs );
-                    //non Dirichlet constraint
-                    if ( entries->size () > 0 )
+                  time_dsp.add(ii - 1, ii + k);
+                }
+            }
+        }
+      else if (dof.fe_support_type() ==
+               spacetime::DG_FiniteElement<dim>::support_type::RadauLeft)
+        {
+          for (dealii::types::global_dof_index ii = dof.dofs_per_cell_time();
+               ii < dof.n_dofs_time();
+               ii += dof.dofs_per_cell_time())
+            {
+              for (dealii::types::global_dof_index l = 0;
+                   l < dof.dofs_per_cell_time();
+                   l++)
+                {
+                  time_dsp.add(ii - l - 1, ii);
+                }
+            }
+        }
+      else
+        {
+          // go over first DoF of each cell
+          for (dealii::types::global_dof_index ii = dof.dofs_per_cell_time();
+               ii < dof.n_dofs_time();
+               ii += dof.dofs_per_cell_time())
+            {
+              // row offset
+              for (dealii::types::global_dof_index k = 0;
+                   k < dof.dofs_per_cell_time();
+                   k++)
+                {
+                  for (dealii::types::global_dof_index l = 0;
+                       l < dof.dofs_per_cell_time();
+                       l++)
                     {
-                        for ( auto entry : *entries )
-                        {
-                            spacetime_constraints->add_entry (
-                                i + time_dof * n_space_dofs ,
-                                entry.first + time_dof * n_space_dofs ,
-                                entry.second );
-                        }
-                    }
-                    else
-                    {
-                        spacetime_constraints->set_inhomogeneity (
-                            i + time_dof * n_space_dofs ,
-                            space_constraints->get_inhomogeneity ( i ) );
+                      time_dsp.add(ii - l - 1, ii + k);
                     }
                 }
             }
         }
-
     }
+  } // namespace internal
 
-    /**
-     * @brief Construction of parallel distributed space-time hanging node constraints.
-     *
-     * This function internally constructs spatial hanging node constraints based on
-     * the spatial part of @dof_handler.
-     *
-     * The spacetime constraints are then obtained by offsetting the constraints by
-     * the total number of dofs in the spatial dof handler.
-     *
-     * @param dof_handler
-     * @param spacetime_constraints
-     */
-    template<int dim,typename Number>
-    void make_hanging_node_constraints (
-        dealii::IndexSet &space_relevant_dofs ,
-        idealii::slab::DoFHandler<dim> &dof_handler ,
-        std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints )
-    {
+  /**
+   * @brief Construction of a sparsity pattern with lower off diagonal jump terms.
+   *
+   * This functions constructs the tensor product between
+   * a spatial sparsity pattern and a temporal upwind sparsity.
+   *
+   * The spatial pattern is constructed by calling the function
+   * make_sparsity_pattern()
+   * with the spatial DoFHandler of @p dof, the @p space_contraints and @p keep_constrained_dofs.
+   *
+   * The temporal pattern is initially constructed as a block-diagonal sparsity
+   * pattern
+   * by the corresponding deal.II method for the temporal DoFHandler of @p dof.
+   * If the number of temporal elements in this slab is greater than one,
+   * additional off diagonal entries for the jump terms between a temporal
+   * element and its direct left/earlier neighbor are added.
+   *
+   * For Gauss-Lobatto support points in time this is only a coupling between
+   * the initial temporal dof of the current element and
+   * the final temporal dof of the neighbor.
+   *
+   * For Gauss-Legendre support points in time this is the complete first lower
+   * off diagonal block.
+   *
+   * @param dof A shared pointer to the DoFHandler object to base the patterns on.
+   * @param st_dsp The dynamic sparsity pattern that will afterwards include the spacetime pattern.
+   * @param space_constraints The spatial constraints handed to the spatial pattern function
+   * @param keep_constrained_dofs When using distribute_local_to_global() of the spacetime constraints
+   * off diagonal entries of constrained dofs will not be written. So it is
+   * possible to not include these in the sparsity pattern. For more details see
+   * the functions in the dealii::DoFTools namespace.
+   */
+  template <int dim>
+  void
+  make_upwind_sparsity_pattern(
+    DoFHandler<dim>                                   &dof,
+    dealii::DynamicSparsityPattern                    &st_dsp,
+    std::shared_ptr<dealii::AffineConstraints<double>> space_constraints =
+      std::make_shared<dealii::AffineConstraints<double>>(),
+    const bool keep_constrained_dofs = true)
+  {
+    dealii::DynamicSparsityPattern space_dsp(dof.n_dofs_space());
+    dealii::DoFTools::make_sparsity_pattern(*dof.spatial(),
+                                            space_dsp,
+                                            *space_constraints,
+                                            keep_constrained_dofs);
 
-        auto space_constraints = std::make_shared<dealii::AffineConstraints<Number>> ();
-        space_constraints->reinit ( space_relevant_dofs );
-        dealii::DoFTools::make_hanging_node_constraints (
-            *dof_handler.spatial () ,
-            *space_constraints );
+    dealii::DynamicSparsityPattern time_dsp(dof.n_dofs_time());
+    internal::upwind_temporal_pattern(dof, time_dsp);
 
-        unsigned int n_space_dofs = dof_handler.n_dofs_space ();
-        for ( unsigned int time_dof = 0 ;
-                time_dof < dof_handler.n_dofs_time () ; time_dof++ )
-        {
-            for ( auto id = space_relevant_dofs.begin () ;
-                    id != space_relevant_dofs.end () ; id++ )
-            {
-                if ( space_constraints->is_constrained ( *id ) )
-                {
-                    const std::vector<std::pair<dealii::types::global_dof_index,double>> *entries =
-                        space_constraints->get_constraint_entries ( *id );
-
-                    spacetime_constraints->add_line ( *id + time_dof * n_space_dofs );
-                    //non Dirichlet constraint
-                    if ( entries->size () > 0 )
-                    {
-                        for ( auto entry : *entries )
-                        {
-                            spacetime_constraints->add_entry (
-                                *id + time_dof * n_space_dofs ,
-                                entry.first + time_dof * n_space_dofs ,
-                                entry.second );
-                        }
-                    }
-                    else
-                    {
-                        spacetime_constraints->set_inhomogeneity (
-                            *id + time_dof * n_space_dofs ,
-                            space_constraints->get_inhomogeneity ( *id ) );
-                    }
-                }
-            }
-        }
-
-    }
-
-    /**
-     * @brief Extract global space-time dof indices active on the current DoFHandler.
-     *
-     * For DoFHandlers with a parallel triangulation this function returns the locally
-     * owned dofs and all dofs belonging to other processors that are located at a locally
-     * owned cell.s
-     */
-    template<int dim>
-    dealii::IndexSet extract_locally_relevant_dofs ( slab::DoFHandler<dim> &dof_handler )
-    {
-        dealii::IndexSet space_relevant_dofs;
-        dealii::DoFTools::extract_locally_relevant_dofs (
-                *dof_handler.spatial () ,
-                space_relevant_dofs );
-
-        dealii::IndexSet spacetime_relevant_dofs ( space_relevant_dofs.size ()
-                                                 * dof_handler.n_dofs_time () );
-
-        for ( dealii::types::global_dof_index time_dof_index = 0 ;
-              time_dof_index < dof_handler.n_dofs_time () ;
-              time_dof_index++ )
-        {
-            spacetime_relevant_dofs.add_indices (
-                space_relevant_dofs ,
-                time_dof_index * dof_handler.n_dofs_space ()//offset
+    for (auto &space_entry : space_dsp)
+      {
+        for (auto &time_entry : time_dsp)
+          {
+            st_dsp.add(time_entry.row() * dof.n_dofs_space() +
+                         space_entry.row(), // test function
+                       time_entry.column() * dof.n_dofs_space() +
+                         space_entry.column() // trial function
             );
-        }
+          }
+      }
+  }
+  /**
+   * @brief Construction of a sparsity pattern with lower off diagonal jump terms.
+   *
+   * This functions works like the previous one butthe spatial pattern is
+   * constructed using the supplied couplings.
+   * @param space_couplings In coupled problems some components
+   * don't couple in the weak formulation and consequently don't needs
+   * entries in the sparsity pattern.
+   *
+   * An example would be the Stokes system where pressure ansatz function is not
+   * multiplied by the pressure test function, which leads to an empty diagonal
+   * block.
+   */
+  template <int dim>
+  void
+  make_upwind_sparsity_pattern(
+    DoFHandler<dim>                                    &dof,
+    const dealii::Table<2, dealii::DoFTools::Coupling> &space_couplings,
+    dealii::DynamicSparsityPattern                     &st_dsp,
+    std::shared_ptr<dealii::AffineConstraints<double>>  space_constraints =
+      std::make_shared<dealii::AffineConstraints<double>>(),
+    const bool keep_constrained_dofs = true)
+  {
+    dealii::DynamicSparsityPattern space_dsp(dof.n_dofs_space());
+    dealii::DoFTools::make_sparsity_pattern(*dof.spatial(),
+                                            space_couplings,
+                                            space_dsp,
+                                            *space_constraints,
+                                            keep_constrained_dofs);
 
-        return spacetime_relevant_dofs;
-    }
+    dealii::DynamicSparsityPattern time_dsp(dof.n_dofs_time());
+    internal::upwind_temporal_pattern(dof, time_dsp);
 
-}
+    for (auto &space_entry : space_dsp)
+      {
+        for (auto &time_entry : time_dsp)
+          {
+            st_dsp.add(time_entry.row() * dof.n_dofs_space() +
+                         space_entry.row(), // test function
+                       time_entry.column() * dof.n_dofs_space() +
+                         space_entry.column() // trial function
+            );
+          }
+      }
+  }
+
+  /**
+   * @brief Construction of a sparsity pattern with upper off diagonal jump terms.
+   *
+   * This functions constructs the tensor product between
+   * a spatial sparsity pattern and a temporal upwind sparsity.
+   *
+   * The spatial pattern is constructed by calling the function
+   * make_sparsity_pattern()
+   * with the spatial DoFHandler of @p dof, the @p space_contraints and @p keep_constrained_dofs.
+   *
+   * The temporal pattern is initially constructed as a block-diagonal sparsity
+   * pattern
+   * by the corresponding deal.II method for the temporal DoFHandler of @p dof.
+   * If the number of temporal elements in this slab is greater than one,
+   * additional off diagonal entries for the jump terms between a temporal
+   * element and its direct right/later neighbor are added.
+   *
+   * For Gauss-Lobatto support points in time this is only a coupling between
+   * the final temporal dof of the current element and
+   * the initial temporal dof of the neighbor.
+   *
+   * For Gauss-Legendre support points in time this is the complete first upper
+   * off diagonal block.
+   *
+   * @param dof A shared pointer to the DoFHandler object to base the patterns on.
+   * @param st_dsp The dynamic sparsity pattern that will afterwards include the spacetime pattern.
+   * @param space_constraints The spatial constraints handed to the spatial pattern function
+   * @param keep_constrained_dofs When using distribute_local_to_global() of the spacetime constraints
+   * off diagonal entries of constrained dofs will not be written. So it is
+   * possible to not include these in the sparsity pattern. For more details see
+   * the functions in the dealii::DoFTools namespace.
+   */
+  template <int dim>
+  void
+  make_downwind_sparsity_pattern(
+    DoFHandler<dim>                                   &dof,
+    dealii::DynamicSparsityPattern                    &st_dsp,
+    std::shared_ptr<dealii::AffineConstraints<double>> space_constraints =
+      std::make_shared<dealii::AffineConstraints<double>>(),
+    const bool keep_constrained_dofs = true)
+  {
+    dealii::DynamicSparsityPattern space_dsp(dof.n_dofs_space());
+    dealii::DoFTools::make_sparsity_pattern(*dof.spatial(),
+                                            space_dsp,
+                                            *space_constraints,
+                                            keep_constrained_dofs);
+
+    dealii::DynamicSparsityPattern time_dsp(dof.n_dofs_time());
+    internal::downwind_temporal_pattern(dof, time_dsp);
+
+    for (auto &space_entry : space_dsp)
+      {
+        for (auto &time_entry : time_dsp)
+          {
+            st_dsp.add(time_entry.row() * dof.n_dofs_space() +
+                         space_entry.row(), // test function
+                       time_entry.column() * dof.n_dofs_space() +
+                         space_entry.column() // trial function
+            );
+          }
+      }
+  }
+  /**
+   * @brief Construction of a sparsity pattern with upper off diagonal jump terms.
+   *
+   * This functions works like the previous one but the spatial pattern is
+   * constructed using the supplied couplings.
+   * @param space_couplings In coupled problems some components
+   * don't couple in the weak formulation and consequently don't needs
+   * entries in the sparsity pattern.
+   *
+   * An example would be the Stokes system where pressure ansatz function is not
+   * multiplied by the pressure test function, which leads to an empty diagonal
+   * block.
+   */
+  template <int dim>
+  void
+  make_downwind_sparsity_pattern(
+    DoFHandler<dim>                                    &dof,
+    const dealii::Table<2, dealii::DoFTools::Coupling> &space_couplings,
+    dealii::DynamicSparsityPattern                     &st_dsp,
+    std::shared_ptr<dealii::AffineConstraints<double>>  space_constraints =
+      std::make_shared<dealii::AffineConstraints<double>>(),
+    const bool keep_constrained_dofs = true)
+  {
+    dealii::DynamicSparsityPattern space_dsp(dof.n_dofs_space());
+    dealii::DoFTools::make_sparsity_pattern(*dof.spatial(),
+                                            space_couplings,
+                                            space_dsp,
+                                            *space_constraints,
+                                            keep_constrained_dofs);
+
+    dealii::DynamicSparsityPattern time_dsp(dof.n_dofs_time());
+    internal::downwind_temporal_pattern(dof, time_dsp);
+
+    for (auto &space_entry : space_dsp)
+      {
+        for (auto &time_entry : time_dsp)
+          {
+            st_dsp.add(time_entry.row() * dof.n_dofs_space() +
+                         space_entry.row(), // test function
+                       time_entry.column() * dof.n_dofs_space() +
+                         space_entry.column() // trial function
+            );
+          }
+      }
+  }
+
+  /**
+   * @brief Construction of space-time hanging node constraints.
+   *
+   * This function internally constructs spatial hanging node constraints based
+   * on the spatial part of @dof_handler.
+   *
+   * The spacetime constraints are then obtained by offsetting the constraints
+   * by the total number of dofs in the spatial dof handler.
+   *
+   * @param dof_handler
+   * @param spacetime_constraints
+   */
+  template <int dim, typename Number>
+  void
+  make_hanging_node_constraints(
+    idealii::slab::DoFHandler<dim>                    &dof_handler,
+    std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints)
+  {
+    auto space_constraints =
+      std::make_shared<dealii::AffineConstraints<Number>>();
+    dealii::DoFTools::make_hanging_node_constraints(*dof_handler.spatial(),
+                                                    *space_constraints);
+
+    unsigned int n_space_dofs = dof_handler.n_dofs_space();
+    for (unsigned int time_dof = 0; time_dof < dof_handler.n_dofs_time();
+         time_dof++)
+      {
+        for (unsigned int i = 0; i < n_space_dofs; i++)
+          {
+            if (space_constraints->is_constrained(i))
+              {
+                const std::vector<
+                  std::pair<dealii::types::global_dof_index, double>> *entries =
+                  space_constraints->get_constraint_entries(i);
+                spacetime_constraints->add_line(i + time_dof * n_space_dofs);
+                // non Dirichlet constraint
+                if (entries->size() > 0)
+                  {
+                    for (auto entry : *entries)
+                      {
+                        spacetime_constraints->add_entry(
+                          i + time_dof * n_space_dofs,
+                          entry.first + time_dof * n_space_dofs,
+                          entry.second);
+                      }
+                  }
+                else
+                  {
+                    spacetime_constraints->set_inhomogeneity(
+                      i + time_dof * n_space_dofs,
+                      space_constraints->get_inhomogeneity(i));
+                  }
+              }
+          }
+      }
+  }
+
+  /**
+   * @brief Construction of parallel distributed space-time hanging node constraints.
+   *
+   * This function internally constructs spatial hanging node constraints based
+   * on the spatial part of @dof_handler.
+   *
+   * The spacetime constraints are then obtained by offsetting the constraints
+   * by the total number of dofs in the spatial dof handler.
+   *
+   * @param dof_handler
+   * @param spacetime_constraints
+   */
+  template <int dim, typename Number>
+  void
+  make_hanging_node_constraints(
+    dealii::IndexSet                                  &space_relevant_dofs,
+    idealii::slab::DoFHandler<dim>                    &dof_handler,
+    std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints)
+  {
+    auto space_constraints =
+      std::make_shared<dealii::AffineConstraints<Number>>();
+    space_constraints->reinit(space_relevant_dofs);
+    dealii::DoFTools::make_hanging_node_constraints(*dof_handler.spatial(),
+                                                    *space_constraints);
+
+    unsigned int n_space_dofs = dof_handler.n_dofs_space();
+    for (unsigned int time_dof = 0; time_dof < dof_handler.n_dofs_time();
+         time_dof++)
+      {
+        for (auto id = space_relevant_dofs.begin();
+             id != space_relevant_dofs.end();
+             id++)
+          {
+            if (space_constraints->is_constrained(*id))
+              {
+                const std::vector<
+                  std::pair<dealii::types::global_dof_index, double>> *entries =
+                  space_constraints->get_constraint_entries(*id);
+
+                spacetime_constraints->add_line(*id + time_dof * n_space_dofs);
+                // non Dirichlet constraint
+                if (entries->size() > 0)
+                  {
+                    for (auto entry : *entries)
+                      {
+                        spacetime_constraints->add_entry(
+                          *id + time_dof * n_space_dofs,
+                          entry.first + time_dof * n_space_dofs,
+                          entry.second);
+                      }
+                  }
+                else
+                  {
+                    spacetime_constraints->set_inhomogeneity(
+                      *id + time_dof * n_space_dofs,
+                      space_constraints->get_inhomogeneity(*id));
+                  }
+              }
+          }
+      }
+  }
+
+  /**
+   * @brief Extract global space-time dof indices active on the current DoFHandler.
+   *
+   * For DoFHandlers with a parallel triangulation this function returns the
+   * locally owned dofs and all dofs belonging to other processors that are
+   * located at a locally owned cell.s
+   */
+  template <int dim>
+  dealii::IndexSet
+  extract_locally_relevant_dofs(slab::DoFHandler<dim> &dof_handler)
+  {
+    dealii::IndexSet space_relevant_dofs;
+    dealii::DoFTools::extract_locally_relevant_dofs(*dof_handler.spatial(),
+                                                    space_relevant_dofs);
+
+    dealii::IndexSet spacetime_relevant_dofs(space_relevant_dofs.size() *
+                                             dof_handler.n_dofs_time());
+
+    for (dealii::types::global_dof_index time_dof_index = 0;
+         time_dof_index < dof_handler.n_dofs_time();
+         time_dof_index++)
+      {
+        spacetime_relevant_dofs.add_indices(
+          space_relevant_dofs,
+          time_dof_index * dof_handler.n_dofs_space() // offset
+        );
+      }
+
+    return spacetime_relevant_dofs;
+  }
+
+} // namespace idealii::slab::DoFTools
 
 #endif /* INCLUDE_IDEAL_II_DOFS_SLAB_DOF_TOOLS_HH_ */

--- a/include/ideal.II/dofs/spacetime_dof_handler.hh
+++ b/include/ideal.II/dofs/spacetime_dof_handler.hh
@@ -16,69 +16,75 @@
 #ifndef INCLUDE_IDEAL_II_DOFS_SPACETIME_DOF_HANDLER_HH_
 #define INCLUDE_IDEAL_II_DOFS_SPACETIME_DOF_HANDLER_HH_
 
-#include <ideal.II/grid/spacetime_tria.hh>
 #include <ideal.II/distributed/spacetime_tria.hh>
+
 #include <ideal.II/dofs/slab_dof_handler.hh>
+
+#include <ideal.II/grid/spacetime_tria.hh>
 
 namespace idealii::spacetime
 {
+  /**
+   * @brief The spacetime dofhandler object.
+   *
+   * In practice this is just a class around a list of shared pointers to
+   * slab::DoFHandler objects to simplify generation and time marching.
+   */
+  template <int dim>
+  class DoFHandler
+  {
+  public:
     /**
-     * @brief The spacetime dofhandler object.
+     * @brief Constructor based on spacetime::Triangulation.
      *
-     * In practice this is just a class around a list of shared pointers to
-     * slab::DoFHandler objects to simplify generation and time marching.
+     * @param tria The spacetime::Triangulation object to use in construction of the underlying handlers.
      */
-    template<int dim>
-    class DoFHandler
-    {
-    public:
-        /**
-         * @brief Constructor based on spacetime::Triangulation.
-         *
-         * @param tria The spacetime::Triangulation object to use in construction of the underlying handlers.
-         */
-        DoFHandler ( spacetime::Triangulation<dim> *tria );
+    DoFHandler(spacetime::Triangulation<dim> *tria);
 
 #ifdef DEAL_II_WITH_MPI
-        /**
-         * @brief Constructor based on parallel::distributed::spacetime::Triangulation.
-         *
-         * @param tria The parallel::distributed::spacetime::Triangulation object to use in construction of the underlying handlers.
-         */
-        DoFHandler(spacetime::parallel::distributed::Triangulation<dim>* tria);
+    /**
+     * @brief Constructor based on parallel::distributed::spacetime::Triangulation.
+     *
+     * @param tria The parallel::distributed::spacetime::Triangulation object to use in construction of the underlying handlers.
+     */
+    DoFHandler(spacetime::parallel::distributed::Triangulation<dim> *tria);
 #endif
-        /**
-         * @brief generate all slab::DofHandler objects.
-         *
-         * This function iterates over all slab::Triangulation objects in the
-         * underlying triangulation and constructs one slab::DoFHandler for each.
-         */
-        void generate ();
+    /**
+     * @brief generate all slab::DofHandler objects.
+     *
+     * This function iterates over all slab::Triangulation objects in the
+     * underlying triangulation and constructs one slab::DoFHandler for each.
+     */
+    void
+    generate();
 
-        /**
-         * @brief The number of slabs.
-         * @return The size of the underlying list.
-         */
-        unsigned int M ();
+    /**
+     * @brief The number of slabs.
+     * @return The size of the underlying list.
+     */
+    unsigned int
+    M();
 
-        /**
-         * @brief An iterator pointing to the first slab::DoFHandler.
-         * @return The result of the begin() call to the underlying list.
-         */
-        slab::DoFHandlerIterator<dim>  begin ();
-        /**
-         * @brief An iterator pointing behind the last slab::DoFHandler.
-         * @return The result of the end() call to the underlying list.
-         */
-        slab::DoFHandlerIterator<dim> end ();
+    /**
+     * @brief An iterator pointing to the first slab::DoFHandler.
+     * @return The result of the begin() call to the underlying list.
+     */
+    slab::DoFHandlerIterator<dim>
+    begin();
+    /**
+     * @brief An iterator pointing behind the last slab::DoFHandler.
+     * @return The result of the end() call to the underlying list.
+     */
+    slab::DoFHandlerIterator<dim>
+    end();
 
-    protected:
-        Triangulation<dim> *_tria;
+  protected:
+    Triangulation<dim> *_tria;
 #ifdef DEAL_II_WITH_MPI
-        spacetime::parallel::distributed::Triangulation<dim> *_par_dist_tria;
+    spacetime::parallel::distributed::Triangulation<dim> *_par_dist_tria;
 #endif
-        std::list<slab::DoFHandler<dim>> _dof_handlers;
-    };
-}
+    std::list<slab::DoFHandler<dim>> _dof_handlers;
+  };
+} // namespace idealii::spacetime
 
 #endif /* INCLUDE_IDEAL_II_DOFS_FIXED_DOF_HANDLER_HH_ */

--- a/include/ideal.II/fe/fe_dg.hh
+++ b/include/ideal.II/fe/fe_dg.hh
@@ -23,88 +23,88 @@
 
 namespace idealii::spacetime
 {
-    template<int dim>
+  template <int dim>
+  /**
+   * @brief A class for dG elements in time and arbitrary elements in space.
+   *
+   * This class implements a tensor product finite element of a discontinuous
+   * Galerkin temporal element and a user supplied spatial element.
+   * For the temporal element both GaussLegendre and GaussLobatto support points
+   * can be chosen
+   **/
+  class DG_FiniteElement
+  {
+  public:
+    // Info/Todo: With proper Quadrature class could be extended to RaudauLeft
+    // and RadauRight Would need Radau based on Legendre polynomial roots
     /**
-     * @brief A class for dG elements in time and arbitrary elements in space.
+     * @brief Choice of underlying temporal support points.
      *
-     * This class implements a tensor product finite element of a discontinuous
-     * Galerkin temporal element and a user supplied spatial element.
-     * For the temporal element both GaussLegendre and GaussLobatto support points
-     * can be chosen
-     **/
-    class DG_FiniteElement
+     * Allows the choice between GaussLobatto and GaussLegendre support points
+     * for the dG(r) elements in time.
+     *
+     * The choice of #Lobatto results in 1D dG elements as defined in FE_DGQ.
+     *
+     * The choice of #Legendre leads to dG elements without support points on
+     * the interval/element edges. This might lead to better convergence, but
+     * the resulting off-diagonal sparsity pattern will be larger as jump terms
+     * then depend on all temporal dofs.
+     *
+     * For r=0 the resulting element always uses the interval midpoint.
+     */
+    enum support_type
     {
-    public:
-        //Info/Todo: With proper Quadrature class could be extended to RaudauLeft and RadauRight
-        //Would need Radau based on Legendre polynomial roots
-        /**
-         * @brief Choice of underlying temporal support points.
-         *
-         * Allows the choice between GaussLobatto and GaussLegendre support points
-         * for the dG(r) elements in time.
-         *
-         * The choice of #Lobatto results in 1D dG elements as defined in FE_DGQ.
-         *
-         * The choice of #Legendre leads to dG elements without support points on the
-         * interval/element edges. This might lead to better convergence, but the
-         * resulting off-diagonal sparsity pattern will be larger as jump terms
-         * then depend on all temporal dofs.
-         *
-         * For r=0 the resulting element always uses the interval midpoint.
-         */
-        enum support_type
-        {
-            /**Support points based on QGauss<1>*/
-            Legendre,
-            /**for dG(r), r>0: Support points based on QGaussLobatto<1>*/
-            Lobatto,
-            /**Support points based on left QGaussRadau<1>*/
-            RadauLeft,
-            /**Support points based on right QGaussRadau<1>*/
-            RadauRight
-        };
-        /**
-         * @brief Constructor for the finite element class.
-         */
-        DG_FiniteElement (
-                std::shared_ptr<dealii::FiniteElement<dim>> fe_space ,
-                const unsigned int r , support_type type =
-                        support_type::Lobatto );
-        /**
-         * @brief The underlying spatial finite element.
-         * @return A shared pointer to the underlying finite element object.
-         */
-        std::shared_ptr<dealii::FiniteElement<dim>>
-        spatial ();
-        /**
-         * @brief The underlying temporal finite element.
-         * @return A shared pointer to the underlying finite element object.
-         */
-        std::shared_ptr<dealii::FiniteElement<1>>
-        temporal ();
-        /**
-         * @brief The number of degrees of freedom per space-time element.
-         *
-         * In practice this is simply (r+1) times the number of DoFs per spatial element.
-         * @return temporal()->dofs_per_cell * spatial()->dofs_per_cell
-         */
-        const unsigned int dofs_per_cell;
-        /**
-         * @brief The #support_type used for construction.
-         *
-         * This function is mostly used internally. One example would be the construction
-         * of the upstream and downstream sparsity patterns,
-         * which include off diagonals for jump terms.
-         * @return The underlying #support_type
-         */
-        support_type
-        type ();
-    private:
-        std::shared_ptr<dealii::FiniteElement<dim>> _fe_space;
-        std::shared_ptr<dealii::FiniteElement<1>> _fe_time;
-        support_type _type;
-
+      /**Support points based on QGauss<1>*/
+      Legendre,
+      /**for dG(r), r>0: Support points based on QGaussLobatto<1>*/
+      Lobatto,
+      /**Support points based on left QGaussRadau<1>*/
+      RadauLeft,
+      /**Support points based on right QGaussRadau<1>*/
+      RadauRight
     };
-} //end namespaces
+    /**
+     * @brief Constructor for the finite element class.
+     */
+    DG_FiniteElement(std::shared_ptr<dealii::FiniteElement<dim>> fe_space,
+                     const unsigned int                          r,
+                     support_type type = support_type::Lobatto);
+    /**
+     * @brief The underlying spatial finite element.
+     * @return A shared pointer to the underlying finite element object.
+     */
+    std::shared_ptr<dealii::FiniteElement<dim>>
+    spatial();
+    /**
+     * @brief The underlying temporal finite element.
+     * @return A shared pointer to the underlying finite element object.
+     */
+    std::shared_ptr<dealii::FiniteElement<1>>
+    temporal();
+    /**
+     * @brief The number of degrees of freedom per space-time element.
+     *
+     * In practice this is simply (r+1) times the number of DoFs per spatial
+     * element.
+     * @return temporal()->dofs_per_cell * spatial()->dofs_per_cell
+     */
+    const unsigned int dofs_per_cell;
+    /**
+     * @brief The #support_type used for construction.
+     *
+     * This function is mostly used internally. One example would be the
+     * construction of the upstream and downstream sparsity patterns, which
+     * include off diagonals for jump terms.
+     * @return The underlying #support_type
+     */
+    support_type
+    type();
+
+  private:
+    std::shared_ptr<dealii::FiniteElement<dim>> _fe_space;
+    std::shared_ptr<dealii::FiniteElement<1>>   _fe_time;
+    support_type                                _type;
+  };
+} // namespace idealii::spacetime
 
 #endif /* INCLUDE_IDEAL_II_FE_FE_DG_HH_ */

--- a/include/ideal.II/fe/spacetime_fe_values.hh
+++ b/include/ideal.II/fe/spacetime_fe_values.hh
@@ -17,6 +17,7 @@
 #define INCLUDE_IDEAL_II_FE_SPACETIME_FE_VALUES_HH_
 
 #include <ideal.II/base/quadrature_lib.hh>
+
 #include <ideal.II/fe/fe_dg.hh>
 
 #include <deal.II/fe/fe_values.h>
@@ -24,560 +25,629 @@
 namespace idealii::spacetime
 {
 
+  /**
+   * @brief Evaluation of the tensor-product space-time basis functions.
+   *
+   * This class supplies common derivatives of the space-time basis functions by
+   * multiplying the corresponding spatial and temporal basis functions in the
+   * given quadrature points.
+   *
+   * In practice spatial derivatives are handled by the underlying spatial
+   * dealii::FEValues object and temporal derivatives are handled by the
+   * underlying temporal dealii::FEValues.
+   */
+  template <int dim>
+  class FEValues
+  {
+  public:
     /**
-     * @brief Evaluation of the tensor-product space-time basis functions.
+     * @brief Constructor of the FEValues class.
      *
-     * This class supplies common derivatives of the space-time basis functions by
-     * multiplying the corresponding spatial and temporal basis functions in the
-     * given quadrature points.
-     *
-     * In practice spatial derivatives are handled by the underlying spatial dealii::FEValues
-     * object and temporal derivatives are handled by the underlying temporal dealii::FEValues.
+     * @param fe: The underlying space-time finite element description class.
+     * @param quad: The space-time quadrature formula to be used.
+     * @param uflags: The update flags to be used during the reinit calls.
      */
-    template<int dim>
-        class FEValues
-        {
-        public:
-            /**
-             * @brief Constructor of the FEValues class.
-             *
-             * @param fe: The underlying space-time finite element description class.
-             * @param quad: The space-time quadrature formula to be used.
-             * @param uflags: The update flags to be used during the reinit calls.
-             */
-            FEValues ( DG_FiniteElement<dim> &fe ,
-                       Quadrature<dim> &quad ,
-                       const dealii::UpdateFlags uflags );
-
-            /**
-             * @brief Reinitialize all objects of the underlying spatial FEValues object.
-             * This function calls reinit(cell_space) of the spatial FEValues object.
-             * @param cell_space Iterator pointing to the current element in space.
-             */
-            void reinit_space (
-                const typename dealii::TriaIterator<dealii::DoFCellAccessor<dim,dim,false>> &cell_space );
-            /**
-             * @brief Reinitialize all objects of the underlying temporal FEValues object.
-             * This function calls reinit(cell_time) of the temporal FEValues object.
-             * @param cell_time Iterator pointing to the current element in time.
-             */
-            void reinit_time (
-                const typename dealii::TriaIterator< dealii::DoFCellAccessor<1,1,false>> &cell_time );
-
-            /**
-             * @brief Value of the space-time shape function at spacetime-quadrature point.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            double shape_value ( unsigned int function_no ,
-                                 unsigned int point_no );
-
-            /**
-             * @brief Temporal derivative of the space-time shape function at spacetime-quadrature point.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            double shape_dt ( unsigned int function_no ,
-                              unsigned int point_no );
-
-            /**
-             * @brief Spatial derivative of the space-time shape function at spacetime-quadrature point.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            dealii::Tensor<1,dim> shape_space_grad ( unsigned int function_no ,
-                                                     unsigned int point_no );
-
-            /**
-             * @brief Function values of a given vector at all quadrature points
-             * @in fe_function
-             * @out values
-             */
-            template<class InputVector>
-            void get_function_values(const InputVector& fe_function,
-                                     std::vector<dealii::Vector<typename InputVector::value_type>>& values)
-            const;
-
-            /**
-             * @brief Function values of a given vector at all quadrature points
-             * @in fe_function
-             * @out values
-             */
-            template<class InputVector>
-            void get_function_dt(const InputVector& fe_function,
-                                 std::vector<dealii::Vector<typename InputVector::value_type>>& values)
-            const;
-
-            /**
-             * @brief Spatial function gradients of a given vector at all quadrature points
-             * @in fe_function
-             * @out values
-             */
-            template<class InputVector>
-            void get_function_space_gradients(const InputVector& fe_function,
-                                              std::vector<std::vector<dealii::Tensor<1,dim,typename InputVector::value_type>>>& gradients)
-            const;
-
-
-            /**
-             * @brief Value of the space-time shape function of a scalar finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the value function of the resulting view.
-             * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Scalar<dim>::value_type
-            scalar_value ( const typename dealii::FEValuesExtractors::Scalar &extractor ,
-                           unsigned int function_no ,
-                           unsigned int point_no );
-
-            /**
-             * @brief Temporal derivative of the space-time shape function of a scalar finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the value function of the resulting view.
-             * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Scalar<dim>::value_type
-            scalar_dt (
-                        const typename dealii::FEValuesExtractors::Scalar &extractor ,
-                        unsigned int function_no ,
-                        unsigned int point_no );
-            /**
-             * @brief Spatial derivative of the space-time shape function of a scalar finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the gradient function of the resulting view.
-             * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Scalar<dim>::gradient_type
-            scalar_space_grad ( const typename dealii::FEValuesExtractors::Scalar &extractor ,
-                                unsigned int function_no , unsigned int point_no );
-
-            /**
-             * @brief Value of the space-time shape function of a vector-valued finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the value function of the resulting view.
-             * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Vector<dim>::value_type
-            vector_value ( const typename dealii::FEValuesExtractors::Vector &extractor ,
-                           unsigned int function_no , unsigned int point_no );
-
-            /**
-             * @brief Temporal derivative of the space-time shape function of a vector-valued finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the value function of the resulting view.
-             * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Vector<dim>::value_type
-            vector_dt ( const typename dealii::FEValuesExtractors::Vector &extractor ,
-                        unsigned int function_no , unsigned int point_no );
-
-            /**
-             * @brief Spatial divergence of the space-time shape function of a vector-valued finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the value function of the resulting view.
-             * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Vector<dim>::divergence_type
-            vector_divergence ( const typename dealii::FEValuesExtractors::Vector &extractor ,
-                                unsigned int function_no , unsigned int point_no );
-
-            /**
-             * @brief Spatial gradient of the space-time shape function of a vector-valued finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the gradient function of the resulting view.
-             * @param extractor Vector extractor defining the vector finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Vector<dim>::gradient_type
-            vector_space_grad ( const typename dealii::FEValuesExtractors::Vector &extractor ,
-                                unsigned int function_no , unsigned int point_no );
-
-            /**
-             * @brief Spatial curl of the space-time shape function of a vector-valued finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the curl function of the resulting view.
-             * @param extractor Vector extractor defining the vector finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Vector<dim>::curl_type
-            vector_space_curl ( const typename dealii::FEValuesExtractors::Vector &extractor ,
-                                unsigned int function_no , unsigned int point_no );
-
-            /**
-             * @brief Get the temporal quadrature point of the given space-time quadrature index.
-             * @param quadrature_point space-time quadrature index.
-             */
-            double time_quadrature_point ( unsigned int quadrature_point );
-
-            /**
-             * @brief Get the spatial quadrature point of the given space-time quadrature index.
-             * @param quadrature_point space-time quadrature index.
-             */
-            dealii::Point<dim> space_quadrature_point ( unsigned int quadrature_point );
-
-            /**
-             * @brief Mapped space-time quadrature weight.
-             * @param quadrature_point space-time quadrature index.
-             */
-            double JxW ( const unsigned int quadrature_point );
-            /**
-             * @brief Local space-time DoF indices of the current space-time element.
-             * @param A vector of indices to save the result to.
-             */
-            void get_local_dof_indices ( std::vector<dealii::types::global_dof_index> &indices );
-
-            /**
-             * @brief The underlying spatial FEValues object.
-             * @return A shared pointer to the spatial FEValues object.
-             */
-            std::shared_ptr<dealii::FEValues<dim>> spatial ();
-            /**
-             * @brief The underlying temporal FEValues object.
-             * @return A shared pointer to the temporal FEValues object.
-             */
-            std::shared_ptr<dealii::FEValues<1>> temporal ();
-
-        private:
-            DG_FiniteElement<dim> &_fe;
-            Quadrature<dim> &_quad;
-
-            std::shared_ptr<dealii::FEValues<dim>> _fev_space;
-            std::shared_ptr<dealii::FEValues<1>> _fev_time;
-
-            std::vector<dealii::types::global_dof_index> local_space_dof_index;
-            std::vector<dealii::types::global_dof_index> local_time_dof_index;
-
-            unsigned int n_dofs_space;
-            unsigned int time_cell_index;
-            const unsigned int n_dofs_space_cell;
-            const unsigned int n_quads_space;
-            public:
-            /**
-             * @brief Number of space-time quadrature points per element.
-             */
-            unsigned int n_quadrature_points;
-        };
+    FEValues(DG_FiniteElement<dim>    &fe,
+             Quadrature<dim>          &quad,
+             const dealii::UpdateFlags uflags);
 
     /**
-     * @brief Evaluation of the tensor-product space-time basis functions at the temporal element edges.
-     *
-     * This class supplies the limits from above and below of the space-time basis functions by
-     * multiplying the corresponding spatial basis functions in the
-     * given spatial quadrature points by the left or right face_values of the temporal basis functions.
-     *
-     * In practice spatial values are handled by the underlying spatial dealii::FEValues
-     * object and temporal limits are handled by the underlying temporal dealii::FEValues with two point Lobatto quadrature.
+     * @brief Reinitialize all objects of the underlying spatial FEValues object.
+     * This function calls reinit(cell_space) of the spatial FEValues object.
+     * @param cell_space Iterator pointing to the current element in space.
      */
-    template<int dim>
-        class FEJumpValues
-        {
-        public:
-            /**
-             * @brief Constructor of the FEJumpValues class.
-             *
-             * @param fe: The underlying space-time finite element description class.
-             * @param quad: The space-time quadrature formula to be used.
-             * @param uflags: The update flags to be used during the reinit calls.
-             */
-            FEJumpValues ( DG_FiniteElement<dim> &fe , Quadrature<dim> &quad ,
-                           const dealii::UpdateFlags uflags );
-
-            /**
-             * @brief Reinitialize all objects of the underlying spatial FEValues object.
-             * This function calls reinit(cell_space) of the spatial FEValues object.
-             * @param cell_space Iterator pointing to the current element in space.
-             */
-            void reinit_space (
-                const typename dealii::TriaIterator<dealii::DoFCellAccessor<dim,dim,false>> &cell_space );
-
-            /**
-             * @brief Reinitialize all objects of the underlying temporal FEValues object.
-             * This function calls reinit(cell_time) of the temporal FEValues object.
-             * @param cell_time Iterator pointing to the current element in time.
-             */
-            void reinit_time (
-               const typename dealii::TriaIterator<dealii::DoFCellAccessor<1,1,false>> &cell_time );
-
-            /**
-             * @brief Value of the limit from above of the space-time shape function at the spatial quadrature point.
-             *
-             * The temporal value is evaluated at the left point of the unit element i.e. 0.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            double shape_value_plus ( unsigned int function_no ,
-                                      unsigned int point_no );
-
-            /**
-             * @brief Value of the limit from below of the space-time shape function at the spatial quadrature point.
-             *
-             * The temporal value is evaluated at the right point of the unit element i.e. 1.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            double shape_value_minus ( unsigned int function_no ,
-                                       unsigned int point_no );
-
-            /**
-             * @brief Left temporal limit from below of function values of a given vector at all space quadrature points
-             * @in fe_function
-             * @out values
-             */
-            template<class InputVector>
-            void get_function_values_minus(const InputVector& fe_function,
-                                     std::vector<dealii::Vector<typename InputVector::value_type>>& values)
-            const;
-
-            /**
-             * @brief Left temporal limit from above of function values of a given vector at all space quadrature points
-             * @in fe_function
-             * @out values
-             */
-            template<class InputVector>
-            void get_function_values_plus(const InputVector& fe_function,
-                                     std::vector<dealii::Vector<typename InputVector::value_type>>& values)
-            const;
-
-            /**
-             * @brief Value of the limit from above of the space-time shape function of a scalar finite element component.
-             *
-             * The temporal value is evaluated at the left point of the unit element i.e. 0.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Scalar<dim>::value_type
-            scalar_value_plus ( const typename dealii::FEValuesExtractors::Scalar &extractor ,
-                                unsigned int function_no , unsigned int point_no );
-
-            /**
-             * @brief Value of the limit from bewlo of the space-time shape function of a scalar finite element component.
-             *
-             * The temporal value is evaluated at the right point of the unit element i.e. 1.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Scalar<dim>::value_type
-            scalar_value_minus (
-                                 const typename dealii::FEValuesExtractors::Scalar &extractor ,
-                                 unsigned int function_no , unsigned int point_no );
-
-            /**
-             * @brief Value of the limit from above of the space-time shape function of a vector-valued finite element component.
-             *
-             * The temporal value is evaluated at the left point of the unit element i.e. 0.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Vector<dim>::value_type
-            vector_value_plus ( const typename dealii::FEValuesExtractors::Vector &extractor ,
-                                unsigned int function_no , unsigned int points_no );
-
-            /**
-             * @brief Value of the limit from below of the space-time shape function of a vector-valued finite element component.
-             *
-             * The temporal value is evaluated at the right point of the unit element i.e. 1.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Vector<dim>::value_type
-            vector_value_minus ( const typename dealii::FEValuesExtractors::Vector &extractor ,
-                                 unsigned int function_no , unsigned int point_no );
-            /**
-             * @brief The underlying spatial FEValues object.
-             * @return A shared pointer to the spatial FEValues object.
-             */
-            std::shared_ptr<dealii::FEValues<dim>> spatial ();
-
-            /**
-             * @brief The underlying temporal FEValues object.
-             * @return A shared pointer to the temporal FEValues object.
-             */
-            std::shared_ptr<dealii::FEValues<1>> temporal ();
-
-            /**
-             * @brief Mapped space-time quadrature weight.
-             * @param quadrature_point space-time quadrature index.
-             */
-            double JxW ( const unsigned int quadrature_point );
-
-            /**
-             * @brief Number of spatial quadrature points per element.
-             */
-            unsigned int n_quadrature_points;
-            private:
-            unsigned int n_dofs_space;
-            DG_FiniteElement<dim> &_fe;
-            Quadrature<dim> &_quad;
-
-            std::shared_ptr<dealii::FEValues<dim>> _fev_space;
-            std::shared_ptr<dealii::FEValues<1>> _fev_time;
-
-            std::vector<dealii::types::global_dof_index> local_space_dof_index;
-            std::vector<dealii::types::global_dof_index> local_time_dof_index;
-        };
+    void
+    reinit_space(const typename dealii::TriaIterator<
+                 dealii::DoFCellAccessor<dim, dim, false>> &cell_space);
+    /**
+     * @brief Reinitialize all objects of the underlying temporal FEValues object.
+     * This function calls reinit(cell_time) of the temporal FEValues object.
+     * @param cell_time Iterator pointing to the current element in time.
+     */
+    void
+    reinit_time(
+      const typename dealii::TriaIterator<dealii::DoFCellAccessor<1, 1, false>>
+        &cell_time);
 
     /**
-     * @brief Evaluation of the tensor-product space-time basis functions on spatial element faces.
-     *
-     * This class supplies common derivatives of the space-time basis functions by
-     * multiplying the corresponding spatial and temporal basis functions in the
-     * given quadrature points.
-     *
-     * In practice spatial derivatives are handled by the underlying spatial dealii::FEFaceValues
-     * object and temporal derivatives are handled by the underlying temporal dealii::FEValues.
+     * @brief Value of the space-time shape function at spacetime-quadrature point.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
      */
-    template<int dim>
-        class FEFaceValues
-        {
-        public:
-            /**
-             * @brief Constructor of the FEValues class.
-             *
-             * @param fe: The underlying space-time finite element description class.
-             * @param quad: The space-time quadrature formula to be used.
-             * @param uflags: The update flags to be used during the reinit calls.
-             * @param additional_flags: Additional update flags that are only appended 
-             *                          to the FEFace Object (e.g.: update_normal_vectors)
-             */
-            FEFaceValues ( DG_FiniteElement<dim> &fe ,
-                           Quadrature<dim - 1> &quad ,
-                           const dealii::UpdateFlags uflags ,
-                           const dealii::UpdateFlags additional_flags );
+    double
+    shape_value(unsigned int function_no, unsigned int point_no);
 
-            /**
-             * @brief Reinitialize all objects of the underlying spatial FEValues object.
-             * This function calls reinit(cell_space) of the spatial FEValues object.
-             * @param cell_space Iterator pointing to the current element in space.
-             */
-            void reinit_space (
-                const typename dealii::TriaIterator<dealii::DoFCellAccessor<dim,dim,false>> &cell_space ,
-                const unsigned int face_no );
-            /**
-             * @brief Reinitialize all objects of the underlying temporal FEValues object.
-             * This function calls reinit(cell_time) of the temporal FEValues object.
-             * @param cell_time Iterator pointing to the current element in time.
-             */
-            void reinit_time (
-               const typename dealii::TriaIterator<dealii::DoFCellAccessor<1,1,false>> &cell_time );
+    /**
+     * @brief Temporal derivative of the space-time shape function at spacetime-quadrature point.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    double
+    shape_dt(unsigned int function_no, unsigned int point_no);
 
-            /**
-             * @brief Value of the space-time shape function at spacetime-quadrature point.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            double shape_value ( unsigned int function_no ,
-                                 unsigned int point_no );
+    /**
+     * @brief Spatial derivative of the space-time shape function at spacetime-quadrature point.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    dealii::Tensor<1, dim>
+    shape_space_grad(unsigned int function_no, unsigned int point_no);
 
-            /**
-             * @brief Value of the space-time shape function of a scalar finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the value function of the resulting view.
-             * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Scalar<dim>::value_type
-            scalar_value ( const typename dealii::FEValuesExtractors::Scalar &extractor ,
-                           unsigned int function_no ,
-                           unsigned int point_no );
+    /**
+     * @brief Function values of a given vector at all quadrature points
+     * @in fe_function
+     * @out values
+     */
+    template <class InputVector>
+    void
+    get_function_values(
+      const InputVector &fe_function,
+      std::vector<dealii::Vector<typename InputVector::value_type>> &values)
+      const;
 
-            /**
-             * @brief Value of the space-time shape function of a vector-valued finite element component.
-             *
-             * This function passes the extractor to the underlying spatial FEValues object
-             * and then calls the value function of the resulting view.
-             * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
-             * @param function_no The number of the space-time function/dof to be evaluated.
-             * @param point_no The number of the quadrature point to evaluate at.
-             */
-            typename dealii::FEValuesViews::Vector<dim>::value_type
-            vector_value ( const typename dealii::FEValuesExtractors::Vector &extractor ,
-                           unsigned int function_no ,
-                           unsigned int point_no );
+    /**
+     * @brief Function values of a given vector at all quadrature points
+     * @in fe_function
+     * @out values
+     */
+    template <class InputVector>
+    void
+    get_function_dt(
+      const InputVector &fe_function,
+      std::vector<dealii::Vector<typename InputVector::value_type>> &values)
+      const;
 
-            /**
-             * @brief Get the temporal quadrature point of the given space-time quadrature index.
-             * @param quadrature_point space-time quadrature index.
-             */
-            double time_quadrature_point ( unsigned int quadrature_point );
+    /**
+     * @brief Spatial function gradients of a given vector at all quadrature points
+     * @in fe_function
+     * @out values
+     */
+    template <class InputVector>
+    void
+    get_function_space_gradients(
+      const InputVector &fe_function,
+      std::vector<
+        std::vector<dealii::Tensor<1, dim, typename InputVector::value_type>>>
+        &gradients) const;
 
-            /**
-             * @brief Get the spatial quadrature point of the given space-time quadrature index.
-             * @param quadrature_point space-time quadrature index.
-             */
-            dealii::Point<dim> space_quadrature_point ( unsigned int quadrature_point );
 
-            /**
-             * @brief Get the normal vector at the spatial face.
-             * @param i The space-time index of the quadrature point
-             */
-            const dealii::Tensor<1,dim>& space_normal_vector ( unsigned int i );
+    /**
+     * @brief Value of the space-time shape function of a scalar finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the value function of the resulting view.
+     * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Scalar<dim>::value_type
+    scalar_value(const typename dealii::FEValuesExtractors::Scalar &extractor,
+                 unsigned int                                       function_no,
+                 unsigned int                                       point_no);
 
-            /**
-             * @brief Mapped space-time quadrature weight.
-             * @param quadrature_point space-time quadrature index.
-             */
-            double JxW ( const unsigned int quadrature_point );
-            /**
-             * @brief Local space-time DoF indices of the current space-time element.
-             * @param A vector of indices to save the result to.
-             */
-            void get_local_dof_indices ( std::vector<dealii::types::global_dof_index> &indices );
+    /**
+     * @brief Temporal derivative of the space-time shape function of a scalar finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the value function of the resulting view.
+     * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Scalar<dim>::value_type
+    scalar_dt(const typename dealii::FEValuesExtractors::Scalar &extractor,
+              unsigned int                                       function_no,
+              unsigned int                                       point_no);
+    /**
+     * @brief Spatial derivative of the space-time shape function of a scalar finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the gradient function of the resulting view.
+     * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Scalar<dim>::gradient_type
+    scalar_space_grad(
+      const typename dealii::FEValuesExtractors::Scalar &extractor,
+      unsigned int                                       function_no,
+      unsigned int                                       point_no);
 
-            /**
-             * @brief The underlying spatial FEValues object.
-             * @return A shared pointer to the spatial FEValues object.
-             */
-            std::shared_ptr<dealii::FEFaceValues<dim>> spatial ();
-            /**
-             * @brief The underlying temporal FEValues object.
-             * @return A shared pointer to the temporal FEValues object.
-             */
-            std::shared_ptr<dealii::FEValues<1>> temporal ();
+    /**
+     * @brief Value of the space-time shape function of a vector-valued finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the value function of the resulting view.
+     * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Vector<dim>::value_type
+    vector_value(const typename dealii::FEValuesExtractors::Vector &extractor,
+                 unsigned int                                       function_no,
+                 unsigned int                                       point_no);
 
-        private:
-            DG_FiniteElement<dim> &_fe;
-            Quadrature<dim - 1> &_quad;
+    /**
+     * @brief Temporal derivative of the space-time shape function of a vector-valued finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the value function of the resulting view.
+     * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Vector<dim>::value_type
+    vector_dt(const typename dealii::FEValuesExtractors::Vector &extractor,
+              unsigned int                                       function_no,
+              unsigned int                                       point_no);
 
-            std::shared_ptr<dealii::FEFaceValues<dim>> _fev_space;
-            std::shared_ptr<dealii::FEValues<1>> _fev_time;
+    /**
+     * @brief Spatial divergence of the space-time shape function of a vector-valued finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the value function of the resulting view.
+     * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Vector<dim>::divergence_type
+    vector_divergence(
+      const typename dealii::FEValuesExtractors::Vector &extractor,
+      unsigned int                                       function_no,
+      unsigned int                                       point_no);
 
-            std::vector<dealii::types::global_dof_index> local_space_dof_index;
-            std::vector<dealii::types::global_dof_index> local_time_dof_index;
+    /**
+     * @brief Spatial gradient of the space-time shape function of a vector-valued finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the gradient function of the resulting view.
+     * @param extractor Vector extractor defining the vector finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Vector<dim>::gradient_type
+    vector_space_grad(
+      const typename dealii::FEValuesExtractors::Vector &extractor,
+      unsigned int                                       function_no,
+      unsigned int                                       point_no);
 
-            unsigned int n_dofs_space;
-            unsigned int time_cell_index;
-            const unsigned int n_dofs_space_cell;
-            const unsigned int n_quads_space;
-            public:
-            /**
-             * @brief Number of space-time quadrature points per element.
-             */
-            unsigned int n_quadrature_points;
-        };
-}
+    /**
+     * @brief Spatial curl of the space-time shape function of a vector-valued finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the curl function of the resulting view.
+     * @param extractor Vector extractor defining the vector finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Vector<dim>::curl_type
+    vector_space_curl(
+      const typename dealii::FEValuesExtractors::Vector &extractor,
+      unsigned int                                       function_no,
+      unsigned int                                       point_no);
+
+    /**
+     * @brief Get the temporal quadrature point of the given space-time quadrature index.
+     * @param quadrature_point space-time quadrature index.
+     */
+    double
+    time_quadrature_point(unsigned int quadrature_point);
+
+    /**
+     * @brief Get the spatial quadrature point of the given space-time quadrature index.
+     * @param quadrature_point space-time quadrature index.
+     */
+    dealii::Point<dim>
+    space_quadrature_point(unsigned int quadrature_point);
+
+    /**
+     * @brief Mapped space-time quadrature weight.
+     * @param quadrature_point space-time quadrature index.
+     */
+    double
+    JxW(const unsigned int quadrature_point);
+    /**
+     * @brief Local space-time DoF indices of the current space-time element.
+     * @param A vector of indices to save the result to.
+     */
+    void
+    get_local_dof_indices(
+      std::vector<dealii::types::global_dof_index> &indices);
+
+    /**
+     * @brief The underlying spatial FEValues object.
+     * @return A shared pointer to the spatial FEValues object.
+     */
+    std::shared_ptr<dealii::FEValues<dim>>
+    spatial();
+    /**
+     * @brief The underlying temporal FEValues object.
+     * @return A shared pointer to the temporal FEValues object.
+     */
+    std::shared_ptr<dealii::FEValues<1>>
+    temporal();
+
+  private:
+    DG_FiniteElement<dim> &_fe;
+    Quadrature<dim>       &_quad;
+
+    std::shared_ptr<dealii::FEValues<dim>> _fev_space;
+    std::shared_ptr<dealii::FEValues<1>>   _fev_time;
+
+    std::vector<dealii::types::global_dof_index> local_space_dof_index;
+    std::vector<dealii::types::global_dof_index> local_time_dof_index;
+
+    unsigned int       n_dofs_space;
+    unsigned int       time_cell_index;
+    const unsigned int n_dofs_space_cell;
+    const unsigned int n_quads_space;
+
+  public:
+    /**
+     * @brief Number of space-time quadrature points per element.
+     */
+    unsigned int n_quadrature_points;
+  };
+
+  /**
+   * @brief Evaluation of the tensor-product space-time basis functions at the temporal element edges.
+   *
+   * This class supplies the limits from above and below of the space-time basis
+   * functions by multiplying the corresponding spatial basis functions in the
+   * given spatial quadrature points by the left or right face_values of the
+   * temporal basis functions.
+   *
+   * In practice spatial values are handled by the underlying spatial
+   * dealii::FEValues object and temporal limits are handled by the underlying
+   * temporal dealii::FEValues with two point Lobatto quadrature.
+   */
+  template <int dim>
+  class FEJumpValues
+  {
+  public:
+    /**
+     * @brief Constructor of the FEJumpValues class.
+     *
+     * @param fe: The underlying space-time finite element description class.
+     * @param quad: The space-time quadrature formula to be used.
+     * @param uflags: The update flags to be used during the reinit calls.
+     */
+    FEJumpValues(DG_FiniteElement<dim>    &fe,
+                 Quadrature<dim>          &quad,
+                 const dealii::UpdateFlags uflags);
+
+    /**
+     * @brief Reinitialize all objects of the underlying spatial FEValues object.
+     * This function calls reinit(cell_space) of the spatial FEValues object.
+     * @param cell_space Iterator pointing to the current element in space.
+     */
+    void
+    reinit_space(const typename dealii::TriaIterator<
+                 dealii::DoFCellAccessor<dim, dim, false>> &cell_space);
+
+    /**
+     * @brief Reinitialize all objects of the underlying temporal FEValues object.
+     * This function calls reinit(cell_time) of the temporal FEValues object.
+     * @param cell_time Iterator pointing to the current element in time.
+     */
+    void
+    reinit_time(
+      const typename dealii::TriaIterator<dealii::DoFCellAccessor<1, 1, false>>
+        &cell_time);
+
+    /**
+     * @brief Value of the limit from above of the space-time shape function at the spatial quadrature point.
+     *
+     * The temporal value is evaluated at the left point of the unit element
+     * i.e. 0.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    double
+    shape_value_plus(unsigned int function_no, unsigned int point_no);
+
+    /**
+     * @brief Value of the limit from below of the space-time shape function at the spatial quadrature point.
+     *
+     * The temporal value is evaluated at the right point of the unit element
+     * i.e. 1.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    double
+    shape_value_minus(unsigned int function_no, unsigned int point_no);
+
+    /**
+     * @brief Left temporal limit from below of function values of a given vector at all space quadrature points
+     * @in fe_function
+     * @out values
+     */
+    template <class InputVector>
+    void
+    get_function_values_minus(
+      const InputVector &fe_function,
+      std::vector<dealii::Vector<typename InputVector::value_type>> &values)
+      const;
+
+    /**
+     * @brief Left temporal limit from above of function values of a given vector at all space quadrature points
+     * @in fe_function
+     * @out values
+     */
+    template <class InputVector>
+    void
+    get_function_values_plus(
+      const InputVector &fe_function,
+      std::vector<dealii::Vector<typename InputVector::value_type>> &values)
+      const;
+
+    /**
+     * @brief Value of the limit from above of the space-time shape function of a scalar finite element component.
+     *
+     * The temporal value is evaluated at the left point of the unit element
+     * i.e. 0.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Scalar<dim>::value_type
+    scalar_value_plus(
+      const typename dealii::FEValuesExtractors::Scalar &extractor,
+      unsigned int                                       function_no,
+      unsigned int                                       point_no);
+
+    /**
+     * @brief Value of the limit from bewlo of the space-time shape function of a scalar finite element component.
+     *
+     * The temporal value is evaluated at the right point of the unit element
+     * i.e. 1.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Scalar<dim>::value_type
+    scalar_value_minus(
+      const typename dealii::FEValuesExtractors::Scalar &extractor,
+      unsigned int                                       function_no,
+      unsigned int                                       point_no);
+
+    /**
+     * @brief Value of the limit from above of the space-time shape function of a vector-valued finite element component.
+     *
+     * The temporal value is evaluated at the left point of the unit element
+     * i.e. 0.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Vector<dim>::value_type
+    vector_value_plus(
+      const typename dealii::FEValuesExtractors::Vector &extractor,
+      unsigned int                                       function_no,
+      unsigned int                                       points_no);
+
+    /**
+     * @brief Value of the limit from below of the space-time shape function of a vector-valued finite element component.
+     *
+     * The temporal value is evaluated at the right point of the unit element
+     * i.e. 1.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Vector<dim>::value_type
+    vector_value_minus(
+      const typename dealii::FEValuesExtractors::Vector &extractor,
+      unsigned int                                       function_no,
+      unsigned int                                       point_no);
+    /**
+     * @brief The underlying spatial FEValues object.
+     * @return A shared pointer to the spatial FEValues object.
+     */
+    std::shared_ptr<dealii::FEValues<dim>>
+    spatial();
+
+    /**
+     * @brief The underlying temporal FEValues object.
+     * @return A shared pointer to the temporal FEValues object.
+     */
+    std::shared_ptr<dealii::FEValues<1>>
+    temporal();
+
+    /**
+     * @brief Mapped space-time quadrature weight.
+     * @param quadrature_point space-time quadrature index.
+     */
+    double
+    JxW(const unsigned int quadrature_point);
+
+    /**
+     * @brief Number of spatial quadrature points per element.
+     */
+    unsigned int n_quadrature_points;
+
+  private:
+    unsigned int           n_dofs_space;
+    DG_FiniteElement<dim> &_fe;
+    Quadrature<dim>       &_quad;
+
+    std::shared_ptr<dealii::FEValues<dim>> _fev_space;
+    std::shared_ptr<dealii::FEValues<1>>   _fev_time;
+
+    std::vector<dealii::types::global_dof_index> local_space_dof_index;
+    std::vector<dealii::types::global_dof_index> local_time_dof_index;
+  };
+
+  /**
+   * @brief Evaluation of the tensor-product space-time basis functions on spatial element faces.
+   *
+   * This class supplies common derivatives of the space-time basis functions by
+   * multiplying the corresponding spatial and temporal basis functions in the
+   * given quadrature points.
+   *
+   * In practice spatial derivatives are handled by the underlying spatial
+   * dealii::FEFaceValues object and temporal derivatives are handled by the
+   * underlying temporal dealii::FEValues.
+   */
+  template <int dim>
+  class FEFaceValues
+  {
+  public:
+    /**
+     * @brief Constructor of the FEValues class.
+     *
+     * @param fe: The underlying space-time finite element description class.
+     * @param quad: The space-time quadrature formula to be used.
+     * @param uflags: The update flags to be used during the reinit calls.
+     * @param additional_flags: Additional update flags that are only appended
+     *                          to the FEFace Object (e.g.:
+     * update_normal_vectors)
+     */
+    FEFaceValues(DG_FiniteElement<dim>    &fe,
+                 Quadrature<dim - 1>      &quad,
+                 const dealii::UpdateFlags uflags,
+                 const dealii::UpdateFlags additional_flags);
+
+    /**
+     * @brief Reinitialize all objects of the underlying spatial FEValues object.
+     * This function calls reinit(cell_space) of the spatial FEValues object.
+     * @param cell_space Iterator pointing to the current element in space.
+     */
+    void
+    reinit_space(const typename dealii::TriaIterator<
+                   dealii::DoFCellAccessor<dim, dim, false>> &cell_space,
+                 const unsigned int                           face_no);
+    /**
+     * @brief Reinitialize all objects of the underlying temporal FEValues object.
+     * This function calls reinit(cell_time) of the temporal FEValues object.
+     * @param cell_time Iterator pointing to the current element in time.
+     */
+    void
+    reinit_time(
+      const typename dealii::TriaIterator<dealii::DoFCellAccessor<1, 1, false>>
+        &cell_time);
+
+    /**
+     * @brief Value of the space-time shape function at spacetime-quadrature point.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    double
+    shape_value(unsigned int function_no, unsigned int point_no);
+
+    /**
+     * @brief Value of the space-time shape function of a scalar finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the value function of the resulting view.
+     * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Scalar<dim>::value_type
+    scalar_value(const typename dealii::FEValuesExtractors::Scalar &extractor,
+                 unsigned int                                       function_no,
+                 unsigned int                                       point_no);
+
+    /**
+     * @brief Value of the space-time shape function of a vector-valued finite element component.
+     *
+     * This function passes the extractor to the underlying spatial FEValues
+     * object and then calls the value function of the resulting view.
+     * @param extractor Scalar extractor defining the scalar finite element component to be evaluated.
+     * @param function_no The number of the space-time function/dof to be evaluated.
+     * @param point_no The number of the quadrature point to evaluate at.
+     */
+    typename dealii::FEValuesViews::Vector<dim>::value_type
+    vector_value(const typename dealii::FEValuesExtractors::Vector &extractor,
+                 unsigned int                                       function_no,
+                 unsigned int                                       point_no);
+
+    /**
+     * @brief Get the temporal quadrature point of the given space-time quadrature index.
+     * @param quadrature_point space-time quadrature index.
+     */
+    double
+    time_quadrature_point(unsigned int quadrature_point);
+
+    /**
+     * @brief Get the spatial quadrature point of the given space-time quadrature index.
+     * @param quadrature_point space-time quadrature index.
+     */
+    dealii::Point<dim>
+    space_quadrature_point(unsigned int quadrature_point);
+
+    /**
+     * @brief Get the normal vector at the spatial face.
+     * @param i The space-time index of the quadrature point
+     */
+    const dealii::Tensor<1, dim> &
+    space_normal_vector(unsigned int i);
+
+    /**
+     * @brief Mapped space-time quadrature weight.
+     * @param quadrature_point space-time quadrature index.
+     */
+    double
+    JxW(const unsigned int quadrature_point);
+    /**
+     * @brief Local space-time DoF indices of the current space-time element.
+     * @param A vector of indices to save the result to.
+     */
+    void
+    get_local_dof_indices(
+      std::vector<dealii::types::global_dof_index> &indices);
+
+    /**
+     * @brief The underlying spatial FEValues object.
+     * @return A shared pointer to the spatial FEValues object.
+     */
+    std::shared_ptr<dealii::FEFaceValues<dim>>
+    spatial();
+    /**
+     * @brief The underlying temporal FEValues object.
+     * @return A shared pointer to the temporal FEValues object.
+     */
+    std::shared_ptr<dealii::FEValues<1>>
+    temporal();
+
+  private:
+    DG_FiniteElement<dim> &_fe;
+    Quadrature<dim - 1>   &_quad;
+
+    std::shared_ptr<dealii::FEFaceValues<dim>> _fev_space;
+    std::shared_ptr<dealii::FEValues<1>>       _fev_time;
+
+    std::vector<dealii::types::global_dof_index> local_space_dof_index;
+    std::vector<dealii::types::global_dof_index> local_time_dof_index;
+
+    unsigned int       n_dofs_space;
+    unsigned int       time_cell_index;
+    const unsigned int n_dofs_space_cell;
+    const unsigned int n_quads_space;
+
+  public:
+    /**
+     * @brief Number of space-time quadrature points per element.
+     */
+    unsigned int n_quadrature_points;
+  };
+} // namespace idealii::spacetime
 
 #endif /* INCLUDE_IDEAL_II_BASE_SPACETIME_QUADRATURE_HH_ */

--- a/include/ideal.II/grid/fixed_tria.hh
+++ b/include/ideal.II/grid/fixed_tria.hh
@@ -16,42 +16,47 @@
 #ifndef INCLUDE_IDEAL_II_GRID_FIXED_TRIA_HH_
 #define INCLUDE_IDEAL_II_GRID_FIXED_TRIA_HH_
 
-#include <memory>
 #include <list>
+#include <memory>
+
 #include "spacetime_tria.hh"
 
 namespace idealii::spacetime::fixed
 {
+  /**
+   * @brief The spacetime triangulation object with a fixed spatial mesh across time.
+   *
+   * In practice all pointers in the list point to the same slab::Triangulation
+   * object.
+   */
+  template <int dim>
+  class Triangulation : public spacetime::Triangulation<dim>
+  {
+  public:
     /**
-     * @brief The spacetime triangulation object with a fixed spatial mesh across time.
-     *
-     * In practice all pointers in the list point to the same slab::Triangulation object.
+     * @brief Constructor that initializes the underlying list object.
+     * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
      */
-    template<int dim>
-    class Triangulation : public spacetime::Triangulation<dim>
-    {
-    public:
-        /**
-         * @brief Constructor that initializes the underlying list object.
-         * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
-         */
-        Triangulation ( unsigned int max_N_intervals_per_slab=0);
+    Triangulation(unsigned int max_N_intervals_per_slab = 0);
 
-        /**
-         * @brief Generate a list of M slab triangulations with matching temporal meshes pointing to the same
-         * spatial triangulation.
-         * @param space_tria The underlying spatial dealii::Triangulation to be used by all slabs.
-         * @param M The number of slabs to be created
-         * @param t0 The temporal startpoint. Defaults to 0.
-         * @param T The temporal endpoint. Defaults to 1.
-         */
-        void generate (
-                std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
-                unsigned int M , double t0 = 0. , double T = 1. );
+    /**
+     * @brief Generate a list of M slab triangulations with matching temporal meshes pointing to the same
+     * spatial triangulation.
+     * @param space_tria The underlying spatial dealii::Triangulation to be used by all slabs.
+     * @param M The number of slabs to be created
+     * @param t0 The temporal startpoint. Defaults to 0.
+     * @param T The temporal endpoint. Defaults to 1.
+     */
+    void
+    generate(std::shared_ptr<dealii::Triangulation<dim>> space_tria,
+             unsigned int                                M,
+             double                                      t0 = 0.,
+             double                                      T  = 1.);
 
-        void refine_global ( const unsigned int times_space = 1 ,
-                             const unsigned int times_time = 1 );
-    };
-}
+    void
+    refine_global(const unsigned int times_space = 1,
+                  const unsigned int times_time  = 1);
+  };
+} // namespace idealii::spacetime::fixed
 
 #endif /* INCLUDE_IDEAL_II_GRID_FIXED_TRIA_HH_ */

--- a/include/ideal.II/grid/slab_tria.hh
+++ b/include/ideal.II/grid/slab_tria.hh
@@ -17,107 +17,112 @@
 #define INCLUDE_IDEAL_II_GRID_SLAB_TRIA_HH_
 
 #include <deal.II/grid/tria.h>
-#include <memory>
+
 #include <list>
+#include <memory>
 
 namespace idealii::slab
 {
+  /**
+   * @brief Actual Triangulation for a specific slab.
+   *
+   * This Triangulation handles a spatial and temporal dealii::Triangulation
+   * object internally.
+   *
+   */
+  template <int dim>
+  class Triangulation
+  {
+  public:
     /**
-     * @brief Actual Triangulation for a specific slab.
+     * @brief Construct an object with a given spatial triangulation and a single
+     * element in time.
      *
-     * This Triangulation handles a spatial and temporal dealii::Triangulation object internally.
-     *
+     * @param space_tria. The spatial triangulation to be used.
+     * @param startpoint. The startpoint of the temporal triangulation.
+     * @param endpoint. The endpoint of the temporal triangulation.
      */
-    template<int dim>
-    class Triangulation
-    {
-    public:
-
-        /**
-         * @brief Construct an object with a given spatial triangulation and a single
-         * element in time.
-         *
-         * @param space_tria. The spatial triangulation to be used.
-         * @param startpoint. The startpoint of the temporal triangulation.
-         * @param endpoint. The endpoint of the temporal triangulation.
-         */
-        Triangulation (
-                std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
-                double startpoint , double endpoint );
-
-        /**
-         * @brief Construct an object with a given spatial triangulation and a given
-         * division of elements in time.
-         *
-         * @param space_tria. The spatial triangulation to be used.
-         * @param step_sizes. The sizes of the temporal elements
-         * @param startpoint. The startpoint of the temporal triangulation.
-         * @param endpoint. The endpoint of the temporal triangulation.
-         */
-        Triangulation (
-                std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
-                std::vector<double> step_sizes,
-                double startpoint , double endpoint );
-
-        /**
-         * @brief (shallow) copy constructor. Only the values for the start- and endpoint
-         * are actually copied. The underlying pointers will point to the same
-         * dealii::Triangulation objects as other.
-         *
-         * @param other The Triangulation to shallow copy.
-         *
-         * @warning This method is mainly needed for adding the Triangulations to the spacetime
-         * lists and should be used with utmost caution anywhere else.
-         *
-         *
-         */
-        Triangulation ( const Triangulation &other );
-        /**
-         * @brief The underlying spatial triangulation.
-         */
-        std::shared_ptr<dealii::Triangulation<dim>> spatial ();
-
-        /**
-         * @brief The underlying temporal triangulation.
-         */
-        std::shared_ptr<dealii::Triangulation<1>> temporal ();
-
-        /**
-         * @brief The startpoint of the temporal triangulation.
-         */
-        double startpoint ();
-
-        /**
-         * @brief The endpoint of the temporal triangulation.
-         */
-        double endpoint ();
-
-        /**
-         * @brief Change the temporal triangulation to the given division
-         *
-         * @param step_sizes. The sizes of the temporal elements
-         * @param startpoint. The startpoint of the temporal triangulation.
-         * @param endpoint. The endpoint of the temporal triangulation.
-         *
-         * @warning Due to a call to clear() of the temporal triangulation no subscriptions can exist to it, such as DoFHandler.
-         */
-        void update_temporal_triangulation(
-                std::vector<double> step_sizes,
-                double startpoint,
-                double endpoint);
-
-    private:
-        std::shared_ptr<dealii::Triangulation<dim>> _spatial_tria;
-        std::shared_ptr<dealii::Triangulation<1>> _temporal_tria;
-        double _startpoint;
-        double _endpoint;
-    };
+    Triangulation(std::shared_ptr<dealii::Triangulation<dim>> space_tria,
+                  double                                      startpoint,
+                  double                                      endpoint);
 
     /**
-     * @brief A shortened type for Iterators over a list of shared pointers to Triangulation<dim> objects
+     * @brief Construct an object with a given spatial triangulation and a given
+     * division of elements in time.
+     *
+     * @param space_tria. The spatial triangulation to be used.
+     * @param step_sizes. The sizes of the temporal elements
+     * @param startpoint. The startpoint of the temporal triangulation.
+     * @param endpoint. The endpoint of the temporal triangulation.
      */
-    template<int dim>
-    using TriaIterator = typename std::list<Triangulation<dim>>::iterator;
-}
+    Triangulation(std::shared_ptr<dealii::Triangulation<dim>> space_tria,
+                  std::vector<double>                         step_sizes,
+                  double                                      startpoint,
+                  double                                      endpoint);
+
+    /**
+     * @brief (shallow) copy constructor. Only the values for the start- and endpoint
+     * are actually copied. The underlying pointers will point to the same
+     * dealii::Triangulation objects as other.
+     *
+     * @param other The Triangulation to shallow copy.
+     *
+     * @warning This method is mainly needed for adding the Triangulations to the spacetime
+     * lists and should be used with utmost caution anywhere else.
+     *
+     *
+     */
+    Triangulation(const Triangulation &other);
+    /**
+     * @brief The underlying spatial triangulation.
+     */
+    std::shared_ptr<dealii::Triangulation<dim>>
+    spatial();
+
+    /**
+     * @brief The underlying temporal triangulation.
+     */
+    std::shared_ptr<dealii::Triangulation<1>>
+    temporal();
+
+    /**
+     * @brief The startpoint of the temporal triangulation.
+     */
+    double
+    startpoint();
+
+    /**
+     * @brief The endpoint of the temporal triangulation.
+     */
+    double
+    endpoint();
+
+    /**
+     * @brief Change the temporal triangulation to the given division
+     *
+     * @param step_sizes. The sizes of the temporal elements
+     * @param startpoint. The startpoint of the temporal triangulation.
+     * @param endpoint. The endpoint of the temporal triangulation.
+     *
+     * @warning Due to a call to clear() of the temporal triangulation no subscriptions can exist to it, such as DoFHandler.
+     */
+    void
+    update_temporal_triangulation(std::vector<double> step_sizes,
+                                  double              startpoint,
+                                  double              endpoint);
+
+  private:
+    std::shared_ptr<dealii::Triangulation<dim>> _spatial_tria;
+    std::shared_ptr<dealii::Triangulation<1>>   _temporal_tria;
+    double                                      _startpoint;
+    double                                      _endpoint;
+  };
+
+  /**
+   * @brief A shortened type for Iterators over a list of shared pointers to Triangulation<dim> objects
+   */
+  template <int dim>
+  using TriaIterator = typename std::list<Triangulation<dim>>::iterator;
+} // namespace idealii::slab
 
 #endif /* INCLUDE_IDEAL_II_GRID_SLAB_TRIA_HH_ */

--- a/include/ideal.II/grid/spacetime_tria.hh
+++ b/include/ideal.II/grid/spacetime_tria.hh
@@ -16,70 +16,76 @@
 #ifndef INCLUDE_IDEAL_II_GRID_SPACETIME_TRIA_HH_
 #define INCLUDE_IDEAL_II_GRID_SPACETIME_TRIA_HH_
 
-#include<ideal.II/grid/slab_tria.hh>
+#include <ideal.II/grid/slab_tria.hh>
 
-#include<deal.II/grid/tria.h>
+#include <deal.II/grid/tria.h>
 
-#include <memory>
 #include <list>
+#include <memory>
 
 namespace idealii::spacetime
 {
+  /**
+   * @brief The spacetime triangulation object.
+   *
+   * In practice this is just a class around a list of shared pointers to
+   * slab::Triangulation objects to simplify generation and time marching.
+   * @note This is a virtual base class.
+   */
+  template <int dim>
+  class Triangulation
+  {
+  public:
     /**
-     * @brief The spacetime triangulation object.
-     *
-     * In practice this is just a class around a list of shared pointers to slab::Triangulation objects to
-     * simplify generation and time marching.
-     * @note This is a virtual base class.
+     * @brief Constructor that initializes the underlying list object.
+     * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
      */
-    template<int dim>
-    class Triangulation
-    {
-    public:
-        /**
-         * @brief Constructor that initializes the underlying list object.
-         * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
-         */
-        Triangulation ( dealii::types::global_cell_index max_N_intervals_per_slab=0);
+    Triangulation(
+      dealii::types::global_cell_index max_N_intervals_per_slab = 0);
 
-        /**
-         * @brief Generate a list of M slab triangulations with matching temporal meshes and space_tria.
-         *
-         * @param space_tria The underlying spatial dealii::parallel::distributed::Triangulation.
-         * @param M The number of slabs to be created.
-         * @param t0 The temporal startpoint. Defaults to 0.
-         * @param T The temporal endpoint. Defaults to 1.
-         */
-        virtual void generate (
-            std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
-            unsigned int M , double t0 = 0. , double T = 1.)=0;
+    /**
+     * @brief Generate a list of M slab triangulations with matching temporal meshes and space_tria.
+     *
+     * @param space_tria The underlying spatial dealii::parallel::distributed::Triangulation.
+     * @param M The number of slabs to be created.
+     * @param t0 The temporal startpoint. Defaults to 0.
+     * @param T The temporal endpoint. Defaults to 1.
+     */
+    virtual void
+    generate(std::shared_ptr<dealii::Triangulation<dim>> space_tria,
+             unsigned int                                M,
+             double                                      t0 = 0.,
+             double                                      T  = 1.) = 0;
 
-        /**
-         * @brief Return the number of slabs in the triangulation.
-         */
-        unsigned int M ();
-        /**
-         * @brief An iterator pointing to the first slab::Triangulation
-         */
-        slab::TriaIterator<dim> begin ();
-        /**
-         * @brief An iterator pointing behind the first slab::Triangulation
-         */
-        slab::TriaIterator<dim> end ();
+    /**
+     * @brief Return the number of slabs in the triangulation.
+     */
+    unsigned int
+    M();
+    /**
+     * @brief An iterator pointing to the first slab::Triangulation
+     */
+    slab::TriaIterator<dim>
+    begin();
+    /**
+     * @brief An iterator pointing behind the first slab::Triangulation
+     */
+    slab::TriaIterator<dim>
+    end();
 
-        /**
-         * @brief Do uniform mesh refinement in time and space
-         * @param times_space Number of times the spatial meshes are refined.
-         * @param times_time Number of times the temporal meshes are refined.
-         */
-        virtual void refine_global (
-            const unsigned int times_space = 1 ,
-            const unsigned int times_time = 1 )=0;
+    /**
+     * @brief Do uniform mesh refinement in time and space
+     * @param times_space Number of times the spatial meshes are refined.
+     * @param times_time Number of times the temporal meshes are refined.
+     */
+    virtual void
+    refine_global(const unsigned int times_space = 1,
+                  const unsigned int times_time  = 1) = 0;
 
-    protected:
-        dealii::types::global_cell_index max_N_intervals_per_slab;
-        std::list<slab::Triangulation<dim>> trias;
-    };
-}
+  protected:
+    dealii::types::global_cell_index    max_N_intervals_per_slab;
+    std::list<slab::Triangulation<dim>> trias;
+  };
+} // namespace idealii::spacetime
 
 #endif /* INCLUDE_IDEAL_II_GRID_FIXED_TRIA_HH_ */

--- a/include/ideal.II/lac/spacetime_trilinos_vector.hh
+++ b/include/ideal.II/lac/spacetime_trilinos_vector.hh
@@ -18,56 +18,66 @@
 
 #include <deal.II/base/config.h>
 #ifdef DEAL_II_WITH_TRILINOS
-#ifdef DEAL_II_WITH_MPI
-#include <deal.II/lac/trilinos_vector.h>
+#  ifdef DEAL_II_WITH_MPI
+#    include <deal.II/lac/trilinos_vector.h>
 
-namespace idealii{
-    namespace slab{
-        /**
-         *	@brief A shortened type for iterators over a list of shared pointers to dealii::TrilinosWrappers::MPI::Vectors.
-         */
-        using TrilinosVectorIterator = typename std::list<dealii::TrilinosWrappers::MPI::Vector>::iterator;
-    }
-    namespace spacetime{
+namespace idealii
+{
+  namespace slab
+  {
+    /**
+     *	@brief A shortened type for iterators over a list of shared pointers to dealii::TrilinosWrappers::MPI::Vectors.
+     */
+    using TrilinosVectorIterator =
+      typename std::list<dealii::TrilinosWrappers::MPI::Vector>::iterator;
+  } // namespace slab
+  namespace spacetime
+  {
 
 
-        /**
-         * @brief The spacetime Trilinos vector object.
-         *
-         * In practice this is just a class around a list of shared pointers to
-         * dealii::TrilinosWrappers::MPI::Vector objects to simplify time marching.
-         */
-        class TrilinosVector{
-        public:
-            /**
-             * @brief Construct an empty list of vectors.
-             */
-            TrilinosVector();
+    /**
+     * @brief The spacetime Trilinos vector object.
+     *
+     * In practice this is just a class around a list of shared pointers to
+     * dealii::TrilinosWrappers::MPI::Vector objects to simplify time marching.
+     */
+    class TrilinosVector
+    {
+    public:
+      /**
+       * @brief Construct an empty list of vectors.
+       */
+      TrilinosVector();
 
-            /**
-             * @brief Clear the list and add M empty vectors.
-             */
-            void reinit(unsigned int M);
+      /**
+       * @brief Clear the list and add M empty vectors.
+       */
+      void
+      reinit(unsigned int M);
 
-            /**
-             * @brief Return the size of the list, i.e. the number of slabs.
-             */
-            unsigned int M();
+      /**
+       * @brief Return the size of the list, i.e. the number of slabs.
+       */
+      unsigned int
+      M();
 
-            /**
-             * @brief Return an iterator pointing to the first "slab" vector.
-             */
-            slab::TrilinosVectorIterator begin();
-            /**
-             * @brief Return an iterator pointing behind the last "slab" vector.
-             */
-            slab::TrilinosVectorIterator end();
+      /**
+       * @brief Return an iterator pointing to the first "slab" vector.
+       */
+      slab::TrilinosVectorIterator
+      begin();
+      /**
+       * @brief Return an iterator pointing behind the last "slab" vector.
+       */
+      slab::TrilinosVectorIterator
+      end();
 
-        private:
-            std::list<dealii::TrilinosWrappers::MPI::Vector> _vectors;
-        };
-    }}
+    private:
+      std::list<dealii::TrilinosWrappers::MPI::Vector> _vectors;
+    };
+  } // namespace spacetime
+} // namespace idealii
 
-#endif /* DEAL_II_WITH_MPI */
-#endif /* DEAL_II_WITH_TRILINOS */
-#endif /* INCLUDE_IDEAL_II_LAC_SPACETIME_VECTOR_HH_ */
+#  endif /* DEAL_II_WITH_MPI */
+#endif   /* DEAL_II_WITH_TRILINOS */
+#endif   /* INCLUDE_IDEAL_II_LAC_SPACETIME_VECTOR_HH_ */

--- a/include/ideal.II/lac/spacetime_vector.hh
+++ b/include/ideal.II/lac/spacetime_vector.hh
@@ -20,55 +20,59 @@
 
 namespace idealii
 {
-    namespace slab
+  namespace slab
+  {
+    /**
+     *	@brief A shortened type for iterators over a list of shared pointers to dealii::Vectors.
+     */
+    template <typename Number>
+    using VectorIterator = typename std::list<dealii::Vector<Number>>::iterator;
+  } // namespace slab
+  namespace spacetime
+  {
+
+    /**
+     * @brief The spacetime vector object.
+     *
+     * In practice this is just a class around a list of shared pointers to
+     * dealii::Vector<Number> objects to simplify time marching.
+     */
+    template <typename Number>
+    class Vector
     {
-        /**
-         *	@brief A shortened type for iterators over a list of shared pointers to dealii::Vectors.
-         */
-        template<typename Number>
-        using VectorIterator = typename std::list<dealii::Vector<Number>>::iterator;
-    }
-    namespace spacetime
-    {
+    public:
+      /**
+       * @brief Construct an empty list of vectors.
+       */
+      Vector();
 
-        /**
-         * @brief The spacetime vector object.
-         *
-         * In practice this is just a class around a list of shared pointers to
-         * dealii::Vector<Number> objects to simplify time marching.
-         */
-        template<typename Number>
-        class Vector
-        {
-        public:
-            /**
-             * @brief Construct an empty list of vectors.
-             */
-            Vector ();
+      /**
+       * @brief Clear the list and add M empty vectors.
+       */
+      void
+      reinit(unsigned int M);
 
-            /**
-             * @brief Clear the list and add M empty vectors.
-             */
-            void reinit ( unsigned int M );
+      /**
+       * @brief Return the size of the list, i.e. the number of slabs.
+       */
+      unsigned int
+      M();
 
-            /**
-             * @brief Return the size of the list, i.e. the number of slabs.
-             */
-            unsigned int M ();
+      /**
+       * @brief Return an iterator pointing to the first "slab" vector.
+       */
+      slab::VectorIterator<Number>
+      begin();
+      /**
+       * @brief Return an iterator pointing behind the last "slab" vector.
+       */
+      slab::VectorIterator<Number>
+      end();
 
-            /**
-             * @brief Return an iterator pointing to the first "slab" vector.
-             */
-            slab::VectorIterator<Number> begin ();
-            /**
-             * @brief Return an iterator pointing behind the last "slab" vector.
-             */
-            slab::VectorIterator<Number> end ();
-
-        private:
-            std::list<dealii::Vector<Number>> _vectors;
-        };
-    }
-}
+    private:
+      std::list<dealii::Vector<Number>> _vectors;
+    };
+  } // namespace spacetime
+} // namespace idealii
 
 #endif /* INCLUDE_IDEAL_II_LAC_SPACETIME_VECTOR_HH_ */

--- a/include/ideal.II/numerics/vector_tools.hh
+++ b/include/ideal.II/numerics/vector_tools.hh
@@ -16,330 +16,336 @@
 #ifndef INCLUDE_IDEAL_II_NUMERICS_VECTOR_TOOLS_HH_
 #define INCLUDE_IDEAL_II_NUMERICS_VECTOR_TOOLS_HH_
 
-#include <deal.II/lac/vector.h>
-#include <deal.II/lac/trilinos_vector.h>
-#include <deal.II/lac/affine_constraints.h>
+#include <ideal.II/base/quadrature_lib.hh>
+
+#include <ideal.II/dofs/slab_dof_handler.hh>
 
 #include <deal.II/fe/fe_values.h>
 
-#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/vector.h>
 
-#include <ideal.II/dofs/slab_dof_handler.hh>
-#include <ideal.II/base/quadrature_lib.hh>
+#include <deal.II/numerics/vector_tools.h>
 
 #include <memory>
 
 namespace idealii::slab::VectorTools
 {
 
-    /**
-     * @brief Compute space-time constraints on the solution corresponding to
-     * Dirichlet conditions.
-     * This function iterates over all temporal degrees of freedom and sets the
-     * boundary values of the corresponding subvector to the value of the specified
-     * at the time of the temporal dof.
-     *
-     * @param dof_handler The space-time slab dof handler the vector is indexed on
-     * @param boundary_component The boundary id corresponding to the Dirichlet conditions
-     * @param boundary_function The function that describes the Dirichlet data
-     * @param spacetime_constraints The constraints to add the boundary values to
-     * @param component_mask A component mask to only apply boundary values to certain FE components
-     *
-     * @note The set_time() method of boundary_function is called internally, so if the function is time-dependent use
-     * get_time() in your implementation of the function to obtain t.
-     */
-    template<int dim,typename Number>
-    void interpolate_boundary_values (
-        idealii::slab::DoFHandler<dim> &dof_handler ,
-        const dealii::types::boundary_id boundary_component ,
-        dealii::Function<dim,Number> &boundary_function ,
-        std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints ,
-        const dealii::ComponentMask &component_mask = dealii::ComponentMask () );
+  /**
+   * @brief Compute space-time constraints on the solution corresponding to
+   * Dirichlet conditions.
+   * This function iterates over all temporal degrees of freedom and sets the
+   * boundary values of the corresponding subvector to the value of the
+   * specified at the time of the temporal dof.
+   *
+   * @param dof_handler The space-time slab dof handler the vector is indexed on
+   * @param boundary_component The boundary id corresponding to the Dirichlet conditions
+   * @param boundary_function The function that describes the Dirichlet data
+   * @param spacetime_constraints The constraints to add the boundary values to
+   * @param component_mask A component mask to only apply boundary values to certain FE components
+   *
+   * @note The set_time() method of boundary_function is called internally, so if the function is time-dependent use
+   * get_time() in your implementation of the function to obtain t.
+   */
+  template <int dim, typename Number>
+  void
+  interpolate_boundary_values(
+    idealii::slab::DoFHandler<dim>                    &dof_handler,
+    const dealii::types::boundary_id                   boundary_component,
+    dealii::Function<dim, Number>                     &boundary_function,
+    std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints,
+    const dealii::ComponentMask &component_mask = dealii::ComponentMask());
 
-    /**
-     * @brief Compute space-time constraints on the solution corresponding to
-     * Dirichlet conditions for the locally relevant set of space dofs.
-     * This function iterates over all temporal degrees of freedom and sets the
-     * boundary values of the corresponding subvector to the value of the specified
-     * at the time of the temporal dof.
-     *
-     * @param space_relevant_dofs The IndexSet of locally relevant dofs in space.
-     * @param dof_handler The space-time slab dof handler the vector is indexed on
-     * @param boundary_component The boundary id corresponding to the Dirichlet conditions
-     * @param boundary_function The function that describes the Dirichlet data
-     * @param spacetime_constraints The constraints to add the boundary values to
-     * @param component_mask A component mask to only apply boundary values to certain FE components
-     *
-     * @note The set_time() method of boundary_function is called internally, so if the function is time-dependent use
-     * get_time() in your implementation of the function to obtain t.
-     */
-    template<int dim,typename Number = double>
-    void interpolate_boundary_values (
-        dealii::IndexSet space_relevant_dofs ,
-        idealii::slab::DoFHandler<dim> &dof_handler ,
-        const dealii::types::boundary_id boundary_component ,
-        dealii::Function<dim,Number> &boundary_function ,
-        std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints ,
-        const dealii::ComponentMask &component_mask = dealii::ComponentMask () )
-    {
-        auto space_constraints = std::make_shared<
-                dealii::AffineConstraints<Number>> ();
-        space_constraints->reinit ( space_relevant_dofs );
-        dealii::Quadrature < 1 > quad_time ( dof_handler.temporal ()->get_fe (0).get_unit_support_points () );
-        dealii::FEValues < 1 > fev (
-            dof_handler.temporal ()->get_fe ( 0 ) ,
-            quad_time ,
-            dealii::update_quadrature_points );
+  /**
+   * @brief Compute space-time constraints on the solution corresponding to
+   * Dirichlet conditions for the locally relevant set of space dofs.
+   * This function iterates over all temporal degrees of freedom and sets the
+   * boundary values of the corresponding subvector to the value of the
+   * specified at the time of the temporal dof.
+   *
+   * @param space_relevant_dofs The IndexSet of locally relevant dofs in space.
+   * @param dof_handler The space-time slab dof handler the vector is indexed on
+   * @param boundary_component The boundary id corresponding to the Dirichlet conditions
+   * @param boundary_function The function that describes the Dirichlet data
+   * @param spacetime_constraints The constraints to add the boundary values to
+   * @param component_mask A component mask to only apply boundary values to certain FE components
+   *
+   * @note The set_time() method of boundary_function is called internally, so if the function is time-dependent use
+   * get_time() in your implementation of the function to obtain t.
+   */
+  template <int dim, typename Number = double>
+  void
+  interpolate_boundary_values(
+    dealii::IndexSet                                   space_relevant_dofs,
+    idealii::slab::DoFHandler<dim>                    &dof_handler,
+    const dealii::types::boundary_id                   boundary_component,
+    dealii::Function<dim, Number>                     &boundary_function,
+    std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints,
+    const dealii::ComponentMask &component_mask = dealii::ComponentMask())
+  {
+    auto space_constraints =
+      std::make_shared<dealii::AffineConstraints<Number>>();
+    space_constraints->reinit(space_relevant_dofs);
+    dealii::Quadrature<1> quad_time(
+      dof_handler.temporal()->get_fe(0).get_unit_support_points());
+    dealii::FEValues<1> fev(dof_handler.temporal()->get_fe(0),
+                            quad_time,
+                            dealii::update_quadrature_points);
 
-        unsigned int n_space_dofs = dof_handler.n_dofs_space ();
-        unsigned int time_dof = 0;
-        std::vector < dealii::types::global_dof_index > local_indices (
-                dof_handler.dofs_per_cell_time () );
-        //loop over time cells instead
-        for ( const auto &cell_time : dof_handler.temporal ()->active_cell_iterators () )
-        {
-            fev.reinit ( cell_time );
+    unsigned int n_space_dofs = dof_handler.n_dofs_space();
+    unsigned int time_dof     = 0;
+    std::vector<dealii::types::global_dof_index> local_indices(
+      dof_handler.dofs_per_cell_time());
+    // loop over time cells instead
+    for (const auto &cell_time :
+         dof_handler.temporal()->active_cell_iterators())
+      {
+        fev.reinit(cell_time);
 
-            cell_time->get_dof_indices ( local_indices );
-            for ( unsigned int q = 0 ; q < quad_time.size () ; q++ )
-            {
-                space_constraints->clear ();
-                time_dof = local_indices[q];
-                boundary_function.set_time ( fev.quadrature_point ( q )[0] );
-                dealii::VectorTools::interpolate_boundary_values (
-                    *dof_handler.spatial () ,
-                    boundary_component ,
-                    boundary_function ,
-                    *space_constraints ,
-                    component_mask );
+        cell_time->get_dof_indices(local_indices);
+        for (unsigned int q = 0; q < quad_time.size(); q++)
+          {
+            space_constraints->clear();
+            time_dof = local_indices[q];
+            boundary_function.set_time(fev.quadrature_point(q)[0]);
+            dealii::VectorTools::interpolate_boundary_values(
+              *dof_handler.spatial(),
+              boundary_component,
+              boundary_function,
+              *space_constraints,
+              component_mask);
 
-                for ( auto id = space_relevant_dofs.begin () ; id != space_relevant_dofs.end () ; id++ )
-                {
-                    //check if this is a constrained dof
-                    if ( space_constraints->is_constrained ( *id ) )
-                    {
-                        const std::vector<std::pair<dealii::types::global_dof_index, double>> *entries
-                        = space_constraints->get_constraint_entries ( *id );
-                        spacetime_constraints->add_line ( *id + time_dof * n_space_dofs );
-                        //non Dirichlet constraint
-                        if ( entries->size () > 0 )
-                        {
-                            for ( auto entry : *entries )
-                            {
-                                std::cout << entry.first << ","
-                                        << entry.second << std::endl;
-                                spacetime_constraints->add_entry (
-                                    *id + time_dof * n_space_dofs ,
-                                    entry.first + time_dof * n_space_dofs ,
-                                    entry.second
-                                );
-                            }
-                        }
-                        else
-                        {
-                            spacetime_constraints->set_inhomogeneity (
-                                *id + time_dof * n_space_dofs ,
-                                space_constraints->get_inhomogeneity ( *id ) );
-                        }
-                    }
-                }
-            }
-        }
-    }
+            for (auto id = space_relevant_dofs.begin();
+                 id != space_relevant_dofs.end();
+                 id++)
+              {
+                // check if this is a constrained dof
+                if (space_constraints->is_constrained(*id))
+                  {
+                    const std::vector<std::pair<dealii::types::global_dof_index,
+                                                double>> *entries =
+                      space_constraints->get_constraint_entries(*id);
+                    spacetime_constraints->add_line(*id +
+                                                    time_dof * n_space_dofs);
+                    // non Dirichlet constraint
+                    if (entries->size() > 0)
+                      {
+                        for (auto entry : *entries)
+                          {
+                            std::cout << entry.first << "," << entry.second
+                                      << std::endl;
+                            spacetime_constraints->add_entry(
+                              *id + time_dof * n_space_dofs,
+                              entry.first + time_dof * n_space_dofs,
+                              entry.second);
+                          }
+                      }
+                    else
+                      {
+                        spacetime_constraints->set_inhomogeneity(
+                          *id + time_dof * n_space_dofs,
+                          space_constraints->get_inhomogeneity(*id));
+                      }
+                  }
+              }
+          }
+      }
+  }
 
-    /**
-     * @brief Compute space-time constraints on the solution corresponding to Hcurl
-     * Dirichlet conditions.
-     * This function iterates over all temporal degrees of freedom and sets the
-     * boundary values of the corresponding subvector to the value of the specified
-     * at the time of the temporal dof.
-     *
-     * @param dof_handler The space-time slab dof handler the vector is indexed on
-     * @param boundary_component The boundary id corresponding to the Dirichlet conditions
-     * @param boundary_function The function that describes the Dirichlet data
-     * @param spacetime_constraints The constraints to add the boundary values to
-     * @param component_mask A component mask to only apply boundary values to certain FE components
-     *
-     * @note The set_time() method of boundary_function is called internally, so if the function is time-dependent use
-     * get_time() in your implementation of the function to obtain t.
-     */
-    template<int dim,typename Number>
-    void
-    project_boundary_values_curl_conforming_l2 (
-        idealii::slab::DoFHandler<dim> &dof_handler ,
-        unsigned int first_vector_component ,
-        dealii::Function<dim,Number> &boundary_function ,
-        const dealii::types::boundary_id boundary_component ,
-        std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints );
+  /**
+   * @brief Compute space-time constraints on the solution corresponding to Hcurl
+   * Dirichlet conditions.
+   * This function iterates over all temporal degrees of freedom and sets the
+   * boundary values of the corresponding subvector to the value of the
+   * specified at the time of the temporal dof.
+   *
+   * @param dof_handler The space-time slab dof handler the vector is indexed on
+   * @param boundary_component The boundary id corresponding to the Dirichlet conditions
+   * @param boundary_function The function that describes the Dirichlet data
+   * @param spacetime_constraints The constraints to add the boundary values to
+   * @param component_mask A component mask to only apply boundary values to certain FE components
+   *
+   * @note The set_time() method of boundary_function is called internally, so if the function is time-dependent use
+   * get_time() in your implementation of the function to obtain t.
+   */
+  template <int dim, typename Number>
+  void
+  project_boundary_values_curl_conforming_l2(
+    idealii::slab::DoFHandler<dim>                    &dof_handler,
+    unsigned int                                       first_vector_component,
+    dealii::Function<dim, Number>                     &boundary_function,
+    const dealii::types::boundary_id                   boundary_component,
+    std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints);
 
-    /**
-     * @brief Get the spatial subvector of a specific temporal dof of the corresponding slab.
-     *
-     * @param spacetime_vector The vector containing the slab space-time values
-     * @param space_vector The resulting vector of spatial values at dof_index
-     * @param dof_index The index of the DoF to be extracted.
-     */
-    void extract_subvector_at_time_dof (
-            const dealii::Vector<double> &spacetime_vector ,
-            dealii::Vector<double> &space_vector ,
-            unsigned int dof_index )
-    {
-        unsigned int n_dofs_space = space_vector.size ();
-        for ( unsigned int i = 0 ; i < n_dofs_space ; i++ )
-        {
-            space_vector[i] = spacetime_vector[i + dof_index * n_dofs_space];
-        }
-    }
+  /**
+   * @brief Get the spatial subvector of a specific temporal dof of the corresponding slab.
+   *
+   * @param spacetime_vector The vector containing the slab space-time values
+   * @param space_vector The resulting vector of spatial values at dof_index
+   * @param dof_index The index of the DoF to be extracted.
+   */
+  void
+  extract_subvector_at_time_dof(const dealii::Vector<double> &spacetime_vector,
+                                dealii::Vector<double>       &space_vector,
+                                unsigned int                  dof_index)
+  {
+    unsigned int n_dofs_space = space_vector.size();
+    for (unsigned int i = 0; i < n_dofs_space; i++)
+      {
+        space_vector[i] = spacetime_vector[i + dof_index * n_dofs_space];
+      }
+  }
 
 #ifdef DEAL_II_WITH_MPI
-    /**
-     * @brief Get the spatial Trilinos subvector of a specific temporal dof of the corresponding slab.
-     *
-     * @param spacetime_vector The Trilinos vector containing the slab space-time values
-     * @param space_vector The resulting Trilinos vector of spatial values at dof_index
-     * @param dof_index The index of the DoF to be extracted.
-     */
-    void extract_subvector_at_time_dof (
-        const dealii::TrilinosWrappers::MPI::Vector &spacetime_vector ,
-        dealii::TrilinosWrappers::MPI::Vector &space_vector ,
-        unsigned int dof_index )
-    {
-        dealii::IndexSet space_owned =  space_vector.locally_owned_elements ();
-        unsigned int n_dofs_space = space_vector.size ();
+  /**
+   * @brief Get the spatial Trilinos subvector of a specific temporal dof of the corresponding slab.
+   *
+   * @param spacetime_vector The Trilinos vector containing the slab space-time values
+   * @param space_vector The resulting Trilinos vector of spatial values at dof_index
+   * @param dof_index The index of the DoF to be extracted.
+   */
+  void
+  extract_subvector_at_time_dof(
+    const dealii::TrilinosWrappers::MPI::Vector &spacetime_vector,
+    dealii::TrilinosWrappers::MPI::Vector       &space_vector,
+    unsigned int                                 dof_index)
+  {
+    dealii::IndexSet space_owned  = space_vector.locally_owned_elements();
+    unsigned int     n_dofs_space = space_vector.size();
+    dealii::TrilinosWrappers::MPI::Vector tmp;
+    tmp.reinit(space_owned, space_vector.get_mpi_communicator());
+    for (auto id = space_owned.begin(); id != space_owned.end(); id++)
+      {
+        tmp[*id] = spacetime_vector[*id + dof_index * n_dofs_space];
+      }
+    space_vector = tmp;
+  }
+#endif
+  /**
+   * @brief Get the spatial subvector at a specific time point of the corresponding slab.
+   * The result is calculated by linear combination of each temporal dof vector
+   * according to the underlying temporal finite element.
+   * @note If t is not in the temporal interval of the slab, the resulting vector will be 0.
+   * @param dof_handler The DoFHandler used to calculate the spacetime_vector.
+   * @param spacetime_vector The vector containing the slab space-time values.
+   * @param space_vector The resulting vector of spatial values at dof_index.
+   * @param t The time point to extract from.
+   */
+  template <int dim>
+  void
+  extract_subvector_at_time_point(
+    slab::DoFHandler<dim>        &dof_handler,
+    const dealii::Vector<double> &spacetime_vector,
+    dealii::Vector<double>       &space_vector,
+    const double                  t)
+  {
+    space_vector              = 0;
+    unsigned int n_dofs_space = space_vector.size();
+    double       left         = 0;
+    double       right        = 0;
+    for (auto cell : dof_handler.temporal()->active_cell_iterators())
+      {
+        left  = cell->face(0)->center()(0);
+        right = cell->face(1)->center()(0);
+        if (t < left || t > right)
+          {
+            continue;
+          }
+        double                      _t = (t - left) / (right - left);
+        dealii::Point<1>            qpoint(_t);
+        const dealii::Quadrature<1> time_qf(qpoint);
+        dealii::FEValues<1> time_values(dof_handler.temporal()->get_fe(),
+                                        time_qf,
+                                        dealii::update_values);
+        time_values.reinit(cell);
+        unsigned int offset =
+          cell->index() * dof_handler.dofs_per_cell_time() * n_dofs_space;
+        for (unsigned int ii = 0; ii < dof_handler.dofs_per_cell_time(); ii++)
+          {
+            double factor = time_values.shape_value(ii, 0);
+            for (unsigned int i = 0; i < n_dofs_space; i++)
+              {
+                space_vector[i] +=
+                  spacetime_vector[i + ii * n_dofs_space + offset] * factor;
+              }
+          }
+      }
+  }
+
+#ifdef DEAL_II_WITH_MPI
+  /**
+   * @brief Get the spatial Trilinos subvector at a specific time point of the corresponding slab.
+   * The result is calculated by linear combination of each temporal dof vector
+   * according to the underlying temporal finite element.
+   * @note If t is not in the temporal interval of the slab, the resulting vector will be 0.
+   * @param dof_handler The DoFHandler used to calculate the spacetime_vector.
+   * @param spacetime_vector The Trilinos vector containing the slab space-time values.
+   * @param space_vector The resulting Trilinos vector of spatial values at dof_index.
+   * @param t The time point to extract from.
+   */
+  template <int dim>
+  void
+  extract_subvector_at_time_point(
+    slab::DoFHandler<dim>                       &dof_handler,
+    const dealii::TrilinosWrappers::MPI::Vector &spacetime_vector,
+    dealii::TrilinosWrappers::MPI::Vector       &space_vector,
+    const double                                 t)
+  {
+    space_vector              = 0;
+    unsigned int n_dofs_space = space_vector.size();
+    double       left         = 0;
+    double       right        = 0;
+    for (auto cell : dof_handler.temporal()->active_cell_iterators())
+      {
+        left  = cell->face(0)->center()(0);
+        right = cell->face(1)->center()(0);
+        if (t < left || t > right)
+          {
+            continue;
+          }
+        double                      _t = (t - left) / (right - left);
+        dealii::Point<1>            qpoint(_t);
+        const dealii::Quadrature<1> time_qf(qpoint);
+        dealii::FEValues<1> time_values(dof_handler.temporal()->get_fe(),
+                                        time_qf,
+                                        dealii::update_values);
+        time_values.reinit(cell);
+        dealii::IndexSet space_owned  = space_vector.locally_owned_elements();
+        unsigned int     n_dofs_space = space_vector.size();
         dealii::TrilinosWrappers::MPI::Vector tmp;
-        tmp.reinit ( space_owned ,  space_vector.get_mpi_communicator () );
-        for ( auto id = space_owned.begin () ;
-                id != space_owned.end () ; id++ )
-        {
-            tmp[*id] = spacetime_vector[*id + dof_index * n_dofs_space];
-        }
-        space_vector = tmp;
-    }
-#endif
-    /**
-     * @brief Get the spatial subvector at a specific time point of the corresponding slab.
-     * The result is calculated by linear combination of each temporal dof vector according
-     * to the underlying temporal finite element.
-     * @note If t is not in the temporal interval of the slab, the resulting vector will be 0.
-     * @param dof_handler The DoFHandler used to calculate the spacetime_vector.
-     * @param spacetime_vector The vector containing the slab space-time values.
-     * @param space_vector The resulting vector of spatial values at dof_index.
-     * @param t The time point to extract from.
-     */
-    template<int dim>
-    void extract_subvector_at_time_point (
-        slab::DoFHandler<dim> &dof_handler ,
-        const dealii::Vector<double> &spacetime_vector ,
-        dealii::Vector<double> &space_vector ,
-        const double t )
-    {
-        space_vector = 0;
-        unsigned int n_dofs_space = space_vector.size ();
-        double left = 0;
-        double right = 0;
-        for ( auto cell : dof_handler.temporal ()->active_cell_iterators () )
-        {
-            left = cell->face ( 0 )->center () ( 0 );
-            right = cell->face ( 1 )->center () ( 0 );
-            if ( t < left || t > right )
-            {
-                continue;
-            }
-            double _t = ( t - left ) / ( right - left );
-            dealii::Point < 1 > qpoint ( _t );
-            const dealii::Quadrature<1> time_qf ( qpoint );
-            dealii::FEValues < 1 > time_values (
-                dof_handler.temporal ()->get_fe () ,
-                time_qf ,
-                dealii::update_values );
-            time_values.reinit ( cell );
-            unsigned int offset = cell->index ()
-                                * dof_handler.dofs_per_cell_time ()
-                                * n_dofs_space;
-            for ( unsigned int ii = 0 ;  ii < dof_handler.dofs_per_cell_time () ; ii++ )
-            {
-                double factor = time_values.shape_value ( ii , 0 );
-                for ( unsigned int i = 0 ; i < n_dofs_space ; i++ )
-                {
-                    space_vector[i] += spacetime_vector[i + ii * n_dofs_space + offset] * factor;
-                }
-            }
-        }
-    }
+        tmp.reinit(space_owned, space_vector.get_mpi_communicator());
 
-#ifdef DEAL_II_WITH_MPI
-    /**
-     * @brief Get the spatial Trilinos subvector at a specific time point of the corresponding slab.
-     * The result is calculated by linear combination of each temporal dof vector according
-     * to the underlying temporal finite element.
-     * @note If t is not in the temporal interval of the slab, the resulting vector will be 0.
-     * @param dof_handler The DoFHandler used to calculate the spacetime_vector.
-     * @param spacetime_vector The Trilinos vector containing the slab space-time values.
-     * @param space_vector The resulting Trilinos vector of spatial values at dof_index.
-     * @param t The time point to extract from.
-     */
-    template<int dim>
-    void extract_subvector_at_time_point (
-            slab::DoFHandler<dim> &dof_handler ,
-            const dealii::TrilinosWrappers::MPI::Vector &spacetime_vector ,
-            dealii::TrilinosWrappers::MPI::Vector &space_vector ,
-            const double t )
-    {
-        space_vector = 0;
-        unsigned int n_dofs_space = space_vector.size ();
-        double left = 0;
-        double right = 0;
-        for ( auto cell : dof_handler.temporal ()->active_cell_iterators () )
-        {
-            left = cell->face ( 0 )->center () ( 0 );
-            right = cell->face ( 1 )->center () ( 0 );
-            if ( t < left || t > right )
-            {
-                continue;
-            }
-            double _t = ( t - left ) / ( right - left );
-            dealii::Point < 1 > qpoint ( _t );
-            const dealii::Quadrature<1> time_qf ( qpoint );
-            dealii::FEValues < 1 > time_values (
-                dof_handler.temporal ()->get_fe () ,
-                time_qf ,
-                dealii::update_values );
-            time_values.reinit ( cell );
-            dealii::IndexSet space_owned =  space_vector.locally_owned_elements ();
-            unsigned int n_dofs_space = space_vector.size ();
-            dealii::TrilinosWrappers::MPI::Vector tmp;
-            tmp.reinit ( space_owned ,
-                         space_vector.get_mpi_communicator () );
-
-            for ( unsigned int ii = 0 ;
-                    ii < dof_handler.dofs_per_cell_time () ; ii++ )
-            {
-                double factor = time_values.shape_value ( ii , 0 );
-                for ( auto id = space_owned.begin () ;
-                        id != space_owned.end () ; id++ )
-                {
-                    tmp[*id] += spacetime_vector[*id + ii * n_dofs_space] * factor;
-                }
-                space_vector = tmp;
-            }
-        }
-    }
+        for (unsigned int ii = 0; ii < dof_handler.dofs_per_cell_time(); ii++)
+          {
+            double factor = time_values.shape_value(ii, 0);
+            for (auto id = space_owned.begin(); id != space_owned.end(); id++)
+              {
+                tmp[*id] += spacetime_vector[*id + ii * n_dofs_space] * factor;
+              }
+            space_vector = tmp;
+          }
+      }
+  }
 #endif
 
-    /**
-     * @brief calculate the L2 inner product of (u-u_{kh}) with itself
-     * @parameter dof_handler The slab::DoFHandler describing the dof distribution of the space-time vector
-     * @parameter spacetime_vector The approximate solution u_{kh}
-     * @parameter exact_solution The function describing the exact solution
-     * @parameter quad The quadrature formula to use when calculating the integrals.
-     */
-    template<int dim>
-    double
-    calculate_L2L2_squared_error_on_slab (
-            slab::DoFHandler<dim> &dof_handler ,
-            dealii::Vector<double> &spacetime_vector ,
-            dealii::Function<dim,double> &exact_solution ,
-            spacetime::Quadrature<dim> &quad );
-}
+  /**
+   * @brief calculate the L2 inner product of (u-u_{kh}) with itself
+   * @parameter dof_handler The slab::DoFHandler describing the dof distribution
+   * of the space-time vector
+   * @parameter spacetime_vector The approximate solution u_{kh}
+   * @parameter exact_solution The function describing the exact solution
+   * @parameter quad The quadrature formula to use when calculating the
+   * integrals.
+   */
+  template <int dim>
+  double
+  calculate_L2L2_squared_error_on_slab(
+    slab::DoFHandler<dim>         &dof_handler,
+    dealii::Vector<double>        &spacetime_vector,
+    dealii::Function<dim, double> &exact_solution,
+    spacetime::Quadrature<dim>    &quad);
+} // namespace idealii::slab::VectorTools
 
 #endif /* INCLUDE_IDEAL_II_VECTOR_TOOLS_HH_ */

--- a/src/base/idealii.cc
+++ b/src/base/idealii.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include <ideal.II/base/version.hh>
 #include <ideal.II/base/idealii.hh>
+
+#include <ideal.II/base/version.hh>
 
 #include <fstream>
 #include <iostream>
@@ -22,15 +23,14 @@
 namespace idealii
 {
 
-    void print_version_info ()
-    {
-        std::cout << "This is ideal.II in version v"
-                  << IDEAL_II_VERSION_MAJOR << "."
-                  << IDEAL_II_VERSION_MINOR << "."
-                  << IDEAL_II_VERSION_PATCH;
+  void
+  print_version_info()
+  {
+    std::cout << "This is ideal.II in version v" << IDEAL_II_VERSION_MAJOR
+              << "." << IDEAL_II_VERSION_MINOR << "." << IDEAL_II_VERSION_PATCH;
 #ifdef DEBUG
-        std::cout << " in DEBUG mode";
+    std::cout << " in DEBUG mode";
 #endif
-        std::cout << std::endl;
-    }
-} //namespace deallib
+    std::cout << std::endl;
+  }
+} // namespace idealii

--- a/src/base/quadrature_lib.cc
+++ b/src/base/quadrature_lib.cc
@@ -13,293 +13,280 @@
 //
 // ---------------------------------------------------------------------
 
-#include <cmath>
+#include <ideal.II/base/quadrature_lib.hh>
+
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/quadrature.h>
-#include <ideal.II/base/quadrature_lib.hh>
 #include <deal.II/base/quadrature_lib.h>
+
+#include <cmath>
 #include <vector>
 namespace idealii
 {
-    namespace internal::QGaussRadau
+  namespace internal::QGaussRadau
+  {
+    // Implements lookup table after affine transformation to [0,1].
+    //
+    // Analytical values for [-1,1] and n < 4 listed on
+    // https://mathworld.wolfram.com/RadauQuadrature.html
+    // Values for n > 3 calculated with the Julia Package
+    // FastGaussQuadrature.jl
+    // https://github.com/JuliaApproximation/FastGaussQuadrature.jl
+    //
+    std::vector<double>
+    get_left_quadrature_points(const unsigned int n)
     {
-        // Implements lookup table after affine transformation to [0,1].
-        //
-        // Analytical values for [-1,1] and n < 4 listed on
-        // https://mathworld.wolfram.com/RadauQuadrature.html
-        // Values for n > 3 calculated with the Julia Package
-        // FastGaussQuadrature.jl
-        // https://github.com/JuliaApproximation/FastGaussQuadrature.jl
-        //
-        std::vector<double>
-        get_left_quadrature_points(const unsigned int n)
+      std::vector<double> q_points(n);
+      switch (n)
         {
-            std::vector<double> q_points(n);
-            switch(n)
-            {
-                case 1:
-                    q_points[0] = 0.;
-                    break;
-                case 2:
-                    q_points[0] = 0.;
-                    q_points[1] = 2./3.;
-                    break;
-                case 3:
-                    q_points[0] = 0.;
-                    q_points[1] = (6.-std::sqrt(6))*0.1;
-                    q_points[2] = (6.+std::sqrt(6))*0.1;
-                    break;
-                case 4:
-                    q_points[0] = 0.000000000000000000;
-                    q_points[1] = 0.212340538239152943;
-                    q_points[2] = 0.590533135559265343;
-                    q_points[3] = 0.911412040487296071;
-                    break;
-                case 5:
-                    q_points[0] = 0.000000000000000000;
-                    q_points[1] = 0.139759864343780571;
-                    q_points[2] = 0.416409567631083166;
-                    q_points[3] = 0.723156986361876197;
-                    q_points[4] = 0.942895803885482331;
-                    break;
-                case 6:
-                    q_points[0] = 0.000000000000000000;
-                    q_points[1] = 0.098535085798826416;
-                    q_points[2] = 0.304535726646363913;
-                    q_points[3] = 0.562025189752613841;
-                    q_points[4] = 0.801986582126391845;
-                    q_points[5] = 0.960190142948531222;
-                    break;
-                case 7:
-                    q_points[0] = 0.000000000000000000;
-                    q_points[1] = 0.073054328680258851;
-                    q_points[2] = 0.230766137969945495;
-                    q_points[3] = 0.441328481228449865;
-                    q_points[4] = 0.663015309718845702;
-                    q_points[5] = 0.851921400331515644;
-                    q_points[6] = 0.970683572840215114;
-                    break;
-                case 8:
-                    q_points[0] = 0.000000000000000000;
-                    q_points[1] = 0.056262560536922135;
-                    q_points[2] = 0.180240691736892389;
-                    q_points[3] = 0.352624717113169672;
-                    q_points[4] = 0.547153626330555420;
-                    q_points[5] = 0.734210177215410598;
-                    q_points[6] = 0.885320946839095790;
-                    q_points[7] = 0.977520613561287499;
-                    break;
-                default:
-                    Assert(false, dealii::StandardExceptions::ExcNotImplemented());
-                    break;
-            }
-            return q_points;
+          case 1:
+            q_points[0] = 0.;
+            break;
+          case 2:
+            q_points[0] = 0.;
+            q_points[1] = 2. / 3.;
+            break;
+          case 3:
+            q_points[0] = 0.;
+            q_points[1] = (6. - std::sqrt(6)) * 0.1;
+            q_points[2] = (6. + std::sqrt(6)) * 0.1;
+            break;
+          case 4:
+            q_points[0] = 0.000000000000000000;
+            q_points[1] = 0.212340538239152943;
+            q_points[2] = 0.590533135559265343;
+            q_points[3] = 0.911412040487296071;
+            break;
+          case 5:
+            q_points[0] = 0.000000000000000000;
+            q_points[1] = 0.139759864343780571;
+            q_points[2] = 0.416409567631083166;
+            q_points[3] = 0.723156986361876197;
+            q_points[4] = 0.942895803885482331;
+            break;
+          case 6:
+            q_points[0] = 0.000000000000000000;
+            q_points[1] = 0.098535085798826416;
+            q_points[2] = 0.304535726646363913;
+            q_points[3] = 0.562025189752613841;
+            q_points[4] = 0.801986582126391845;
+            q_points[5] = 0.960190142948531222;
+            break;
+          case 7:
+            q_points[0] = 0.000000000000000000;
+            q_points[1] = 0.073054328680258851;
+            q_points[2] = 0.230766137969945495;
+            q_points[3] = 0.441328481228449865;
+            q_points[4] = 0.663015309718845702;
+            q_points[5] = 0.851921400331515644;
+            q_points[6] = 0.970683572840215114;
+            break;
+          case 8:
+            q_points[0] = 0.000000000000000000;
+            q_points[1] = 0.056262560536922135;
+            q_points[2] = 0.180240691736892389;
+            q_points[3] = 0.352624717113169672;
+            q_points[4] = 0.547153626330555420;
+            q_points[5] = 0.734210177215410598;
+            q_points[6] = 0.885320946839095790;
+            q_points[7] = 0.977520613561287499;
+            break;
+          default:
+            Assert(false, dealii::StandardExceptions::ExcNotImplemented());
+            break;
         }
+      return q_points;
+    }
 
-        std::vector<double>
-        get_quadrature_points(const unsigned int                  n,
-                              ::idealii::QGaussRadau<1>::EndPoint end_point)
+    std::vector<double>
+    get_quadrature_points(const unsigned int                  n,
+                          ::idealii::QGaussRadau<1>::EndPoint end_point)
+    {
+      std::vector<double> left_points = get_left_quadrature_points(n);
+      switch (end_point)
         {
-            std::vector<double> left_points = get_left_quadrature_points(n);
-            switch(end_point)
+          case ::idealii::QGaussRadau<1>::left:
             {
-                case ::idealii::QGaussRadau<1>::left:
-                {
-                    return left_points;
-                }
-                case ::idealii::QGaussRadau<1>::right:
-                {
-                    std::vector<double> points(n);
-                    for (unsigned int i = 0 ; i < n ; ++i){
-                        points[n-i-1] = 1.-left_points[i];
-                    }
-                    return points;
-                }
-                default:
-                {
-                    Assert(
-                        false,
-                        dealii::ExcMessage(
-                          "This constructor can only be called with either "
-                          "QGaussRadau::left or QGaussRadau::right as "
-                          "second argument."  
-                        ));
-                    return {};
-                }
+              return left_points;
             }
-        }
-
-        // Implements lookup table after affine transformation to [0,1].
-        //
-        // Analytical values for [-1,1] and n < 4 listed on
-        // https://mathworld.wolfram.com/RadauQuadrature.html
-        // Values for n > 3 calculated with the Julia Package
-        // FastGaussQuadrature.jl
-        // https://github.com/JuliaApproximation/FastGaussQuadrature.jl
-        //
-        std::vector<double>
-        get_left_quadrature_weights(const unsigned int n)
-        {
-            std::vector<double> weights(n);
-            switch(n)
+          case ::idealii::QGaussRadau<1>::right:
             {
-                case 1:
-                    weights[0] = 1.;
-                    break;
-                case 2:
-                    weights[0] = 0.25;
-                    weights[1] = 0.75;
-                    break;
-                case 3:
-                    weights[0] = 1./9.;
-                    weights[1] = (16.+std::sqrt(6))/36.;
-                    weights[2] = (16.-std::sqrt(6))/36.;
-                    break;
-                case 4:
-                    weights[0] = 0.062500000000000000;
-                    weights[1] = 0.328844319980059696;
-                    weights[2] = 0.388193468843171852;
-                    weights[3] = 0.220462211176768369;
-                    break;
-                case 5:
-                    weights[0] = 0.040000000000000001;
-                    weights[1] = 0.223103901083570894;
-                    weights[2] = 0.311826522975741427;
-                    weights[3] = 0.281356015149462124;
-                    weights[4] = 0.143713560791225797;
-                    break;
-                case 6:
-                    weights[0] = 0.027777777777777776;
-                    weights[1] = 0.159820376610255471;
-                    weights[2] = 0.242693594234484888;
-                    weights[3] = 0.260463391594787597;
-                    weights[4] = 0.208450667155953895;
-                    weights[5] = 0.100794192626740456;
-                    break;
-                case 7:
-                    weights[0] = 0.020408163265306121;
-                    weights[1] = 0.119613744612656100;
-                    weights[2] = 0.190474936822115581;
-                    weights[3] = 0.223554914507283209;
-                    weights[4] = 0.212351889502977870;
-                    weights[5] = 0.159102115733650767;
-                    weights[6] = 0.074494235556010341;
-                    break;
-                case 8:
-                    weights[0] = 0.015625000000000000;
-                    weights[1] = 0.092679077401489660;
-                    weights[2] = 0.152065310323392683;
-                    weights[3] = 0.188258772694559262;
-                    weights[4] = 0.195786083726246729;
-                    weights[5] = 0.173507397817250691;
-                    weights[6] = 0.124823950664932445;
-                    weights[7] = 0.057254407372128648;
-                    break;
-                default:
-                    Assert(false, dealii::StandardExceptions::ExcNotImplemented());
-                    break;
-            }
-            return weights;
-        }
-        std::vector<double>
-        get_quadrature_weights(const unsigned int                       n,
-                            const ::idealii::QGaussRadau<1>::EndPoint end_point)
-        {
-        std::vector<double> left_weights = get_left_quadrature_weights(n);
-        switch (end_point)
-            {
-            case ::idealii::QGaussRadau<1>::EndPoint::left:
-                return left_weights;
-            case ::idealii::QGaussRadau<1>::EndPoint::right:
+              std::vector<double> points(n);
+              for (unsigned int i = 0; i < n; ++i)
                 {
-                std::vector<double> weights(n);
-                for (unsigned int i = 0; i < n; ++i)
-                    {
-                    weights[n - i - 1] = left_weights[i];
-                    }
-                return weights;
+                  points[n - i - 1] = 1. - left_points[i];
                 }
-            default:
-                Assert(false,
-                    dealii::ExcMessage(
-                        "This constructor can only be called with either "
-                        "QGaussRadau::EndPoint::left or "
-                        "QGaussRadau::EndPoint::right as second argument."));
-                return {};
+              return points;
+            }
+          default:
+            {
+              Assert(false,
+                     dealii::ExcMessage(
+                       "This constructor can only be called with either "
+                       "QGaussRadau::left or QGaussRadau::right as "
+                       "second argument."));
+              return {};
             }
         }
     }
+
+    // Implements lookup table after affine transformation to [0,1].
+    //
+    // Analytical values for [-1,1] and n < 4 listed on
+    // https://mathworld.wolfram.com/RadauQuadrature.html
+    // Values for n > 3 calculated with the Julia Package
+    // FastGaussQuadrature.jl
+    // https://github.com/JuliaApproximation/FastGaussQuadrature.jl
+    //
+    std::vector<double>
+    get_left_quadrature_weights(const unsigned int n)
+    {
+      std::vector<double> weights(n);
+      switch (n)
+        {
+          case 1:
+            weights[0] = 1.;
+            break;
+          case 2:
+            weights[0] = 0.25;
+            weights[1] = 0.75;
+            break;
+          case 3:
+            weights[0] = 1. / 9.;
+            weights[1] = (16. + std::sqrt(6)) / 36.;
+            weights[2] = (16. - std::sqrt(6)) / 36.;
+            break;
+          case 4:
+            weights[0] = 0.062500000000000000;
+            weights[1] = 0.328844319980059696;
+            weights[2] = 0.388193468843171852;
+            weights[3] = 0.220462211176768369;
+            break;
+          case 5:
+            weights[0] = 0.040000000000000001;
+            weights[1] = 0.223103901083570894;
+            weights[2] = 0.311826522975741427;
+            weights[3] = 0.281356015149462124;
+            weights[4] = 0.143713560791225797;
+            break;
+          case 6:
+            weights[0] = 0.027777777777777776;
+            weights[1] = 0.159820376610255471;
+            weights[2] = 0.242693594234484888;
+            weights[3] = 0.260463391594787597;
+            weights[4] = 0.208450667155953895;
+            weights[5] = 0.100794192626740456;
+            break;
+          case 7:
+            weights[0] = 0.020408163265306121;
+            weights[1] = 0.119613744612656100;
+            weights[2] = 0.190474936822115581;
+            weights[3] = 0.223554914507283209;
+            weights[4] = 0.212351889502977870;
+            weights[5] = 0.159102115733650767;
+            weights[6] = 0.074494235556010341;
+            break;
+          case 8:
+            weights[0] = 0.015625000000000000;
+            weights[1] = 0.092679077401489660;
+            weights[2] = 0.152065310323392683;
+            weights[3] = 0.188258772694559262;
+            weights[4] = 0.195786083726246729;
+            weights[5] = 0.173507397817250691;
+            weights[6] = 0.124823950664932445;
+            weights[7] = 0.057254407372128648;
+            break;
+          default:
+            Assert(false, dealii::StandardExceptions::ExcNotImplemented());
+            break;
+        }
+      return weights;
+    }
+    std::vector<double>
+    get_quadrature_weights(const unsigned int                        n,
+                           const ::idealii::QGaussRadau<1>::EndPoint end_point)
+    {
+      std::vector<double> left_weights = get_left_quadrature_weights(n);
+      switch (end_point)
+        {
+          case ::idealii::QGaussRadau<1>::EndPoint::left:
+            return left_weights;
+          case ::idealii::QGaussRadau<1>::EndPoint::right:
+            {
+              std::vector<double> weights(n);
+              for (unsigned int i = 0; i < n; ++i)
+                {
+                  weights[n - i - 1] = left_weights[i];
+                }
+              return weights;
+            }
+          default:
+            Assert(false,
+                   dealii::ExcMessage(
+                     "This constructor can only be called with either "
+                     "QGaussRadau::EndPoint::left or "
+                     "QGaussRadau::EndPoint::right as second argument."));
+            return {};
+        }
+    }
+  } // namespace internal::QGaussRadau
 
 #ifndef DOXYGEN
-    template<>
-    QGaussRadau<1>::QGaussRadau(const unsigned int n, EndPoint end_point)
-        : dealii::Quadrature<1>(n),
-        end_point(end_point)
-    {
-        Assert(n > 0, dealii::ExcMessage("Need at least one point for quadrature rules"));
-        std::vector<double> p = 
-          internal::QGaussRadau::get_quadrature_points(n,end_point);
-        std::vector<double> w = 
-          internal::QGaussRadau::get_quadrature_weights(n,end_point);
+  template <>
+  QGaussRadau<1>::QGaussRadau(const unsigned int n, EndPoint end_point)
+    : dealii::Quadrature<1>(n)
+    , end_point(end_point)
+  {
+    Assert(n > 0,
+           dealii::ExcMessage("Need at least one point for quadrature rules"));
+    std::vector<double> p =
+      internal::QGaussRadau::get_quadrature_points(n, end_point);
+    std::vector<double> w =
+      internal::QGaussRadau::get_quadrature_weights(n, end_point);
 
-        for ( unsigned int i = 0 ; i < this->size() ; ++i)
-        {
-            this->quadrature_points[i] = dealii::Point<1>(p[i]);
-            this->weights[i]           = w[i];
-        }
-    }
+    for (unsigned int i = 0; i < this->size(); ++i)
+      {
+        this->quadrature_points[i] = dealii::Point<1>(p[i]);
+        this->weights[i]           = w[i];
+      }
+  }
 #endif
 
-    template<int dim>
-    QGaussRadau<dim>::QGaussRadau(const unsigned int n,
-                                  EndPoint           end_point)
-        : dealii::Quadrature<dim>(QGaussRadau<1>(
-            n,
-            static_cast<QGaussRadau<1>::EndPoint>(end_point)))
-        , end_point(end_point)
+  template <int dim>
+  QGaussRadau<dim>::QGaussRadau(const unsigned int n, EndPoint end_point)
+    : dealii::Quadrature<dim>(
+        QGaussRadau<1>(n, static_cast<QGaussRadau<1>::EndPoint>(end_point)))
+    , end_point(end_point)
+  {}
+
+  QRightBox::QRightBox()
+    : QGaussRadau<1>(1, QGaussRadau<1>::EndPoint::right)
+  {}
+
+  QLeftBox::QLeftBox()
+    : QGaussRadau<1>(1, QGaussRadau<1>::EndPoint::right)
+  {}
+
+  namespace spacetime
+  {
+    template <int dim>
+    QGauss<dim>::QGauss(unsigned int n_spatial, unsigned int n_temporal)
+      : Quadrature<dim>(std::make_shared<dealii::QGauss<dim>>(n_spatial),
+                        std::make_shared<dealii::QGauss<1>>(n_temporal))
     {}
 
-    QRightBox::QRightBox ()
-        :
-        QGaussRadau<1> ( 1 , QGaussRadau<1>::EndPoint::right )
+    template <int dim>
+    QGaussRightBox<dim>::QGaussRightBox(unsigned int n_spatial)
+      : Quadrature<dim>(std::make_shared<dealii::QGauss<dim>>(n_spatial),
+                        std::make_shared<QRightBox>())
     {}
 
-    QLeftBox::QLeftBox ()
-        :
-        QGaussRadau<1> ( 1, QGaussRadau<1>::EndPoint::right )
+    template <int dim>
+    QGaussLeftBox<dim>::QGaussLeftBox(unsigned int n_spatial)
+      : Quadrature<dim>(std::make_shared<dealii::QGauss<dim>>(n_spatial),
+                        std::make_shared<QLeftBox>())
     {}
-    
-    namespace spacetime
-    {
-        template<int dim>
-        QGauss<dim>::QGauss ( unsigned int n_spatial ,
-                              unsigned int n_temporal )
-            :
-            Quadrature<dim> ( std::make_shared<dealii::QGauss<dim>> ( n_spatial ) ,
-                              std::make_shared<dealii::QGauss<1>> ( n_temporal )
-            )
-        {
-        }
-
-        template<int dim>
-        QGaussRightBox<dim>::QGaussRightBox ( unsigned int n_spatial )
-            :
-            Quadrature<dim> ( std::make_shared<dealii::QGauss<dim>> ( n_spatial ) ,
-                              std::make_shared<QRightBox> ()
-            )
-        {
-        }
-
-        template<int dim>
-        QGaussLeftBox<dim>::QGaussLeftBox ( unsigned int n_spatial )
-            :
-            Quadrature<dim> ( std::make_shared<dealii::QGauss<dim>> ( n_spatial ) ,
-                              std::make_shared<QLeftBox> ()
-            )
-        {
-        }
-    }
-}
+  } // namespace spacetime
+} // namespace idealii
 
 #include "quadrature_lib.inst"
-

--- a/src/base/quadrature_lib.inst
+++ b/src/base/quadrature_lib.inst
@@ -18,7 +18,7 @@
 
 namespace idealii
 {
-  
+
   // explicit specialization
   // note that 1d formulae are specialized by implementation
   template class QGaussRadau<2>;
@@ -26,14 +26,14 @@ namespace idealii
 
   namespace spacetime
   {
-    template class QGauss<1> ;
-    template class QGauss<2> ;
-    template class QGauss<3> ;
+    template class QGauss<1>;
+    template class QGauss<2>;
+    template class QGauss<3>;
 
-    template class QGaussRightBox<1> ;
-    template class QGaussRightBox<2> ;
-    template class QGaussRightBox<3> ;
-  }
-}
+    template class QGaussRightBox<1>;
+    template class QGaussRightBox<2>;
+    template class QGaussRightBox<3>;
+  } // namespace spacetime
+} // namespace idealii
 
 #endif

--- a/src/base/spacetime_quadrature.cc
+++ b/src/base/spacetime_quadrature.cc
@@ -18,29 +18,30 @@
 namespace idealii::spacetime
 {
 
-    template<int dim>
-    Quadrature<dim>::Quadrature (
-            std::shared_ptr<dealii::Quadrature<dim>> quad_space ,
-            std::shared_ptr<dealii::Quadrature<1>> quad_time )
-    {
-        Assert( quad_space.use_count () , dealii::ExcNotImplemented () );
-        Assert( quad_time.use_count () , dealii::ExcNotImplemented () );
-        _quad_space = quad_space;
-        _quad_time = quad_time;
-    }
+  template <int dim>
+  Quadrature<dim>::Quadrature(
+    std::shared_ptr<dealii::Quadrature<dim>> quad_space,
+    std::shared_ptr<dealii::Quadrature<1>>   quad_time)
+  {
+    Assert(quad_space.use_count(), dealii::ExcNotImplemented());
+    Assert(quad_time.use_count(), dealii::ExcNotImplemented());
+    _quad_space = quad_space;
+    _quad_time  = quad_time;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::Quadrature<dim>> Quadrature<dim>::spatial ()
-    {
-        return _quad_space;
-    }
+  template <int dim>
+  std::shared_ptr<dealii::Quadrature<dim>>
+  Quadrature<dim>::spatial()
+  {
+    return _quad_space;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::Quadrature<1>> Quadrature<dim>::temporal ()
-    {
-        return _quad_time;
-    }
-}
+  template <int dim>
+  std::shared_ptr<dealii::Quadrature<1>>
+  Quadrature<dim>::temporal()
+  {
+    return _quad_time;
+  }
+} // namespace idealii::spacetime
 
 #include "spacetime_quadrature.inst"
-

--- a/src/base/spacetime_quadrature.inst
+++ b/src/base/spacetime_quadrature.inst
@@ -18,9 +18,9 @@
 
 namespace idealii::spacetime
 {
-    template class Quadrature<1> ;
-    template class Quadrature<2> ;
-    template class Quadrature<3> ;
-}
+  template class Quadrature<1>;
+  template class Quadrature<2>;
+  template class Quadrature<3>;
+} // namespace idealii::spacetime
 
 #endif

--- a/src/base/time_iterator.cc
+++ b/src/base/time_iterator.cc
@@ -17,266 +17,278 @@
 
 namespace idealii
 {
-    template<int dim>
-    TimeIteratorCollection<dim>::TimeIteratorCollection ()
-    {
-        tria.it_collection = std::vector<slab::TriaIterator<dim>*> ();
-        tria.obj_collection =
-            std::vector<spacetime::Triangulation<dim>*> ();
+  template <int dim>
+  TimeIteratorCollection<dim>::TimeIteratorCollection()
+  {
+    tria.it_collection  = std::vector<slab::TriaIterator<dim> *>();
+    tria.obj_collection = std::vector<spacetime::Triangulation<dim> *>();
 
 #ifdef DEAL__II_WITH_MPI
-        par_dist_tria.it_collection =
-            std::vector<slab::parallel::distributed::TriaIterator<dim>*> ();
+    par_dist_tria.it_collection =
+      std::vector<slab::parallel::distributed::TriaIterator<dim> *>();
 
-        par_dist_tria.obj_collection =
-            std::vector<spacetime::parallel::distributed::Triangulation<dim>*> ();
+    par_dist_tria.obj_collection =
+      std::vector<spacetime::parallel::distributed::Triangulation<dim> *>();
 #endif
-        dof.it_collection = std::vector<slab::DoFHandlerIterator<dim>*> ();
-        dof.obj_collection = std::vector<spacetime::DoFHandler<dim>*> ();
+    dof.it_collection  = std::vector<slab::DoFHandlerIterator<dim> *>();
+    dof.obj_collection = std::vector<spacetime::DoFHandler<dim> *>();
 
-        vector_double.it_collection = std::vector<slab::VectorIterator<double>*> ();
+    vector_double.it_collection = std::vector<slab::VectorIterator<double> *>();
 
-        vector_double.obj_collection = std::vector<spacetime::Vector<double>*> ();
+    vector_double.obj_collection = std::vector<spacetime::Vector<double> *>();
 #ifdef DEAL_II_WITH_MPI
-        trilinos_vector.it_collection = std::vector<slab::TrilinosVectorIterator*> ();
+    trilinos_vector.it_collection =
+      std::vector<slab::TrilinosVectorIterator *>();
 
-        trilinos_vector.obj_collection = std::vector<spacetime::TrilinosVector*> ();
+    trilinos_vector.obj_collection = std::vector<spacetime::TrilinosVector *>();
 #endif
-    }
+  }
 
-    template<int dim>
-    void TimeIteratorCollection<dim>::add_iterator (
-         slab::TriaIterator<dim> *it ,
-         spacetime::Triangulation<dim> *obj )
-    {
-        tria.it_collection.push_back ( it );
-        tria.obj_collection.push_back ( obj );
-    }
-
-#ifdef DEAL_II_WITH_MPI
-    template<int dim>
-    void TimeIteratorCollection<dim>::add_iterator (
-         slab::parallel::distributed::TriaIterator<dim> *it ,
-         spacetime::parallel::distributed::Triangulation<dim> *obj )
-    {
-        par_dist_tria.it_collection.push_back ( it );
-        par_dist_tria.obj_collection.push_back ( obj );
-    }
-#endif
-
-    template<int dim>
-    void TimeIteratorCollection<dim>::add_iterator (
-         slab::DoFHandlerIterator<dim> *it ,
-         spacetime::DoFHandler<dim> *obj )
-    {
-        dof.it_collection.push_back ( it );
-        dof.obj_collection.push_back ( obj );
-    }
-
-    template<int dim>
-    void TimeIteratorCollection<dim>::add_iterator (
-         slab::VectorIterator<double> *it ,
-         spacetime::Vector<double> *obj )
-    {
-        vector_double.it_collection.push_back ( it );
-        vector_double.obj_collection.push_back ( obj );
-    }
-#ifdef DEAL_II_WITH_MPI
-    template<int dim>
-    void TimeIteratorCollection<dim>::add_iterator (
-         slab::TrilinosVectorIterator *it ,
-         spacetime::TrilinosVector *obj )
-    {
-        trilinos_vector.it_collection.push_back ( it );
-        trilinos_vector.obj_collection.push_back ( obj );
-    }
-#endif
-    template<int dim>
-    void TimeIteratorCollection<dim>::increment ()
-    {
-        for ( unsigned int i = 0 ; i < tria.it_collection.size () ; i++ )
-        {
-            Assert( *tria.it_collection[i] != tria.obj_collection[i]->end () ,
-                    dealii::ExcIteratorPastEnd () );
-            ++( *tria.it_collection[i] );
-        }
+  template <int dim>
+  void
+  TimeIteratorCollection<dim>::add_iterator(slab::TriaIterator<dim>       *it,
+                                            spacetime::Triangulation<dim> *obj)
+  {
+    tria.it_collection.push_back(it);
+    tria.obj_collection.push_back(obj);
+  }
 
 #ifdef DEAL_II_WITH_MPI
-        for ( unsigned int i = 0 ; i < par_dist_tria.it_collection.size () ;
-                i++ )
-        {
-            Assert( *par_dist_tria.it_collection[i] != par_dist_tria.obj_collection[i]->end () ,
-                    dealii::ExcIteratorPastEnd () );
-            ++( *par_dist_tria.it_collection[i] );
-        }
+  template <int dim>
+  void
+  TimeIteratorCollection<dim>::add_iterator(
+    slab::parallel::distributed::TriaIterator<dim>       *it,
+    spacetime::parallel::distributed::Triangulation<dim> *obj)
+  {
+    par_dist_tria.it_collection.push_back(it);
+    par_dist_tria.obj_collection.push_back(obj);
+  }
 #endif
-        for ( unsigned int i = 0 ; i < dof.it_collection.size () ; i++ )
-        {
-            Assert( *dof.it_collection[i] != dof.obj_collection[i]->end () ,
-                    dealii::ExcIteratorPastEnd () );
-            ++( *dof.it_collection[i] );
-        }
-        for ( unsigned int i = 0 ; i < vector_double.it_collection.size () ; i++ )
-        {
-            Assert( *vector_double.it_collection[i] != vector_double.obj_collection[i]->end () ,
-                    dealii::ExcIteratorPastEnd () );
-            ++( *vector_double.it_collection[i] );
-        }
-#ifdef DEAL_II_WITH_MPI
-        for ( unsigned int i = 0 ; i < trilinos_vector.it_collection.size () ; i++ )
-        {
-            Assert( *trilinos_vector.it_collection[i] != trilinos_vector.obj_collection[i]->end () ,
-                    dealii::ExcIteratorPastEnd () );
-            ++( *trilinos_vector.it_collection[i] );
-        }
-#endif
-    }
 
-    template<int dim>
-    void TimeIteratorCollection<dim>::decrement ()
-    {
-        for ( unsigned int i = 0 ; i < tria.it_collection.size () ; i++ )
-        {
-            Assert( *tria.it_collection[i] != std::prev ( tria.obj_collection[i]->begin () ) ,
-                    dealii::ExcIteratorPastEnd () );
-            --( *tria.it_collection[i] );
-        }
+  template <int dim>
+  void
+  TimeIteratorCollection<dim>::add_iterator(slab::DoFHandlerIterator<dim> *it,
+                                            spacetime::DoFHandler<dim>    *obj)
+  {
+    dof.it_collection.push_back(it);
+    dof.obj_collection.push_back(obj);
+  }
+
+  template <int dim>
+  void
+  TimeIteratorCollection<dim>::add_iterator(slab::VectorIterator<double> *it,
+                                            spacetime::Vector<double>    *obj)
+  {
+    vector_double.it_collection.push_back(it);
+    vector_double.obj_collection.push_back(obj);
+  }
+#ifdef DEAL_II_WITH_MPI
+  template <int dim>
+  void
+  TimeIteratorCollection<dim>::add_iterator(slab::TrilinosVectorIterator *it,
+                                            spacetime::TrilinosVector    *obj)
+  {
+    trilinos_vector.it_collection.push_back(it);
+    trilinos_vector.obj_collection.push_back(obj);
+  }
+#endif
+  template <int dim>
+  void
+  TimeIteratorCollection<dim>::increment()
+  {
+    for (unsigned int i = 0; i < tria.it_collection.size(); i++)
+      {
+        Assert(*tria.it_collection[i] != tria.obj_collection[i]->end(),
+               dealii::ExcIteratorPastEnd());
+        ++(*tria.it_collection[i]);
+      }
 
 #ifdef DEAL_II_WITH_MPI
-        for ( unsigned int i = 0 ; i < par_dist_tria.it_collection.size () ; i++ )
-        {
-            Assert( *par_dist_tria.it_collection[i] != std::prev ( par_dist_tria.obj_collection[i]->begin () ) ,
-                    dealii::ExcIteratorPastEnd () );
-            --( *par_dist_tria.it_collection[i] );
-        }
+    for (unsigned int i = 0; i < par_dist_tria.it_collection.size(); i++)
+      {
+        Assert(*par_dist_tria.it_collection[i] !=
+                 par_dist_tria.obj_collection[i]->end(),
+               dealii::ExcIteratorPastEnd());
+        ++(*par_dist_tria.it_collection[i]);
+      }
 #endif
-        for ( unsigned int i = 0 ; i < dof.it_collection.size () ; i++ )
-        {
-            Assert( *dof.it_collection[i] != std::prev ( dof.obj_collection[i]->begin () ) ,
-                    dealii::ExcIteratorPastEnd () );
-            --( *dof.it_collection[i] );
-        }
-        for ( unsigned int i = 0 ; i < vector_double.it_collection.size () ; i++ )
-        {
-            Assert( *vector_double.it_collection[i] != std::prev ( vector_double.obj_collection[i]->begin () ) ,
-                    dealii::ExcIteratorPastEnd () );
-            --( *vector_double.it_collection[i] );
-        }
+    for (unsigned int i = 0; i < dof.it_collection.size(); i++)
+      {
+        Assert(*dof.it_collection[i] != dof.obj_collection[i]->end(),
+               dealii::ExcIteratorPastEnd());
+        ++(*dof.it_collection[i]);
+      }
+    for (unsigned int i = 0; i < vector_double.it_collection.size(); i++)
+      {
+        Assert(*vector_double.it_collection[i] !=
+                 vector_double.obj_collection[i]->end(),
+               dealii::ExcIteratorPastEnd());
+        ++(*vector_double.it_collection[i]);
+      }
+#ifdef DEAL_II_WITH_MPI
+    for (unsigned int i = 0; i < trilinos_vector.it_collection.size(); i++)
+      {
+        Assert(*trilinos_vector.it_collection[i] !=
+                 trilinos_vector.obj_collection[i]->end(),
+               dealii::ExcIteratorPastEnd());
+        ++(*trilinos_vector.it_collection[i]);
+      }
+#endif
+  }
+
+  template <int dim>
+  void
+  TimeIteratorCollection<dim>::decrement()
+  {
+    for (unsigned int i = 0; i < tria.it_collection.size(); i++)
+      {
+        Assert(*tria.it_collection[i] !=
+                 std::prev(tria.obj_collection[i]->begin()),
+               dealii::ExcIteratorPastEnd());
+        --(*tria.it_collection[i]);
+      }
+
+#ifdef DEAL_II_WITH_MPI
+    for (unsigned int i = 0; i < par_dist_tria.it_collection.size(); i++)
+      {
+        Assert(*par_dist_tria.it_collection[i] !=
+                 std::prev(par_dist_tria.obj_collection[i]->begin()),
+               dealii::ExcIteratorPastEnd());
+        --(*par_dist_tria.it_collection[i]);
+      }
+#endif
+    for (unsigned int i = 0; i < dof.it_collection.size(); i++)
+      {
+        Assert(*dof.it_collection[i] !=
+                 std::prev(dof.obj_collection[i]->begin()),
+               dealii::ExcIteratorPastEnd());
+        --(*dof.it_collection[i]);
+      }
+    for (unsigned int i = 0; i < vector_double.it_collection.size(); i++)
+      {
+        Assert(*vector_double.it_collection[i] !=
+                 std::prev(vector_double.obj_collection[i]->begin()),
+               dealii::ExcIteratorPastEnd());
+        --(*vector_double.it_collection[i]);
+      }
 #ifdef DEAL_II_WITH_TRILINOS
-#ifdef DEAL_II_WITH_MPI
-        for ( unsigned int i = 0 ; i < trilinos_vector.it_collection.size () ; i++ )
-        {
-            Assert( *trilinos_vector.it_collection[i] != std::prev ( trilinos_vector.obj_collection[i]->begin () ) ,
-                    dealii::ExcIteratorPastEnd () );
-            --( *trilinos_vector.it_collection[i] );
-        }
+#  ifdef DEAL_II_WITH_MPI
+    for (unsigned int i = 0; i < trilinos_vector.it_collection.size(); i++)
+      {
+        Assert(*trilinos_vector.it_collection[i] !=
+                 std::prev(trilinos_vector.obj_collection[i]->begin()),
+               dealii::ExcIteratorPastEnd());
+        --(*trilinos_vector.it_collection[i]);
+      }
+#  endif
 #endif
-#endif
-    }
+  }
 
-    template<int dim>
-    bool TimeIteratorCollection<dim>::at_end ()
-    {
-        bool res = false;
-        for ( unsigned int i = 0 ; i < tria.it_collection.size () ; i++ )
-        {
-            if ( *tria.it_collection[i] == tria.obj_collection[i]->end () )
-            {
-                res = true;
-            }
-        }
+  template <int dim>
+  bool
+  TimeIteratorCollection<dim>::at_end()
+  {
+    bool res = false;
+    for (unsigned int i = 0; i < tria.it_collection.size(); i++)
+      {
+        if (*tria.it_collection[i] == tria.obj_collection[i]->end())
+          {
+            res = true;
+          }
+      }
 
 #ifdef DEAL_II_WITH_MPI
-        for ( unsigned int i = 0 ; i < par_dist_tria.it_collection.size () ;
-                i++ )
-        {
-            if ( *par_dist_tria.it_collection[i] == par_dist_tria.obj_collection[i]->end () )
-            {
-                res = true;
-            }
-        }
+    for (unsigned int i = 0; i < par_dist_tria.it_collection.size(); i++)
+      {
+        if (*par_dist_tria.it_collection[i] ==
+            par_dist_tria.obj_collection[i]->end())
+          {
+            res = true;
+          }
+      }
 #endif
-        for ( unsigned int i = 0 ; i < dof.it_collection.size () ; i++ )
-        {
-            if ( *dof.it_collection[i] == dof.obj_collection[i]->end () )
-            {
-                res = true;
-            }
-        }
-        for ( unsigned int i = 0 ; i < vector_double.it_collection.size () ;
-                i++ )
-        {
-            if ( *vector_double.it_collection[i] == vector_double.obj_collection[i]->end () )
-            {
-                res = true;
-            }
-        }
+    for (unsigned int i = 0; i < dof.it_collection.size(); i++)
+      {
+        if (*dof.it_collection[i] == dof.obj_collection[i]->end())
+          {
+            res = true;
+          }
+      }
+    for (unsigned int i = 0; i < vector_double.it_collection.size(); i++)
+      {
+        if (*vector_double.it_collection[i] ==
+            vector_double.obj_collection[i]->end())
+          {
+            res = true;
+          }
+      }
 #ifdef DEAL_II_WITH_TRILINOS
-#ifdef DEAL_II_WITH_MPI
-        for ( unsigned int i = 0 ;
-                i < trilinos_vector.it_collection.size () ; i++ )
-        {
-            if ( *trilinos_vector.it_collection[i] == trilinos_vector.obj_collection[i]->end () )
-            {
-                res = true;
-            }
-        }
+#  ifdef DEAL_II_WITH_MPI
+    for (unsigned int i = 0; i < trilinos_vector.it_collection.size(); i++)
+      {
+        if (*trilinos_vector.it_collection[i] ==
+            trilinos_vector.obj_collection[i]->end())
+          {
+            res = true;
+          }
+      }
+#  endif
 #endif
-#endif
-        return res;
-    }
+    return res;
+  }
 
-    template<int dim>
-    bool TimeIteratorCollection<dim>::before_begin ()
-    {
-        bool res = false;
-        for ( unsigned int i = 0 ; i < tria.it_collection.size () ; i++ )
-        {
-            if ( *tria.it_collection[i] == std::prev ( tria.obj_collection[i]->begin () ) )
-            {
-                res = true;
-            }
-        }
+  template <int dim>
+  bool
+  TimeIteratorCollection<dim>::before_begin()
+  {
+    bool res = false;
+    for (unsigned int i = 0; i < tria.it_collection.size(); i++)
+      {
+        if (*tria.it_collection[i] ==
+            std::prev(tria.obj_collection[i]->begin()))
+          {
+            res = true;
+          }
+      }
 #ifdef DEAL_II_WITH_MPI
-        for ( unsigned int i = 0 ; i < par_dist_tria.it_collection.size () ;
-                i++ )
-        {
-            if ( *par_dist_tria.it_collection[i] == std::prev ( par_dist_tria.obj_collection[i]->begin () ) )
-            {
-                res = true;
-            }
-        }
+    for (unsigned int i = 0; i < par_dist_tria.it_collection.size(); i++)
+      {
+        if (*par_dist_tria.it_collection[i] ==
+            std::prev(par_dist_tria.obj_collection[i]->begin()))
+          {
+            res = true;
+          }
+      }
 #endif
-        for ( unsigned int i = 0 ; i < dof.it_collection.size () ; i++ )
-        {
-            if ( *dof.it_collection[i] == std::prev ( dof.obj_collection[i]->begin () ) )
-            {
-                res = true;
-            }
-        }
-        for ( unsigned int i = 0 ; i < vector_double.it_collection.size () ;
-                i++ )
-        {
-            if ( *vector_double.it_collection[i] == std::prev ( vector_double.obj_collection[i]->begin () ) )
-            {
-                res = true;
-            }
-        }
+    for (unsigned int i = 0; i < dof.it_collection.size(); i++)
+      {
+        if (*dof.it_collection[i] == std::prev(dof.obj_collection[i]->begin()))
+          {
+            res = true;
+          }
+      }
+    for (unsigned int i = 0; i < vector_double.it_collection.size(); i++)
+      {
+        if (*vector_double.it_collection[i] ==
+            std::prev(vector_double.obj_collection[i]->begin()))
+          {
+            res = true;
+          }
+      }
 #ifdef DEAL_II_WITH_TRILINOS
-#ifdef DEAL_II_WITH_MPI
-        for ( unsigned int i = 0 ;
-                i < trilinos_vector.it_collection.size () ; i++ )
-        {
-            if ( *trilinos_vector.it_collection[i] == std::prev ( trilinos_vector.obj_collection[i]->begin () ) )
-            {
-                res = true;
-            }
-        }
+#  ifdef DEAL_II_WITH_MPI
+    for (unsigned int i = 0; i < trilinos_vector.it_collection.size(); i++)
+      {
+        if (*trilinos_vector.it_collection[i] ==
+            std::prev(trilinos_vector.obj_collection[i]->begin()))
+          {
+            res = true;
+          }
+      }
+#  endif
 #endif
-#endif
-        return res;
-    }
-}
+    return res;
+  }
+} // namespace idealii
 
 #include "time_iterator.inst"
-

--- a/src/base/time_iterator.inst
+++ b/src/base/time_iterator.inst
@@ -19,8 +19,8 @@
 namespace idealii
 {
 
-    template class TimeIteratorCollection<2> ;
-    template class TimeIteratorCollection<3> ;
-}
+  template class TimeIteratorCollection<2>;
+  template class TimeIteratorCollection<3>;
+} // namespace idealii
 
 #endif

--- a/src/distributed/fixed_tria.cc
+++ b/src/distributed/fixed_tria.cc
@@ -18,101 +18,129 @@
 #ifdef DEAL_II_WITH_MPI
 namespace idealii::spacetime::parallel::distributed::fixed
 {
-    template<int dim>
-    Triangulation<dim>::Triangulation (dealii::types::global_cell_index max_N_intervals_per_slab)
-    :
-    spacetime::parallel::distributed::Triangulation<dim> (max_N_intervals_per_slab)
-    {
-    }
+  template <int dim>
+  Triangulation<dim>::Triangulation(
+    dealii::types::global_cell_index max_N_intervals_per_slab)
+    : spacetime::parallel::distributed::Triangulation<dim>(
+        max_N_intervals_per_slab)
+  {}
 
-    template<int dim>
-    void Triangulation<dim>::generate (
-        std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> space_tria ,
-        unsigned int M ,
-        double t0 , double T )
-    {
-        Assert( space_tria.use_count () , dealii::ExcNotInitialized () );
-        //Todo: somehow assert that space_tria is actually parallel distributed
-        double t = t0;
-        double k = ( T - t0 ) / M;
-        for ( unsigned int i = 0 ; i < M ; i++ )
-        {
-            this->trias.push_back (
-                idealii::slab::parallel::distributed::Triangulation<dim> ( space_tria , t , t + k ) );
-            t += k;
-        }
-    }
+  template <int dim>
+  void
+  Triangulation<dim>::generate(
+    std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+                 space_tria,
+    unsigned int M,
+    double       t0,
+    double       T)
+  {
+    Assert(space_tria.use_count(), dealii::ExcNotInitialized());
+    // Todo: somehow assert that space_tria is actually parallel distributed
+    double t = t0;
+    double k = (T - t0) / M;
+    for (unsigned int i = 0; i < M; i++)
+      {
+        this->trias.push_back(
+          idealii::slab::parallel::distributed::Triangulation<dim>(space_tria,
+                                                                   t,
+                                                                   t + k));
+        t += k;
+      }
+  }
 
-    template<int dim>
-    void Triangulation<dim>::refine_global (
-            const unsigned int times_space , const unsigned int times_time )
-    {
-
-        slab::parallel::distributed::TriaIterator<dim> slab_tria = this->begin ();
-        slab_tria->spatial ()->refine_global ( times_space );
-        for ( ; slab_tria != this->end () ; ++slab_tria )
-        {
-            slab_tria->temporal ()->refine_global ( times_time );
-
-
-            //Check if temporal triangulation got too large (unless max_N = 0)
-            if ( this->max_N_intervals_per_slab &&
-                 slab_tria->temporal()->n_global_active_cells() > this->max_N_intervals_per_slab)
-            {
-                dealii::types::global_cell_index M = slab_tria->temporal()->n_global_active_cells();
-                std::vector<double> step_sizes(M);
-                dealii::types::global_cell_index i = 0;
-                for (auto &cell : slab_tria->temporal()->active_cell_iterators()){
-                    step_sizes[i] = cell->bounding_box().side_length(0);
-                    i++;
-                }
-
-                //number of subdivisions needed is at least
-                dealii::types::global_cell_index subdiv = M/this->max_N_intervals_per_slab;
-                //remaining intervals?
-                dealii::types::global_cell_index modulus = M%this->max_N_intervals_per_slab;
-
-                std::vector<std::vector<double>> partial_step_sizes;
-                for ( dealii::types::global_cell_index j = 0 ; j < subdiv ; j++){
-                    partial_step_sizes.push_back(std::vector<double>(this->max_N_intervals_per_slab));
-                }
-                if ( modulus ){
-                    partial_step_sizes.push_back(std::vector<double>(modulus));
-                }
+  template <int dim>
+  void
+  Triangulation<dim>::refine_global(const unsigned int times_space,
+                                    const unsigned int times_time)
+  {
+    slab::parallel::distributed::TriaIterator<dim> slab_tria = this->begin();
+    slab_tria->spatial()->refine_global(times_space);
+    for (; slab_tria != this->end(); ++slab_tria)
+      {
+        slab_tria->temporal()->refine_global(times_time);
 
 
-                //Distribute step sizes onto subdivisions
-                for ( i = 0 ; i < M ; ++i ){
-                    dealii::types::global_cell_index j = i/this->max_N_intervals_per_slab;
-                    dealii::types::global_cell_index k  = i%this->max_N_intervals_per_slab;
-                    partial_step_sizes[j][k] = step_sizes[i];
-                }
+        // Check if temporal triangulation got too large (unless max_N = 0)
+        if (this->max_N_intervals_per_slab &&
+            slab_tria->temporal()->n_global_active_cells() >
+              this->max_N_intervals_per_slab)
+          {
+            dealii::types::global_cell_index M =
+              slab_tria->temporal()->n_global_active_cells();
+            std::vector<double>              step_sizes(M);
+            dealii::types::global_cell_index i = 0;
+            for (auto &cell : slab_tria->temporal()->active_cell_iterators())
+              {
+                step_sizes[i] = cell->bounding_box().side_length(0);
+                i++;
+              }
 
-                // we need to calculate temporal bounds for the new slabs
-                double end = slab_tria->startpoint();
-                double start = end;
+            // number of subdivisions needed is at least
+            dealii::types::global_cell_index subdiv =
+              M / this->max_N_intervals_per_slab;
+            // remaining intervals?
+            dealii::types::global_cell_index modulus =
+              M % this->max_N_intervals_per_slab;
 
-                //The first new slabs will be emplaced before the current one.
-                //Then, they will not invalidate the list iterator going forward
-                for ( i =  0 ; i < partial_step_sizes.size()-1 ; ++i ){
-                    start = end;
-                    for ( dealii::types::global_cell_index j = 0 ; j < partial_step_sizes[i].size() ; ++j ){
-                        end += partial_step_sizes[i][j];
-                    }
-                    this->trias.emplace(slab_tria,slab_tria->spatial(),partial_step_sizes[i],start,end);
-                }
-                //Finally, update the current slab triangulation
+            std::vector<std::vector<double>> partial_step_sizes;
+            for (dealii::types::global_cell_index j = 0; j < subdiv; j++)
+              {
+                partial_step_sizes.push_back(
+                  std::vector<double>(this->max_N_intervals_per_slab));
+              }
+            if (modulus)
+              {
+                partial_step_sizes.push_back(std::vector<double>(modulus));
+              }
+
+
+            // Distribute step sizes onto subdivisions
+            for (i = 0; i < M; ++i)
+              {
+                dealii::types::global_cell_index j =
+                  i / this->max_N_intervals_per_slab;
+                dealii::types::global_cell_index k =
+                  i % this->max_N_intervals_per_slab;
+                partial_step_sizes[j][k] = step_sizes[i];
+              }
+
+            // we need to calculate temporal bounds for the new slabs
+            double end   = slab_tria->startpoint();
+            double start = end;
+
+            // The first new slabs will be emplaced before the current one.
+            // Then, they will not invalidate the list iterator going forward
+            for (i = 0; i < partial_step_sizes.size() - 1; ++i)
+              {
                 start = end;
-                for ( dealii::types::global_cell_index j = 0 ; j < partial_step_sizes[i].size() ; ++j ){
+                for (dealii::types::global_cell_index j = 0;
+                     j < partial_step_sizes[i].size();
+                     ++j)
+                  {
                     end += partial_step_sizes[i][j];
-                }
-                slab_tria->update_temporal_triangulation(partial_step_sizes[i],start,end);
-            }
-        }
+                  }
+                this->trias.emplace(slab_tria,
+                                    slab_tria->spatial(),
+                                    partial_step_sizes[i],
+                                    start,
+                                    end);
+              }
+            // Finally, update the current slab triangulation
+            start = end;
+            for (dealii::types::global_cell_index j = 0;
+                 j < partial_step_sizes[i].size();
+                 ++j)
+              {
+                end += partial_step_sizes[i][j];
+              }
+            slab_tria->update_temporal_triangulation(partial_step_sizes[i],
+                                                     start,
+                                                     end);
+          }
+      }
+  }
+} // namespace idealii::spacetime::parallel::distributed::fixed
 
-    }
-}
-
-#include "fixed_tria.inst"
+#  include "fixed_tria.inst"
 
 #endif

--- a/src/distributed/fixed_tria.inst
+++ b/src/distributed/fixed_tria.inst
@@ -18,9 +18,9 @@
 
 namespace idealii::spacetime::parallel::distributed::fixed
 {
-    template class Triangulation<2> ;
-    template class Triangulation<3> ;
+  template class Triangulation<2>;
+  template class Triangulation<3>;
 
-} //namespaces
+} // namespace idealii::spacetime::parallel::distributed::fixed
 
 #endif

--- a/src/distributed/slab_tria.cc
+++ b/src/distributed/slab_tria.cc
@@ -13,118 +13,118 @@
 //
 // ---------------------------------------------------------------------
 
-#include <ideal.II/distributed/slab_tria.hh>
 #include <deal.II/base/config.h>
 
+#include <ideal.II/distributed/slab_tria.hh>
+
 #ifdef DEAL_II_WITH_MPI
-#include <deal.II/grid/grid_generator.h>
+#  include <deal.II/grid/grid_generator.h>
 
 namespace idealii::slab::parallel::distributed
 {
 
-    template<int dim>
-    Triangulation<dim>::Triangulation (
-        std::shared_ptr<
-        dealii::parallel::distributed::Triangulation<dim>> space_tria ,
-        double start , double end )
-        :
-        _startpoint ( start ),
-        _endpoint ( end )
-    {
-        Assert( space_tria.use_count () , dealii::ExcNotInitialized () );
-        _spatial_tria = space_tria;
-        _temporal_tria = std::make_shared<dealii::Triangulation<1>> ();
-        dealii::GridGenerator::hyper_cube ( *_temporal_tria ,
-                                            _startpoint ,
-                                            _endpoint );
-    }
+  template <int dim>
+  Triangulation<dim>::Triangulation(
+    std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+           space_tria,
+    double start,
+    double end)
+    : _startpoint(start)
+    , _endpoint(end)
+  {
+    Assert(space_tria.use_count(), dealii::ExcNotInitialized());
+    _spatial_tria  = space_tria;
+    _temporal_tria = std::make_shared<dealii::Triangulation<1>>();
+    dealii::GridGenerator::hyper_cube(*_temporal_tria, _startpoint, _endpoint);
+  }
 
 
-    template<int dim>
-    Triangulation<dim>::Triangulation (
-        std::shared_ptr<
-        dealii::parallel::distributed::Triangulation<dim>> space_tria ,
-        std::vector<double> step_sizes,
-        double start ,
-        double end )
-        :
-        _startpoint ( start ),
-        _endpoint ( end )
-    {
-        _spatial_tria = space_tria;
-        _temporal_tria = std::make_shared<dealii::Triangulation<1>> ();
-        //Grid generator needs step sizes for each dimension,
-        //so we need to construct a new vector with on entry.
-        std::vector<std::vector<double>> spacing;
-        spacing.push_back(step_sizes);
-        dealii::Point<1> p1(_startpoint);
-        dealii::Point<1> p2(_endpoint);
-        dealii::GridGenerator::subdivided_hyper_rectangle( *_temporal_tria,
-                                                           spacing,
-                                                           p1,
-                                                           p2
-        );
-    }
+  template <int dim>
+  Triangulation<dim>::Triangulation(
+    std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+                        space_tria,
+    std::vector<double> step_sizes,
+    double              start,
+    double              end)
+    : _startpoint(start)
+    , _endpoint(end)
+  {
+    _spatial_tria  = space_tria;
+    _temporal_tria = std::make_shared<dealii::Triangulation<1>>();
+    // Grid generator needs step sizes for each dimension,
+    // so we need to construct a new vector with on entry.
+    std::vector<std::vector<double>> spacing;
+    spacing.push_back(step_sizes);
+    dealii::Point<1> p1(_startpoint);
+    dealii::Point<1> p2(_endpoint);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*_temporal_tria,
+                                                      spacing,
+                                                      p1,
+                                                      p2);
+  }
 
-    template<int dim>
-    Triangulation<dim>::Triangulation ( const Triangulation &other )
-    :
-    _startpoint ( other._startpoint ),
-    _endpoint ( other._endpoint )
-    {
-        Assert( other._spatial_tria.use_count () , dealii::ExcNotInitialized () );
-        _spatial_tria = other._spatial_tria;
-        Assert( other._temporal_tria.use_count () , dealii::ExcNotInitialized () );
-        _temporal_tria = other._temporal_tria;
-    }
+  template <int dim>
+  Triangulation<dim>::Triangulation(const Triangulation &other)
+    : _startpoint(other._startpoint)
+    , _endpoint(other._endpoint)
+  {
+    Assert(other._spatial_tria.use_count(), dealii::ExcNotInitialized());
+    _spatial_tria = other._spatial_tria;
+    Assert(other._temporal_tria.use_count(), dealii::ExcNotInitialized());
+    _temporal_tria = other._temporal_tria;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>> Triangulation<
-    dim>::spatial ()
-    {
-        Assert( _spatial_tria.use_count () , dealii::ExcNotInitialized () );
-        return _spatial_tria;
-    }
+  template <int dim>
+  std::shared_ptr<dealii::parallel::distributed::Triangulation<dim>>
+  Triangulation<dim>::spatial()
+  {
+    Assert(_spatial_tria.use_count(), dealii::ExcNotInitialized());
+    return _spatial_tria;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::Triangulation<1>> Triangulation<dim>::temporal ()
-    {
-        Assert( _temporal_tria.use_count () , dealii::ExcNotInitialized () );
-        return _temporal_tria;
-    }
+  template <int dim>
+  std::shared_ptr<dealii::Triangulation<1>>
+  Triangulation<dim>::temporal()
+  {
+    Assert(_temporal_tria.use_count(), dealii::ExcNotInitialized());
+    return _temporal_tria;
+  }
 
-    template<int dim>
-    double Triangulation<dim>::startpoint ()
-    {
-        return _startpoint;
-    }
+  template <int dim>
+  double
+  Triangulation<dim>::startpoint()
+  {
+    return _startpoint;
+  }
 
-    template<int dim>
-    double Triangulation<dim>::endpoint ()
-    {
-        return _endpoint;
-    }
+  template <int dim>
+  double
+  Triangulation<dim>::endpoint()
+  {
+    return _endpoint;
+  }
 
-    template<int dim>
-    void Triangulation<dim>:: update_temporal_triangulation(
-        std::vector<double> step_sizes,
-        double startpoint,
-        double endpoint){
-        _startpoint = startpoint;
-        _endpoint = endpoint;
-        std::vector<std::vector<double>> spacing;
-        spacing.push_back(step_sizes);
-        //TODO: add an assertion that no subscribers exist
-        _temporal_tria->clear();
-        dealii::Point<1> p1(_startpoint);
-        dealii::Point<1> p2(_endpoint);
-        dealii::GridGenerator::subdivided_hyper_rectangle( *_temporal_tria,
-                                                           spacing,
-                                                           p1,
-                                                           p2
-        );
-    }
-}
+  template <int dim>
+  void
+  Triangulation<dim>::update_temporal_triangulation(
+    std::vector<double> step_sizes,
+    double              startpoint,
+    double              endpoint)
+  {
+    _startpoint = startpoint;
+    _endpoint   = endpoint;
+    std::vector<std::vector<double>> spacing;
+    spacing.push_back(step_sizes);
+    // TODO: add an assertion that no subscribers exist
+    _temporal_tria->clear();
+    dealii::Point<1> p1(_startpoint);
+    dealii::Point<1> p2(_endpoint);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*_temporal_tria,
+                                                      spacing,
+                                                      p1,
+                                                      p2);
+  }
+} // namespace idealii::slab::parallel::distributed
 
-#include "slab_tria.inst"
+#  include "slab_tria.inst"
 #endif

--- a/src/distributed/slab_tria.inst
+++ b/src/distributed/slab_tria.inst
@@ -18,9 +18,9 @@
 
 namespace idealii::slab::parallel::distributed
 {
-    template class Triangulation<2> ;
-    template class Triangulation<3> ;
+  template class Triangulation<2>;
+  template class Triangulation<3>;
 
-} //namespaces
+} // namespace idealii::slab::parallel::distributed
 
 #endif

--- a/src/distributed/spacetime_tria.cc
+++ b/src/distributed/spacetime_tria.cc
@@ -18,32 +18,36 @@
 #ifdef DEAL_II_WITH_MPI
 namespace idealii::spacetime::parallel::distributed
 {
-    template<int dim>
-    Triangulation<dim>::Triangulation (dealii::types::global_cell_index max_N_intervals_per_slab)
-    :max_N_intervals_per_slab(max_N_intervals_per_slab)
-    {
-        trias =
-            std::list<idealii::slab::parallel::distributed::Triangulation<dim>> ();
-    }
+  template <int dim>
+  Triangulation<dim>::Triangulation(
+    dealii::types::global_cell_index max_N_intervals_per_slab)
+    : max_N_intervals_per_slab(max_N_intervals_per_slab)
+  {
+    trias =
+      std::list<idealii::slab::parallel::distributed::Triangulation<dim>>();
+  }
 
-    template<int dim>
-    unsigned int Triangulation<dim>::M ()
-    {
-        return trias.size ();
-    }
+  template <int dim>
+  unsigned int
+  Triangulation<dim>::M()
+  {
+    return trias.size();
+  }
 
-    template<int dim>
-    slab::parallel::distributed::TriaIterator<dim> Triangulation<dim>::begin ()
-    {
-        return trias.begin ();
-    }
+  template <int dim>
+  slab::parallel::distributed::TriaIterator<dim>
+  Triangulation<dim>::begin()
+  {
+    return trias.begin();
+  }
 
-    template<int dim>
-    slab::parallel::distributed::TriaIterator<dim> Triangulation<dim>::end ()
-    {
-        return trias.end ();
-    }
+  template <int dim>
+  slab::parallel::distributed::TriaIterator<dim>
+  Triangulation<dim>::end()
+  {
+    return trias.end();
+  }
 
-}
-#include "spacetime_tria.inst"
+} // namespace idealii::spacetime::parallel::distributed
+#  include "spacetime_tria.inst"
 #endif

--- a/src/distributed/spacetime_tria.inst
+++ b/src/distributed/spacetime_tria.inst
@@ -18,8 +18,8 @@
 
 namespace idealii::spacetime::parallel::distributed
 {
-    template class Triangulation<2> ;
-    template class Triangulation<3> ;
-} //namespaces
+  template class Triangulation<2>;
+  template class Triangulation<3>;
+} // namespace idealii::spacetime::parallel::distributed
 
 #endif

--- a/src/dofs/slab_dof_handler.cc
+++ b/src/dofs/slab_dof_handler.cc
@@ -17,108 +17,117 @@
 
 namespace idealii::slab
 {
-    template<int dim>
-    DoFHandler<dim>::DoFHandler ( Triangulation<dim> &tria )
-    {
-        Assert( tria.spatial ().use_count () , dealii::ExcNotInitialized () );
-        Assert( tria.temporal ().use_count () , dealii::ExcNotInitialized () );
-        _spatial_dof = std::make_shared<dealii::DoFHandler<dim>> ( *tria.spatial () );
-        _temporal_dof = std::make_shared<dealii::DoFHandler<1>> ( *tria.temporal () );
-        _locally_owned_dofs = dealii::IndexSet ();
-    }
+  template <int dim>
+  DoFHandler<dim>::DoFHandler(Triangulation<dim> &tria)
+  {
+    Assert(tria.spatial().use_count(), dealii::ExcNotInitialized());
+    Assert(tria.temporal().use_count(), dealii::ExcNotInitialized());
+    _spatial_dof  = std::make_shared<dealii::DoFHandler<dim>>(*tria.spatial());
+    _temporal_dof = std::make_shared<dealii::DoFHandler<1>>(*tria.temporal());
+    _locally_owned_dofs = dealii::IndexSet();
+  }
 #ifdef DEAL_II_WITH_MPI
-    template<int dim>
-    DoFHandler<dim>::DoFHandler ( slab::parallel::distributed::Triangulation<dim> &tria )
-    {
-        Assert( tria.spatial ().use_count () , dealii::ExcNotInitialized () );
-        Assert( tria.temporal ().use_count () , dealii::ExcNotInitialized () );
-        _spatial_dof = std::make_shared<dealii::DoFHandler<dim>> ( *tria.spatial () );
-        _temporal_dof = std::make_shared<dealii::DoFHandler<1>> ( *tria.temporal () );
-        _locally_owned_dofs = dealii::IndexSet ();
-    }
+  template <int dim>
+  DoFHandler<dim>::DoFHandler(
+    slab::parallel::distributed::Triangulation<dim> &tria)
+  {
+    Assert(tria.spatial().use_count(), dealii::ExcNotInitialized());
+    Assert(tria.temporal().use_count(), dealii::ExcNotInitialized());
+    _spatial_dof  = std::make_shared<dealii::DoFHandler<dim>>(*tria.spatial());
+    _temporal_dof = std::make_shared<dealii::DoFHandler<1>>(*tria.temporal());
+    _locally_owned_dofs = dealii::IndexSet();
+  }
 #endif
 
-    template<int dim>
-    DoFHandler<dim>::DoFHandler ( const DoFHandler<dim> &other )
-    {
-        Assert( other._spatial_dof.use_count () , dealii::ExcNotInitialized () );
-        _spatial_dof = other._spatial_dof;
-        Assert( other._temporal_dof.use_count () , dealii::ExcNotInitialized () );
-        _temporal_dof = other._temporal_dof;
-        _locally_owned_dofs = other._locally_owned_dofs;
-        _fe_support_type = other._fe_support_type;
-    }
+  template <int dim>
+  DoFHandler<dim>::DoFHandler(const DoFHandler<dim> &other)
+  {
+    Assert(other._spatial_dof.use_count(), dealii::ExcNotInitialized());
+    _spatial_dof = other._spatial_dof;
+    Assert(other._temporal_dof.use_count(), dealii::ExcNotInitialized());
+    _temporal_dof       = other._temporal_dof;
+    _locally_owned_dofs = other._locally_owned_dofs;
+    _fe_support_type    = other._fe_support_type;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::DoFHandler<dim>> DoFHandler<dim>::spatial ()
-    {
-        return _spatial_dof;
-    }
+  template <int dim>
+  std::shared_ptr<dealii::DoFHandler<dim>>
+  DoFHandler<dim>::spatial()
+  {
+    return _spatial_dof;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::DoFHandler<1>> DoFHandler<dim>::temporal ()
-    {
-        return _temporal_dof;
-    }
+  template <int dim>
+  std::shared_ptr<dealii::DoFHandler<1>>
+  DoFHandler<dim>::temporal()
+  {
+    return _temporal_dof;
+  }
 
-    template<int dim>
-    void DoFHandler<dim>::distribute_dofs (
-        spacetime::DG_FiniteElement<dim> fe )
-    {
-        _fe_support_type = fe.type ();
-        _spatial_dof->distribute_dofs ( *fe.spatial () );
-        _temporal_dof->distribute_dofs ( *fe.temporal () );
-        dealii::IndexSet space_owned_dofs = _spatial_dof->locally_owned_dofs ();
+  template <int dim>
+  void
+  DoFHandler<dim>::distribute_dofs(spacetime::DG_FiniteElement<dim> fe)
+  {
+    _fe_support_type = fe.type();
+    _spatial_dof->distribute_dofs(*fe.spatial());
+    _temporal_dof->distribute_dofs(*fe.temporal());
+    dealii::IndexSet space_owned_dofs = _spatial_dof->locally_owned_dofs();
 
-        _locally_owned_dofs.clear ();
-        _locally_owned_dofs.set_size ( space_owned_dofs.size () * _temporal_dof->n_dofs () );
+    _locally_owned_dofs.clear();
+    _locally_owned_dofs.set_size(space_owned_dofs.size() *
+                                 _temporal_dof->n_dofs());
 
-        for ( dealii::types::global_dof_index time_dof_index = 0 ;
-              time_dof_index < _temporal_dof->n_dofs () ;
-              time_dof_index++ )
-        {
-            _locally_owned_dofs.add_indices (
-                space_owned_dofs ,
-                time_dof_index * _spatial_dof->n_dofs () // offset
-            );
-        }
-    }
+    for (dealii::types::global_dof_index time_dof_index = 0;
+         time_dof_index < _temporal_dof->n_dofs();
+         time_dof_index++)
+      {
+        _locally_owned_dofs.add_indices(space_owned_dofs,
+                                        time_dof_index *
+                                          _spatial_dof->n_dofs() // offset
+        );
+      }
+  }
 
-    template<int dim>
-    unsigned int DoFHandler<dim>::n_dofs_spacetime ()
-    {
-        return _spatial_dof->n_dofs () * _temporal_dof->n_dofs ();
-    }
+  template <int dim>
+  unsigned int
+  DoFHandler<dim>::n_dofs_spacetime()
+  {
+    return _spatial_dof->n_dofs() * _temporal_dof->n_dofs();
+  }
 
-    template<int dim>
-    unsigned int DoFHandler<dim>::n_dofs_space ()
-    {
-        return _spatial_dof->n_dofs ();
-    }
+  template <int dim>
+  unsigned int
+  DoFHandler<dim>::n_dofs_space()
+  {
+    return _spatial_dof->n_dofs();
+  }
 
-    template<int dim>
-    unsigned int DoFHandler<dim>::n_dofs_time ()
-    {
-        return _temporal_dof->n_dofs ();
-    }
+  template <int dim>
+  unsigned int
+  DoFHandler<dim>::n_dofs_time()
+  {
+    return _temporal_dof->n_dofs();
+  }
 
-    template<int dim>
-    unsigned int DoFHandler<dim>::dofs_per_cell_time ()
-    {
-        return _temporal_dof->get_fe ().dofs_per_cell;
-    }
+  template <int dim>
+  unsigned int
+  DoFHandler<dim>::dofs_per_cell_time()
+  {
+    return _temporal_dof->get_fe().dofs_per_cell;
+  }
 
-    template<int dim>
-    typename spacetime::DG_FiniteElement<dim>::support_type DoFHandler<dim>::fe_support_type ()
-    {
-        return _fe_support_type;
-    }
+  template <int dim>
+  typename spacetime::DG_FiniteElement<dim>::support_type
+  DoFHandler<dim>::fe_support_type()
+  {
+    return _fe_support_type;
+  }
 
-    template<int dim>
-    const dealii::IndexSet& DoFHandler<dim>::locally_owned_dofs ()
-    {
-        return _locally_owned_dofs;
-    }
-}
+  template <int dim>
+  const dealii::IndexSet &
+  DoFHandler<dim>::locally_owned_dofs()
+  {
+    return _locally_owned_dofs;
+  }
+} // namespace idealii::slab
 #include "slab_dof_handler.inst"
-

--- a/src/dofs/slab_dof_handler.inst
+++ b/src/dofs/slab_dof_handler.inst
@@ -18,8 +18,8 @@
 
 namespace idealii::slab
 {
-    template class DoFHandler<2> ;
-    template class DoFHandler<3> ;
-}
+  template class DoFHandler<2>;
+  template class DoFHandler<3>;
+} // namespace idealii::slab
 
 #endif

--- a/src/dofs/spacetime_dof_handler.cc
+++ b/src/dofs/spacetime_dof_handler.cc
@@ -17,73 +17,80 @@
 
 namespace idealii::spacetime
 {
-    template<int dim>
-    DoFHandler<dim>::DoFHandler ( Triangulation<dim> *tria )
-    {
-        _tria = tria;
+  template <int dim>
+  DoFHandler<dim>::DoFHandler(Triangulation<dim> *tria)
+  {
+    _tria = tria;
 #ifdef DEAL_II_WITH_MPI
-        _par_dist_tria = nullptr;
+    _par_dist_tria = nullptr;
 #endif
-        _dof_handlers = std::list<idealii::slab::DoFHandler<dim>> ();
-    }
+    _dof_handlers = std::list<idealii::slab::DoFHandler<dim>>();
+  }
 
 #ifdef DEAL_II_WITH_MPI
-    template<int dim>
-    DoFHandler<dim>::DoFHandler (
-      spacetime::parallel::distributed::Triangulation<dim> *tria )
-    {
-        _tria = nullptr;
-        _par_dist_tria = tria;
-        _dof_handlers = std::list<idealii::slab::DoFHandler<dim>> ();
-    }
+  template <int dim>
+  DoFHandler<dim>::DoFHandler(
+    spacetime::parallel::distributed::Triangulation<dim> *tria)
+  {
+    _tria          = nullptr;
+    _par_dist_tria = tria;
+    _dof_handlers  = std::list<idealii::slab::DoFHandler<dim>>();
+  }
 #endif
-    template<int dim>
-    unsigned int DoFHandler<dim>::M ()
-    {
-        return _dof_handlers.size ();
-    }
+  template <int dim>
+  unsigned int
+  DoFHandler<dim>::M()
+  {
+    return _dof_handlers.size();
+  }
 
-    template<int dim>
-    void DoFHandler<dim>::generate ()
-    {
-        if ( _tria != nullptr )
-        {
-            slab::TriaIterator<dim> tria_it = this->_tria->begin ();
-            slab::TriaIterator<dim> tria_end = this->_tria->end ();
-            for ( ; tria_it != tria_end ; ++tria_it )
-            {
-                this->_dof_handlers.push_back ( idealii::slab::DoFHandler<dim> ( *tria_it ) );
-            }
-        }
+  template <int dim>
+  void
+  DoFHandler<dim>::generate()
+  {
+    if (_tria != nullptr)
+      {
+        slab::TriaIterator<dim> tria_it  = this->_tria->begin();
+        slab::TriaIterator<dim> tria_end = this->_tria->end();
+        for (; tria_it != tria_end; ++tria_it)
+          {
+            this->_dof_handlers.push_back(
+              idealii::slab::DoFHandler<dim>(*tria_it));
+          }
+      }
 #ifdef DEAL_II_WITH_MPI
-        else if ( _par_dist_tria != nullptr )
-        {
-            slab::parallel::distributed::TriaIterator<dim> tria_it = this->_par_dist_tria->begin ();
-            slab::parallel::distributed::TriaIterator<dim> tria_end = this->_par_dist_tria->end ();
-            for ( ; tria_it != tria_end ; ++tria_it )
-            {
-                this->_dof_handlers.push_back ( idealii::slab::DoFHandler<dim> ( *tria_it ) );
-            }
-        }
+    else if (_par_dist_tria != nullptr)
+      {
+        slab::parallel::distributed::TriaIterator<dim> tria_it =
+          this->_par_dist_tria->begin();
+        slab::parallel::distributed::TriaIterator<dim> tria_end =
+          this->_par_dist_tria->end();
+        for (; tria_it != tria_end; ++tria_it)
+          {
+            this->_dof_handlers.push_back(
+              idealii::slab::DoFHandler<dim>(*tria_it));
+          }
+      }
 #endif
-        else
-        {
-            Assert( false , dealii::ExcInternalError () );
-        }
-    }
+    else
+      {
+        Assert(false, dealii::ExcInternalError());
+      }
+  }
 
-    template<int dim>
-        slab::DoFHandlerIterator<dim> DoFHandler<dim>::begin ()
-        {
-            return _dof_handlers.begin ();
-        }
+  template <int dim>
+  slab::DoFHandlerIterator<dim>
+  DoFHandler<dim>::begin()
+  {
+    return _dof_handlers.begin();
+  }
 
-    template<int dim>
-        slab::DoFHandlerIterator<dim> DoFHandler<dim>::end ()
-        {
-            return _dof_handlers.end ();
-        }
-}
+  template <int dim>
+  slab::DoFHandlerIterator<dim>
+  DoFHandler<dim>::end()
+  {
+    return _dof_handlers.end();
+  }
+} // namespace idealii::spacetime
 
 #include "spacetime_dof_handler.inst"
-

--- a/src/dofs/spacetime_dof_handler.inst
+++ b/src/dofs/spacetime_dof_handler.inst
@@ -18,8 +18,8 @@
 
 namespace idealii::spacetime
 {
-    template class DoFHandler<2> ;
-    template class DoFHandler<3> ;
-}
+  template class DoFHandler<2>;
+  template class DoFHandler<3>;
+} // namespace idealii::spacetime
 
 #endif

--- a/src/fe/fe_dg.cc
+++ b/src/fe/fe_dg.cc
@@ -13,67 +13,70 @@
 //
 // ---------------------------------------------------------------------
 
-#include <deal.II/fe/fe_dgq.h>
-#include <ideal.II/fe/fe_dg.hh>
-#include <memory>
 #include "ideal.II/base/quadrature_lib.hh"
+
+#include <ideal.II/fe/fe_dg.hh>
+
 #include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_dgq.h>
+
+#include <memory>
 
 namespace idealii::spacetime
 {
-    template<int dim>
-    DG_FiniteElement<dim>::DG_FiniteElement (
-        std::shared_ptr<dealii::FiniteElement<dim>> fe_space ,
-        const unsigned int r , support_type type )
-    :
-        dofs_per_cell ( fe_space->dofs_per_cell * ( r + 1 ) ),
-        _fe_space (fe_space ),
-        _type ( type )
-    {
-        if ( type == support_type::Legendre || (type == support_type::Lobatto && r == 0) )
-        {
-            _fe_time =
-                std::make_shared<dealii::FE_DGQArbitraryNodes<1>> (dealii::QGauss<1> ( r + 1 ) );
-        }
-        else if (type == support_type::Lobatto)
-        {
-            _fe_time =
-                std::make_shared<dealii::FE_DGQArbitraryNodes<1>> (dealii::QGaussLobatto<1> ( r + 1 ) );
-        }
-        else if (type == support_type::RadauLeft)
-        {
-            _fe_time = 
-                std::make_shared<dealii::FE_DGQArbitraryNodes<1>>(
-                    idealii::QGaussRadau<1>(r+1,QGaussRadau<1>::left)
-                );
-        }
-        else 
-        {
-            _fe_time = 
-                std::make_shared<dealii::FE_DGQArbitraryNodes<1>>(
-                    idealii::QGaussRadau<1>(r+1,QGaussRadau<1>::right)
-                );
-        }
-    
-    }
+  template <int dim>
+  DG_FiniteElement<dim>::DG_FiniteElement(
+    std::shared_ptr<dealii::FiniteElement<dim>> fe_space,
+    const unsigned int                          r,
+    support_type                                type)
+    : dofs_per_cell(fe_space->dofs_per_cell * (r + 1))
+    , _fe_space(fe_space)
+    , _type(type)
+  {
+    if (type == support_type::Legendre ||
+        (type == support_type::Lobatto && r == 0))
+      {
+        _fe_time = std::make_shared<dealii::FE_DGQArbitraryNodes<1>>(
+          dealii::QGauss<1>(r + 1));
+      }
+    else if (type == support_type::Lobatto)
+      {
+        _fe_time = std::make_shared<dealii::FE_DGQArbitraryNodes<1>>(
+          dealii::QGaussLobatto<1>(r + 1));
+      }
+    else if (type == support_type::RadauLeft)
+      {
+        _fe_time = std::make_shared<dealii::FE_DGQArbitraryNodes<1>>(
+          idealii::QGaussRadau<1>(r + 1, QGaussRadau<1>::left));
+      }
+    else
+      {
+        _fe_time = std::make_shared<dealii::FE_DGQArbitraryNodes<1>>(
+          idealii::QGaussRadau<1>(r + 1, QGaussRadau<1>::right));
+      }
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::FiniteElement<dim>> DG_FiniteElement<dim>::spatial ()
-    {
-        return _fe_space;
-    }
+  template <int dim>
+  std::shared_ptr<dealii::FiniteElement<dim>>
+  DG_FiniteElement<dim>::spatial()
+  {
+    return _fe_space;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::FiniteElement<1>> DG_FiniteElement<dim>::temporal ()
-    {
-        return _fe_time;
-    }
+  template <int dim>
+  std::shared_ptr<dealii::FiniteElement<1>>
+  DG_FiniteElement<dim>::temporal()
+  {
+    return _fe_time;
+  }
 
-    template<int dim>
-    typename DG_FiniteElement<dim>::support_type DG_FiniteElement<dim>::type ()
-    {
-        return _type;
-    }
-}
+  template <int dim>
+  typename DG_FiniteElement<dim>::support_type
+  DG_FiniteElement<dim>::type()
+  {
+    return _type;
+  }
+} // namespace idealii::spacetime
 
 #include "fe_dg.inst"

--- a/src/fe/fe_dg.inst
+++ b/src/fe/fe_dg.inst
@@ -18,8 +18,8 @@
 
 namespace idealii::spacetime
 {
-    template class DG_FiniteElement<2> ;
-    template class DG_FiniteElement<3> ;
-}
+  template class DG_FiniteElement<2>;
+  template class DG_FiniteElement<3>;
+} // namespace idealii::spacetime
 
 #endif

--- a/src/fe/spacetime_fe_values.cc
+++ b/src/fe/spacetime_fe_values.cc
@@ -19,681 +19,743 @@
 namespace idealii::spacetime
 {
 
-    ////////////////////////////////////////////////////////////
-    // FEValues ////////////////////////////////////////////////
-    ////////////////////////////////////////////////////////////
-    template<int dim>
-    FEValues<dim>::FEValues (
-        DG_FiniteElement<dim> &fe ,
-        Quadrature<dim> &quad ,
-        const dealii::UpdateFlags uflags )
-        :
-        _fe ( fe ),
-        _quad ( quad ),
-        _fev_space ( std::make_shared<dealii::FEValues<dim>> ( *fe.spatial () ,
-                                                               *quad.spatial () ,
-                                                               uflags )
-        ),
-        _fev_time ( std::make_shared<dealii::FEValues<1>> ( *fe.temporal () ,
-                                                            *quad.temporal () ,
-                                                            uflags )
-        ),
-        local_space_dof_index ( fe.spatial ()->dofs_per_cell ),
-        local_time_dof_index ( fe.temporal ()->dofs_per_cell ),
-        n_dofs_space ( 0 ),
-        time_cell_index ( 0 ),
-        n_dofs_space_cell ( _fe.spatial ()->dofs_per_cell ),
-        n_quads_space ( _fev_space->n_quadrature_points ),
-        n_quadrature_points ( _fev_space->n_quadrature_points * _fev_time->n_quadrature_points )
-    {
-    }
+  ////////////////////////////////////////////////////////////
+  // FEValues ////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////
+  template <int dim>
+  FEValues<dim>::FEValues(DG_FiniteElement<dim>    &fe,
+                          Quadrature<dim>          &quad,
+                          const dealii::UpdateFlags uflags)
+    : _fe(fe)
+    , _quad(quad)
+    , _fev_space(std::make_shared<dealii::FEValues<dim>>(*fe.spatial(),
+                                                         *quad.spatial(),
+                                                         uflags))
+    , _fev_time(std::make_shared<dealii::FEValues<1>>(*fe.temporal(),
+                                                      *quad.temporal(),
+                                                      uflags))
+    , local_space_dof_index(fe.spatial()->dofs_per_cell)
+    , local_time_dof_index(fe.temporal()->dofs_per_cell)
+    , n_dofs_space(0)
+    , time_cell_index(0)
+    , n_dofs_space_cell(_fe.spatial()->dofs_per_cell)
+    , n_quads_space(_fev_space->n_quadrature_points)
+    , n_quadrature_points(_fev_space->n_quadrature_points *
+                          _fev_time->n_quadrature_points)
+  {}
 
-    template<int dim>
-    void FEValues<dim>::reinit_space (
-        const typename dealii::TriaIterator<dealii::DoFCellAccessor<dim,dim,false>> &cell_space )
-    {
-        _fev_space->reinit ( cell_space );
-        cell_space->get_dof_indices ( local_space_dof_index );
-        n_dofs_space = cell_space->get_dof_handler ().n_dofs ();
-    }
+  template <int dim>
+  void
+  FEValues<dim>::reinit_space(
+    const typename dealii::TriaIterator<
+      dealii::DoFCellAccessor<dim, dim, false>> &cell_space)
+  {
+    _fev_space->reinit(cell_space);
+    cell_space->get_dof_indices(local_space_dof_index);
+    n_dofs_space = cell_space->get_dof_handler().n_dofs();
+  }
 
-    template<int dim>
-    void FEValues<dim>::reinit_time (
-        const typename dealii::TriaIterator<dealii::DoFCellAccessor<1,1,false>> &cell_time )
-    {
-        _fev_time->reinit ( cell_time );
-        cell_time->get_dof_indices ( local_time_dof_index );
-        time_cell_index = cell_time->index ();
-    }
+  template <int dim>
+  void
+  FEValues<dim>::reinit_time(
+    const typename dealii::TriaIterator<dealii::DoFCellAccessor<1, 1, false>>
+      &cell_time)
+  {
+    _fev_time->reinit(cell_time);
+    cell_time->get_dof_indices(local_time_dof_index);
+    time_cell_index = cell_time->index();
+  }
 
-    template<int dim>
-    double FEValues<dim>::shape_value (
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return _fev_space->shape_value ( function_no % n_dofs_space_cell ,
-                                         point_no % n_quads_space )
-              * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                         point_no / n_quads_space );
-    }
+  template <int dim>
+  double
+  FEValues<dim>::shape_value(unsigned int function_no, unsigned int point_no)
+  {
+    return _fev_space->shape_value(function_no % n_dofs_space_cell,
+                                   point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    double FEValues<dim>::shape_dt (
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return _fev_space->shape_value ( function_no % n_dofs_space_cell ,
-                                         point_no % n_quads_space )
-               * _fev_time->shape_grad ( function_no / n_dofs_space_cell ,
-                                         point_no / n_quads_space )[0];
-    }
+  template <int dim>
+  double
+  FEValues<dim>::shape_dt(unsigned int function_no, unsigned int point_no)
+  {
+    return _fev_space->shape_value(function_no % n_dofs_space_cell,
+                                   point_no % n_quads_space) *
+           _fev_time->shape_grad(function_no / n_dofs_space_cell,
+                                 point_no / n_quads_space)[0];
+  }
 
-    template<int dim>
-    dealii::Tensor<1,dim> FEValues<dim>::shape_space_grad (
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return _fev_space->shape_grad ( function_no % n_dofs_space_cell ,
-                                        point_no % n_quads_space )
-             * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                        point_no / n_quads_space );
-    }
+  template <int dim>
+  dealii::Tensor<1, dim>
+  FEValues<dim>::shape_space_grad(unsigned int function_no,
+                                  unsigned int point_no)
+  {
+    return _fev_space->shape_grad(function_no % n_dofs_space_cell,
+                                  point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    template<class InputVector>
-    void FEValues<dim>::get_function_values (
-        const InputVector &fe_function ,
-        std::vector<dealii::Vector<typename InputVector::value_type>> &values
-    ) const
-    {
-        Assert ( values.size () == n_quadrature_points ,
-                 dealii::ExcDimensionMismatch ( values.size () , n_quadrature_points )
-        );
-        double phi_x;
-        unsigned int comp_i_x = 0;
-        unsigned int q = 0;
+  template <int dim>
+  template <class InputVector>
+  void
+  FEValues<dim>::get_function_values(
+    const InputVector                                             &fe_function,
+    std::vector<dealii::Vector<typename InputVector::value_type>> &values) const
+  {
+    Assert(values.size() == n_quadrature_points,
+           dealii::ExcDimensionMismatch(values.size(), n_quadrature_points));
+    double       phi_x;
+    unsigned int comp_i_x = 0;
+    unsigned int q        = 0;
 
-        for ( unsigned int q = 0 ; q < n_quadrature_points ; ++q )
-        {
-            Assert ( values[q].size () == _fe.spatial ()->n_components () ,
-                     dealii::ExcDimensionMismatch ( values[q].size () , _fe.spatial ()->n_components () )
-            );
-            values[q] = 0;
-        }
+    for (unsigned int q = 0; q < n_quadrature_points; ++q)
+      {
+        Assert(values[q].size() == _fe.spatial()->n_components(),
+               dealii::ExcDimensionMismatch(values[q].size(),
+                                            _fe.spatial()->n_components()));
+        values[q] = 0;
+      }
 
-        for ( unsigned int q_x = 0 ; q_x < n_quads_space ; ++q_x )
-        {
-            for ( unsigned int i_x = 0 ; i_x < n_dofs_space_cell ; ++i_x )
-            {
-                comp_i_x = _fe.spatial ()->system_to_component_index ( i_x ).first;
-                phi_x = _fev_space->shape_value_component ( i_x , q_x , comp_i_x );
-                for ( unsigned int q_t = 0 ; q_t < _fev_time->n_quadrature_points ; ++q_t )
-                {
-                    q = q_x + n_quads_space * q_t;
-                    for ( unsigned int i_t = 0 ; i_t < _fev_time->dofs_per_cell ; ++i_t )
-                    {
-                        values[q] ( comp_i_x ) +=
-                           phi_x * _fev_time->shape_value ( i_t , q_t )
-                           * fe_function[local_space_dof_index[i_x] + n_dofs_space * local_time_dof_index[i_t]];
-                    }
-                }
-            }
-        }
-    }
+    for (unsigned int q_x = 0; q_x < n_quads_space; ++q_x)
+      {
+        for (unsigned int i_x = 0; i_x < n_dofs_space_cell; ++i_x)
+          {
+            comp_i_x = _fe.spatial()->system_to_component_index(i_x).first;
+            phi_x    = _fev_space->shape_value_component(i_x, q_x, comp_i_x);
+            for (unsigned int q_t = 0; q_t < _fev_time->n_quadrature_points;
+                 ++q_t)
+              {
+                q = q_x + n_quads_space * q_t;
+                for (unsigned int i_t = 0; i_t < _fev_time->dofs_per_cell;
+                     ++i_t)
+                  {
+                    values[q](comp_i_x) +=
+                      phi_x * _fev_time->shape_value(i_t, q_t) *
+                      fe_function[local_space_dof_index[i_x] +
+                                  n_dofs_space * local_time_dof_index[i_t]];
+                  }
+              }
+          }
+      }
+  }
 
 
-    template<int dim>
-    template<class InputVector>
-    void FEValues<dim>::get_function_dt (
-        const InputVector &fe_function ,
-        std::vector<dealii::Vector<typename InputVector::value_type>> &values ) const
-    {
-        Assert ( values.size () == n_quadrature_points ,
-                 dealii::ExcDimensionMismatch ( values.size () , n_quadrature_points )
-        );
-        double phi_x;
-        unsigned int comp_i_x = 0;
-        unsigned int q = 0;
+  template <int dim>
+  template <class InputVector>
+  void
+  FEValues<dim>::get_function_dt(
+    const InputVector                                             &fe_function,
+    std::vector<dealii::Vector<typename InputVector::value_type>> &values) const
+  {
+    Assert(values.size() == n_quadrature_points,
+           dealii::ExcDimensionMismatch(values.size(), n_quadrature_points));
+    double       phi_x;
+    unsigned int comp_i_x = 0;
+    unsigned int q        = 0;
 
-        for ( unsigned int q = 0 ; q < n_quadrature_points ; ++q )
-        {
-            Assert ( values[q].size () == _fe.spatial ()->n_components () ,
-                     dealii::ExcDimensionMismatch ( values[q].size () , _fe.spatial ()->n_components () )
-            );
-            values[q] = 0;
-        }
+    for (unsigned int q = 0; q < n_quadrature_points; ++q)
+      {
+        Assert(values[q].size() == _fe.spatial()->n_components(),
+               dealii::ExcDimensionMismatch(values[q].size(),
+                                            _fe.spatial()->n_components()));
+        values[q] = 0;
+      }
 
-        for ( unsigned int q_x = 0 ; q_x < n_quads_space ; ++q_x )
-        {
-            for ( unsigned int i_x = 0 ; i_x < n_dofs_space_cell ; ++i_x )
-            {
-                comp_i_x = _fe.spatial ()->system_to_component_index ( i_x ).first;
-                phi_x = _fev_space->shape_value_component ( i_x , q_x , comp_i_x );
-                for ( unsigned int q_t = 0 ; q_t < _fev_time->n_quadrature_points ; ++q_t )
-                {
-                    q = q_x + n_quads_space * q_t;
-                    for ( unsigned int i_t = 0 ; i_t < _fev_time->dofs_per_cell ; ++i_t )
-                    {
-                        values[q] ( comp_i_x ) +=
-                                phi_x * _fev_time->shape_grad ( i_t , q_t )[0]
-                                * fe_function[local_space_dof_index[i_x] + n_dofs_space * local_time_dof_index[i_t]];
-                    }
-                }
-            }
-        }
-    }
+    for (unsigned int q_x = 0; q_x < n_quads_space; ++q_x)
+      {
+        for (unsigned int i_x = 0; i_x < n_dofs_space_cell; ++i_x)
+          {
+            comp_i_x = _fe.spatial()->system_to_component_index(i_x).first;
+            phi_x    = _fev_space->shape_value_component(i_x, q_x, comp_i_x);
+            for (unsigned int q_t = 0; q_t < _fev_time->n_quadrature_points;
+                 ++q_t)
+              {
+                q = q_x + n_quads_space * q_t;
+                for (unsigned int i_t = 0; i_t < _fev_time->dofs_per_cell;
+                     ++i_t)
+                  {
+                    values[q](comp_i_x) +=
+                      phi_x * _fev_time->shape_grad(i_t, q_t)[0] *
+                      fe_function[local_space_dof_index[i_x] +
+                                  n_dofs_space * local_time_dof_index[i_t]];
+                  }
+              }
+          }
+      }
+  }
 
-    template<int dim>
-    template<class InputVector>
-    void FEValues<dim>::get_function_space_gradients (
-        const InputVector &fe_function ,
-        std::vector<std::vector<dealii::Tensor<1,dim,typename InputVector::value_type>>> &gradients ) const
-    {
-        Assert ( gradients.size () == n_quadrature_points ,
-                 dealii::ExcDimensionMismatch ( gradients.size () , n_quadrature_points )
-        );
-        dealii::Tensor<1,dim,double> grad_phi_x;
-        unsigned int comp_i_x = 0;
-        unsigned int q = 0;
+  template <int dim>
+  template <class InputVector>
+  void
+  FEValues<dim>::get_function_space_gradients(
+    const InputVector &fe_function,
+    std::vector<
+      std::vector<dealii::Tensor<1, dim, typename InputVector::value_type>>>
+      &gradients) const
+  {
+    Assert(gradients.size() == n_quadrature_points,
+           dealii::ExcDimensionMismatch(gradients.size(), n_quadrature_points));
+    dealii::Tensor<1, dim, double> grad_phi_x;
+    unsigned int                   comp_i_x = 0;
+    unsigned int                   q        = 0;
 
-        for ( unsigned int q = 0 ; q < n_quadrature_points ; ++q )
-        {
-            Assert ( gradients[q].size () == _fe.spatial ()->n_components () ,
-                     dealii::ExcDimensionMismatch ( gradients[q].size () , _fe.spatial ()->n_components () )
-            );
-            for ( unsigned int c = 0 ; c < _fe.spatial ()->n_components () ; ++c )
-            {
-                gradients[q][c] = 0;
-            }
-        }
+    for (unsigned int q = 0; q < n_quadrature_points; ++q)
+      {
+        Assert(gradients[q].size() == _fe.spatial()->n_components(),
+               dealii::ExcDimensionMismatch(gradients[q].size(),
+                                            _fe.spatial()->n_components()));
+        for (unsigned int c = 0; c < _fe.spatial()->n_components(); ++c)
+          {
+            gradients[q][c] = 0;
+          }
+      }
 
-        double u_i = 0;
-        for ( unsigned int q_x = 0 ; q_x < n_quads_space ; ++q_x )
-        {
-            for ( unsigned int i_x = 0 ; i_x < n_dofs_space_cell ; ++i_x )
-            {
-                comp_i_x = _fe.spatial ()->system_to_component_index ( i_x ).first;
-                grad_phi_x = _fev_space->shape_grad_component ( i_x , q_x , comp_i_x );
-                for ( unsigned int q_t = 0 ; q_t < _fev_time->n_quadrature_points ; ++q_t )
-                {
-                    q = q_x + n_quads_space * q_t;
-                    for ( unsigned int i_t = 0 ; i_t < _fev_time->dofs_per_cell ; ++i_t )
-                    {
-                        u_i = fe_function[local_space_dof_index[i_x] + n_dofs_space * local_time_dof_index[i_t]];
-                        gradients[q][comp_i_x] += grad_phi_x
-                                                  * _fev_time->shape_value ( i_t , q_t )
-                                                  * u_i;
-                    }
-                }
-            }
-        }
-    }
+    double u_i = 0;
+    for (unsigned int q_x = 0; q_x < n_quads_space; ++q_x)
+      {
+        for (unsigned int i_x = 0; i_x < n_dofs_space_cell; ++i_x)
+          {
+            comp_i_x   = _fe.spatial()->system_to_component_index(i_x).first;
+            grad_phi_x = _fev_space->shape_grad_component(i_x, q_x, comp_i_x);
+            for (unsigned int q_t = 0; q_t < _fev_time->n_quadrature_points;
+                 ++q_t)
+              {
+                q = q_x + n_quads_space * q_t;
+                for (unsigned int i_t = 0; i_t < _fev_time->dofs_per_cell;
+                     ++i_t)
+                  {
+                    u_i = fe_function[local_space_dof_index[i_x] +
+                                      n_dofs_space * local_time_dof_index[i_t]];
+                    gradients[q][comp_i_x] +=
+                      grad_phi_x * _fev_time->shape_value(i_t, q_t) * u_i;
+                  }
+              }
+          }
+      }
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Scalar<dim>::value_type FEValues<dim>::scalar_value (
-        const typename dealii::FEValuesExtractors::Scalar &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % n_dofs_space_cell ,
-                                                  point_no % n_quads_space )
-                       * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                                  point_no / n_quads_space );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Scalar<dim>::value_type
+  FEValues<dim>::scalar_value(
+    const typename dealii::FEValuesExtractors::Scalar &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no % n_dofs_space_cell,
+                                          point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Scalar<dim>::value_type FEValues<dim>::scalar_dt (
-        const typename dealii::FEValuesExtractors::Scalar &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % n_dofs_space_cell ,
-                                                  point_no % n_quads_space )
-                        * _fev_time->shape_grad ( function_no / n_dofs_space_cell ,
-                                                  point_no / n_quads_space )[0];
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Scalar<dim>::value_type
+  FEValues<dim>::scalar_dt(
+    const typename dealii::FEValuesExtractors::Scalar &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no % n_dofs_space_cell,
+                                          point_no % n_quads_space) *
+           _fev_time->shape_grad(function_no / n_dofs_space_cell,
+                                 point_no / n_quads_space)[0];
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Scalar<dim>::gradient_type FEValues<dim>::scalar_space_grad (
-        const typename dealii::FEValuesExtractors::Scalar &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].gradient ( function_no % n_dofs_space_cell ,
-                                                     point_no % n_quads_space )
-                          * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                                     point_no / n_quads_space );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Scalar<dim>::gradient_type
+  FEValues<dim>::scalar_space_grad(
+    const typename dealii::FEValuesExtractors::Scalar &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].gradient(function_no % n_dofs_space_cell,
+                                             point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Vector<dim>::value_type FEValues<dim>::vector_value (
-        const typename dealii::FEValuesExtractors::Vector &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % n_dofs_space_cell ,
-                                                  point_no % n_quads_space )
-                       * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                                  point_no / n_quads_space );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Vector<dim>::value_type
+  FEValues<dim>::vector_value(
+    const typename dealii::FEValuesExtractors::Vector &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no % n_dofs_space_cell,
+                                          point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Vector<dim>::value_type FEValues<dim>::vector_dt (
-        const typename dealii::FEValuesExtractors::Vector &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % n_dofs_space_cell ,
-                                                  point_no % n_quads_space )
-                        * _fev_time->shape_grad ( function_no / n_dofs_space_cell ,
-                                                  point_no / n_quads_space )[0];
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Vector<dim>::value_type
+  FEValues<dim>::vector_dt(
+    const typename dealii::FEValuesExtractors::Vector &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no % n_dofs_space_cell,
+                                          point_no % n_quads_space) *
+           _fev_time->shape_grad(function_no / n_dofs_space_cell,
+                                 point_no / n_quads_space)[0];
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Vector<dim>::divergence_type FEValues<dim>::vector_divergence (
-        const typename dealii::FEValuesExtractors::Vector &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].divergence ( function_no % n_dofs_space_cell ,
-                                                       point_no % n_quads_space )
-                            * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                                       point_no / n_quads_space );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Vector<dim>::divergence_type
+  FEValues<dim>::vector_divergence(
+    const typename dealii::FEValuesExtractors::Vector &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].divergence(function_no % n_dofs_space_cell,
+                                               point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Vector<dim>::gradient_type FEValues<dim>::vector_space_grad (
-        const typename dealii::FEValuesExtractors::Vector &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].gradient ( function_no % n_dofs_space_cell ,
-                                                     point_no % n_quads_space )
-                          * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                                     point_no / n_quads_space );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Vector<dim>::gradient_type
+  FEValues<dim>::vector_space_grad(
+    const typename dealii::FEValuesExtractors::Vector &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].gradient(function_no % n_dofs_space_cell,
+                                             point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Vector<dim>::curl_type FEValues<dim>::vector_space_curl (
-        const typename dealii::FEValuesExtractors::Vector &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].curl ( function_no % n_dofs_space_cell ,
-                                                 point_no % n_quads_space )
-                      * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                                 point_no / n_quads_space );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Vector<dim>::curl_type
+  FEValues<dim>::vector_space_curl(
+    const typename dealii::FEValuesExtractors::Vector &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].curl(function_no % n_dofs_space_cell,
+                                         point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    double FEValues<dim>::time_quadrature_point ( unsigned int quadrature_point )
-    {
-        return _fev_time->quadrature_point ( quadrature_point / n_quads_space )[0];
-    }
+  template <int dim>
+  double
+  FEValues<dim>::time_quadrature_point(unsigned int quadrature_point)
+  {
+    return _fev_time->quadrature_point(quadrature_point / n_quads_space)[0];
+  }
 
-    template<int dim>
-    dealii::Point<dim> FEValues<dim>::space_quadrature_point ( unsigned int quadrature_point )
-    {
-        return _fev_space->quadrature_point ( quadrature_point % n_quads_space );
-    }
+  template <int dim>
+  dealii::Point<dim>
+  FEValues<dim>::space_quadrature_point(unsigned int quadrature_point)
+  {
+    return _fev_space->quadrature_point(quadrature_point % n_quads_space);
+  }
 
-    template<int dim>
-    double FEValues<dim>::JxW ( unsigned int quadrature_point )
-    {
-        return _fev_space->JxW ( quadrature_point % n_quads_space )
-               * _fev_time->JxW ( quadrature_point / n_quads_space );
-    }
+  template <int dim>
+  double
+  FEValues<dim>::JxW(unsigned int quadrature_point)
+  {
+    return _fev_space->JxW(quadrature_point % n_quads_space) *
+           _fev_time->JxW(quadrature_point / n_quads_space);
+  }
 
-    template<int dim>
-    void FEValues<dim>::get_local_dof_indices ( std::vector<dealii::types::global_dof_index> &indices )
-    {
-        for ( unsigned int i = 0 ; i < _fe.dofs_per_cell ; i++ )
-        {
+  template <int dim>
+  void
+  FEValues<dim>::get_local_dof_indices(
+    std::vector<dealii::types::global_dof_index> &indices)
+  {
+    for (unsigned int i = 0; i < _fe.dofs_per_cell; i++)
+      {
+        indices[i + time_cell_index * _fe.dofs_per_cell] =
+          local_space_dof_index[i % n_dofs_space_cell] +
+          local_time_dof_index[i / n_dofs_space_cell] * n_dofs_space;
+      }
+  }
 
-            indices[i + time_cell_index * _fe.dofs_per_cell]
-            = local_space_dof_index[i % n_dofs_space_cell]
-              + local_time_dof_index[i / n_dofs_space_cell] * n_dofs_space;
-        }
-    }
+  template <int dim>
+  std::shared_ptr<dealii::FEValues<dim>>
+  FEValues<dim>::spatial()
+  {
+    return _fev_space;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::FEValues<dim>> FEValues<dim>::spatial ()
-    {
-        return _fev_space;
-    }
+  template <int dim>
+  std::shared_ptr<dealii::FEValues<1>>
+  FEValues<dim>::temporal()
+  {
+    return _fev_time;
+  }
+  ////////////////////////////////////////////////////////////
+  // FEJumpValues ////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////
+  template <int dim>
+  FEJumpValues<dim>::FEJumpValues(DG_FiniteElement<dim>    &fe,
+                                  Quadrature<dim>          &quad,
+                                  const dealii::UpdateFlags uflags)
+    : _fe(fe)
+    , _quad(quad)
+    , _fev_space(std::make_shared<dealii::FEValues<dim>>(*fe.spatial(),
+                                                         *quad.spatial(),
+                                                         uflags))
+    , _fev_time(
+        std::make_shared<dealii::FEValues<1>>(*fe.temporal(),
+                                              dealii::QGaussLobatto<1>(2),
+                                              uflags))
+    , local_space_dof_index(fe.spatial()->dofs_per_cell)
+    , local_time_dof_index(fe.temporal()->dofs_per_cell)
+  {
+    n_quadrature_points =
+      _fev_space->n_quadrature_points * _fev_time->n_quadrature_points;
+    n_dofs_space = 0;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::FEValues<1>> FEValues<dim>::temporal ()
-    {
-        return _fev_time;
-    }
-    ////////////////////////////////////////////////////////////
-    // FEJumpValues ////////////////////////////////////////////
-    ////////////////////////////////////////////////////////////
-    template<int dim>
-    FEJumpValues<dim>::FEJumpValues (
-        DG_FiniteElement<dim> &fe ,
-        Quadrature<dim> &quad ,
-        const dealii::UpdateFlags uflags )
-        :
-        _fe ( fe ),
-        _quad ( quad ),
-        _fev_space (
-            std::make_shared<dealii::FEValues<dim>> ( *fe.spatial () , *quad.spatial () , uflags )
-        ),
-        _fev_time (
-            std::make_shared<dealii::FEValues<1>> ( *fe.temporal () ,
-                                                    dealii::QGaussLobatto<1> ( 2 ) ,
-                                                    uflags )
-        ),
-        local_space_dof_index ( fe.spatial ()->dofs_per_cell ),
-        local_time_dof_index ( fe.temporal ()->dofs_per_cell )
-    {
-        n_quadrature_points =_fev_space->n_quadrature_points*_fev_time->n_quadrature_points;
-        n_dofs_space  = 0;
-    }
+  template <int dim>
+  void
+  FEJumpValues<dim>::reinit_space(
+    const typename dealii::TriaIterator<
+      dealii::DoFCellAccessor<dim, dim, false>> &cell_space)
+  {
+    _fev_space->reinit(cell_space);
+    cell_space->get_dof_indices(local_space_dof_index);
+    n_dofs_space = cell_space->get_dof_handler().n_dofs();
+  }
 
-    template<int dim>
-    void FEJumpValues<dim>::reinit_space (
-        const typename dealii::TriaIterator<dealii::DoFCellAccessor<dim,dim,false>> &cell_space )
-    {
-        _fev_space->reinit ( cell_space );
-        cell_space->get_dof_indices ( local_space_dof_index );
-        n_dofs_space = cell_space->get_dof_handler().n_dofs();
-    }
+  template <int dim>
+  void
+  FEJumpValues<dim>::reinit_time(
+    const typename dealii::TriaIterator<dealii::DoFCellAccessor<1, 1, false>>
+      &cell_time)
+  {
+    _fev_time->reinit(cell_time);
+    cell_time->get_dof_indices(local_time_dof_index);
+  }
 
-    template<int dim>
-    void FEJumpValues<dim>::reinit_time (
-        const typename dealii::TriaIterator<dealii::DoFCellAccessor<1,1,false>> &cell_time )
-    {
-        _fev_time->reinit ( cell_time );
-        cell_time->get_dof_indices ( local_time_dof_index );
-    }
+  template <int dim>
+  double
+  FEJumpValues<dim>::shape_value_plus(unsigned int function_no,
+                                      unsigned int point_no)
+  {
+    return _fev_space->shape_value(function_no % _fe.spatial()->dofs_per_cell,
+                                   point_no % _fev_space->n_quadrature_points) *
+           _fev_time->shape_value(function_no / _fe.spatial()->dofs_per_cell,
+                                  0);
+  }
 
-    template<int dim>
-    double FEJumpValues<dim>::shape_value_plus (
-         unsigned int function_no ,
-         unsigned int point_no )
-    {
-        return _fev_space->shape_value ( function_no % _fe.spatial ()->dofs_per_cell ,
-                                         point_no % _fev_space->n_quadrature_points )
-              * _fev_time->shape_value ( function_no / _fe.spatial ()->dofs_per_cell , 0 );
-    }
+  template <int dim>
+  double
+  FEJumpValues<dim>::shape_value_minus(unsigned int function_no,
+                                       unsigned int point_no)
+  {
+    return _fev_space->shape_value(function_no % _fe.spatial()->dofs_per_cell,
+                                   point_no % _fev_space->n_quadrature_points) *
+           _fev_time->shape_value(function_no / _fe.spatial()->dofs_per_cell,
+                                  1);
+  }
 
-    template<int dim>
-    double FEJumpValues<dim>::shape_value_minus (
-          unsigned int function_no ,
-          unsigned int point_no )
-    {
-        return _fev_space->shape_value ( function_no % _fe.spatial ()->dofs_per_cell ,
-                                         point_no % _fev_space->n_quadrature_points )
-              * _fev_time->shape_value ( function_no / _fe.spatial ()->dofs_per_cell , 1 );
-    }
+  template <int dim>
+  template <class InputVector>
+  void
+  FEJumpValues<dim>::get_function_values_plus(
+    const InputVector                                             &fe_function,
+    std::vector<dealii::Vector<typename InputVector::value_type>> &values) const
+  {
+    unsigned int n_quads_space = _fev_space->n_quadrature_points;
+    Assert(values.size() == n_quads_space,
+           dealii::ExcDimensionMismatch(values.size(), n_quads_space));
 
-    template<int dim>
-    template<class InputVector>
-    void FEJumpValues<dim>::get_function_values_plus(
-        const InputVector& fe_function,
-        std::vector<dealii::Vector<typename InputVector::value_type>>& values) const
-    {
-        unsigned int n_quads_space = _fev_space->n_quadrature_points;
-        Assert(values.size() == n_quads_space,
-               dealii::ExcDimensionMismatch(values.size(),n_quads_space)
-        );
+    double       phi_x;
+    unsigned int comp_i_x = 0;
 
-        double phi_x;
-        unsigned int comp_i_x = 0;
+    for (unsigned int q_x = 0; q_x < n_quads_space; ++q_x)
+      {
+        Assert(values[q_x].size() == _fe.spatial()->n_components(),
+               dealii::ExcDimensionMismatch(values[q_x].size(),
+                                            _fe.spatial()->n_components()));
+        values[q_x] = 0;
+      }
 
-        for (unsigned int q_x = 0 ; q_x < n_quads_space ; ++q_x){
-            Assert(values[q_x].size() == _fe.spatial()->n_components(),
-                   dealii::ExcDimensionMismatch(values[q_x].size(),_fe.spatial()->n_components())
-            );
-            values[q_x]=0;
-        }
+    for (unsigned int q_x = 0; q_x < n_quads_space; ++q_x)
+      {
+        for (unsigned int i_x = 0; i_x < _fe.spatial()->dofs_per_cell; ++i_x)
+          {
+            comp_i_x = _fe.spatial()->system_to_component_index(i_x).first;
+            phi_x    = _fev_space->shape_value_component(i_x, q_x, comp_i_x);
+            for (unsigned int i_t = 0; i_t < _fev_time->dofs_per_cell; ++i_t)
+              {
+                values[q_x](comp_i_x) +=
+                  phi_x * _fev_time->shape_value(i_t, 0) *
+                  fe_function[local_space_dof_index[i_x] +
+                              n_dofs_space * local_time_dof_index[i_t]];
+              }
+          }
+      }
+  }
 
-        for (unsigned int q_x = 0 ; q_x < n_quads_space ; ++q_x){
-            for ( unsigned int i_x = 0 ; i_x < _fe.spatial()->dofs_per_cell ; ++i_x ){
-                comp_i_x = _fe.spatial()->system_to_component_index(i_x).first;
-                phi_x = _fev_space->shape_value_component ( i_x , q_x , comp_i_x );
-                for ( unsigned int i_t = 0 ; i_t < _fev_time->dofs_per_cell ; ++i_t ){
-                    values[q_x](comp_i_x)
-                        += phi_x * _fev_time->shape_value( i_t , 0 )
-                         * fe_function[local_space_dof_index[i_x]+n_dofs_space*local_time_dof_index[i_t]];
-                }
-            }
-        }
-    }
+  template <int dim>
+  template <class InputVector>
+  void
+  FEJumpValues<dim>::get_function_values_minus(
+    const InputVector                                             &fe_function,
+    std::vector<dealii::Vector<typename InputVector::value_type>> &values) const
+  {
+    unsigned int n_quads_space = _fev_space->n_quadrature_points;
+    Assert(values.size() == n_quads_space,
+           dealii::ExcDimensionMismatch(values.size(), n_quads_space));
 
-    template<int dim>
-    template<class InputVector>
-    void FEJumpValues<dim>::get_function_values_minus(
-        const InputVector& fe_function,
-        std::vector<dealii::Vector<typename InputVector::value_type>>& values) const
-    {
-        unsigned int n_quads_space = _fev_space->n_quadrature_points;
-        Assert(values.size() == n_quads_space,
-               dealii::ExcDimensionMismatch(values.size(),n_quads_space)
-        );
+    double       phi_x;
+    unsigned int comp_i_x = 0;
 
-        double phi_x;
-        unsigned int comp_i_x = 0;
+    for (unsigned int q_x = 0; q_x < n_quads_space; ++q_x)
+      {
+        Assert(values[q_x].size() == _fe.spatial()->n_components(),
+               dealii::ExcDimensionMismatch(values[q_x].size(),
+                                            _fe.spatial()->n_components()));
+        values[q_x] = 0;
+      }
 
-        for (unsigned int q_x = 0 ; q_x < n_quads_space ; ++q_x){
-            Assert(values[q_x].size() == _fe.spatial()->n_components(),
-                   dealii::ExcDimensionMismatch(values[q_x].size(),_fe.spatial()->n_components())
-            );
-            values[q_x]=0;
-        }
+    for (unsigned int q_x = 0; q_x < n_quads_space; ++q_x)
+      {
+        for (unsigned int i_x = 0; i_x < _fe.spatial()->dofs_per_cell; ++i_x)
+          {
+            comp_i_x = _fe.spatial()->system_to_component_index(i_x).first;
+            phi_x    = _fev_space->shape_value_component(i_x, q_x, comp_i_x);
+            for (unsigned int i_t = 0; i_t < _fev_time->dofs_per_cell; ++i_t)
+              {
+                values[q_x](comp_i_x) +=
+                  phi_x * _fev_time->shape_value(i_t, 1) *
+                  fe_function[local_space_dof_index[i_x] +
+                              n_dofs_space * local_time_dof_index[i_t]];
+              }
+          }
+      }
+  }
 
-        for (unsigned int q_x = 0 ; q_x < n_quads_space ; ++q_x){
-            for ( unsigned int i_x = 0 ; i_x < _fe.spatial()->dofs_per_cell ; ++i_x ){
-                comp_i_x = _fe.spatial()->system_to_component_index(i_x).first;
-                phi_x = _fev_space->shape_value_component ( i_x , q_x , comp_i_x );
-                for ( unsigned int i_t = 0 ; i_t < _fev_time->dofs_per_cell ; ++i_t ){
-                    values[q_x](comp_i_x)
-                        += phi_x * _fev_time->shape_value( i_t , 1 )
-                         * fe_function[local_space_dof_index[i_x]+n_dofs_space*local_time_dof_index[i_t]];
-                }
-            }
-        }
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Scalar<dim>::value_type
+  FEJumpValues<dim>::scalar_value_plus(
+    const typename dealii::FEValuesExtractors::Scalar &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no %
+                                            _fe.spatial()->dofs_per_cell,
+                                          point_no %
+                                            _fev_space->n_quadrature_points) *
+           _fev_time->shape_value(function_no / _fe.spatial()->dofs_per_cell,
+                                  0);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Scalar<dim>::value_type FEJumpValues<dim>::scalar_value_plus (
-        const typename dealii::FEValuesExtractors::Scalar &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % _fe.spatial ()->dofs_per_cell ,
-                                                  point_no % _fev_space->n_quadrature_points )
-                       * _fev_time->shape_value ( function_no / _fe.spatial ()->dofs_per_cell , 0 );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Scalar<dim>::value_type
+  FEJumpValues<dim>::scalar_value_minus(
+    const typename dealii::FEValuesExtractors::Scalar &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no %
+                                            _fe.spatial()->dofs_per_cell,
+                                          point_no %
+                                            _fev_space->n_quadrature_points) *
+           _fev_time->shape_value(function_no / _fe.spatial()->dofs_per_cell,
+                                  1);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Scalar<dim>::value_type FEJumpValues<dim>::scalar_value_minus (
-        const typename dealii::FEValuesExtractors::Scalar &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % _fe.spatial ()->dofs_per_cell ,
-                                                  point_no % _fev_space->n_quadrature_points )
-                       * _fev_time->shape_value ( function_no / _fe.spatial ()->dofs_per_cell , 1 );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Vector<dim>::value_type
+  FEJumpValues<dim>::vector_value_plus(
+    const typename dealii::FEValuesExtractors::Vector &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no %
+                                            _fe.spatial()->dofs_per_cell,
+                                          point_no %
+                                            _fev_space->n_quadrature_points) *
+           _fev_time->shape_value(function_no / _fe.spatial()->dofs_per_cell,
+                                  0);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Vector<dim>::value_type FEJumpValues<dim>::vector_value_plus (
-            const typename dealii::FEValuesExtractors::Vector &extractor ,
-            unsigned int function_no ,
-            unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % _fe.spatial ()->dofs_per_cell ,
-                                                  point_no % _fev_space->n_quadrature_points )
-                       * _fev_time->shape_value ( function_no / _fe.spatial ()->dofs_per_cell , 0 );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Vector<dim>::value_type
+  FEJumpValues<dim>::vector_value_minus(
+    const typename dealii::FEValuesExtractors::Vector &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no %
+                                            _fe.spatial()->dofs_per_cell,
+                                          point_no %
+                                            _fev_space->n_quadrature_points) *
+           _fev_time->shape_value(function_no / _fe.spatial()->dofs_per_cell,
+                                  1);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Vector<dim>::value_type FEJumpValues<dim>::vector_value_minus (
-            const typename dealii::FEValuesExtractors::Vector &extractor ,
-            unsigned int function_no ,
-            unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % _fe.spatial ()->dofs_per_cell ,
-                                                  point_no % _fev_space->n_quadrature_points )
-                       * _fev_time->shape_value ( function_no / _fe.spatial ()->dofs_per_cell , 1 );
-    }
+  template <int dim>
+  double
+  FEJumpValues<dim>::JxW(unsigned int quadrature_point)
+  {
+    return _fev_space->JxW(quadrature_point % _fev_space->n_quadrature_points);
+  }
 
-    template<int dim>
-    double FEJumpValues<dim>::JxW ( unsigned int quadrature_point )
-    {
-        return _fev_space->JxW ( quadrature_point % _fev_space->n_quadrature_points );
-    }
+  template <int dim>
+  std::shared_ptr<dealii::FEValues<dim>>
+  FEJumpValues<dim>::spatial()
+  {
+    return _fev_space;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::FEValues<dim>> FEJumpValues<dim>::spatial ()
-    {
-        return _fev_space;
-    }
+  template <int dim>
+  std::shared_ptr<dealii::FEValues<1>>
+  FEJumpValues<dim>::temporal()
+  {
+    return _fev_time;
+  }
 
-    template<int dim>
-    std::shared_ptr<dealii::FEValues<1>> FEJumpValues<dim>::temporal ()
-    {
-        return _fev_time;
-    }
+  ////////////////////////////////////////////////////////////
+  // FEFaceValues ////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////
+  template <int dim>
+  FEFaceValues<dim>::FEFaceValues(DG_FiniteElement<dim>    &fe,
+                                  Quadrature<dim - 1>      &quad,
+                                  const dealii::UpdateFlags uflags,
+                                  const dealii::UpdateFlags additional_flags)
+    : _fe(fe)
+    , _quad(quad)
+    , _fev_space(
+        std::make_shared<dealii::FEFaceValues<dim>>(*fe.spatial(),
+                                                    *quad.spatial(),
+                                                    uflags | additional_flags))
+    , _fev_time(std::make_shared<dealii::FEValues<1>>(*fe.temporal(),
+                                                      *quad.temporal(),
+                                                      uflags))
+    , local_space_dof_index(fe.spatial()->dofs_per_cell)
+    , local_time_dof_index(fe.temporal()->dofs_per_cell)
+    , n_dofs_space(0)
+    , time_cell_index(0)
+    , n_dofs_space_cell(_fe.spatial()->dofs_per_cell)
+    , n_quads_space(_fev_space->n_quadrature_points)
+    , n_quadrature_points(_fev_space->n_quadrature_points *
+                          _fev_time->n_quadrature_points)
+  {}
 
-    ////////////////////////////////////////////////////////////
-    // FEFaceValues ////////////////////////////////////////////////
-    ////////////////////////////////////////////////////////////
-    template<int dim>
-    FEFaceValues<dim>::FEFaceValues (
-        DG_FiniteElement<dim> &fe ,
-        Quadrature<dim - 1> &quad ,
-        const dealii::UpdateFlags uflags,
-        const dealii::UpdateFlags additional_flags )
-        :
-        _fe ( fe ),
-        _quad ( quad ),
-        _fev_space ( std::make_shared<dealii::FEFaceValues<dim>> ( *fe.spatial () ,
-                                                                   *quad.spatial () ,
-                                                                   uflags | additional_flags )
-        ),
-        _fev_time ( std::make_shared<dealii::FEValues<1>> ( *fe.temporal () ,
-                                                            *quad.temporal () ,
-                                                            uflags )
-        ),
-        local_space_dof_index ( fe.spatial ()->dofs_per_cell ),
-        local_time_dof_index ( fe.temporal ()->dofs_per_cell ),
-        n_dofs_space ( 0 ),
-        time_cell_index ( 0 ),
-        n_dofs_space_cell ( _fe.spatial ()->dofs_per_cell ),
-        n_quads_space ( _fev_space->n_quadrature_points ),
-        n_quadrature_points ( _fev_space->n_quadrature_points * _fev_time->n_quadrature_points )
-    {
-    }
+  template <int dim>
+  void
+  FEFaceValues<dim>::reinit_space(
+    const typename dealii::TriaIterator<
+      dealii::DoFCellAccessor<dim, dim, false>> &cell_space,
+    const unsigned int                           face_no)
+  {
+    _fev_space->reinit(cell_space, face_no);
+    cell_space->get_dof_indices(local_space_dof_index);
+    n_dofs_space = cell_space->get_dof_handler().n_dofs();
+  }
 
-    template<int dim>
-    void FEFaceValues<dim>::reinit_space (
-        const typename dealii::TriaIterator<dealii::DoFCellAccessor<dim,dim,false>> &cell_space ,
-        const unsigned int face_no )
-    {
-        _fev_space->reinit ( cell_space , face_no );
-        cell_space->get_dof_indices ( local_space_dof_index );
-        n_dofs_space = cell_space->get_dof_handler ().n_dofs ();
-    }
+  template <int dim>
+  void
+  FEFaceValues<dim>::reinit_time(
+    const typename dealii::TriaIterator<dealii::DoFCellAccessor<1, 1, false>>
+      &cell_time)
+  {
+    _fev_time->reinit(cell_time);
+    cell_time->get_dof_indices(local_time_dof_index);
+    time_cell_index = cell_time->index();
+  }
 
-    template<int dim>
-    void FEFaceValues<dim>::reinit_time (
-        const typename dealii::TriaIterator<dealii::DoFCellAccessor<1,1,false>> &cell_time )
-    {
-        _fev_time->reinit ( cell_time );
-        cell_time->get_dof_indices ( local_time_dof_index );
-        time_cell_index = cell_time->index ();
-    }
+  template <int dim>
+  double
+  FEFaceValues<dim>::shape_value(unsigned int function_no,
+                                 unsigned int point_no)
+  {
+    return _fev_space->shape_value(function_no % n_dofs_space_cell,
+                                   point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    double FEFaceValues<dim>::shape_value (
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return _fev_space->shape_value ( function_no % n_dofs_space_cell ,
-                                         point_no % n_quads_space )
-              * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                         point_no / n_quads_space );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Scalar<dim>::value_type
+  FEFaceValues<dim>::scalar_value(
+    const typename dealii::FEValuesExtractors::Scalar &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no % n_dofs_space_cell,
+                                          point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Scalar<dim>::value_type FEFaceValues<dim>::scalar_value (
-        const typename dealii::FEValuesExtractors::Scalar &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % n_dofs_space_cell ,
-                                                  point_no % n_quads_space )
-                       * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                                  point_no / n_quads_space );
-    }
+  template <int dim>
+  typename dealii::FEValuesViews::Vector<dim>::value_type
+  FEFaceValues<dim>::vector_value(
+    const typename dealii::FEValuesExtractors::Vector &extractor,
+    unsigned int                                       function_no,
+    unsigned int                                       point_no)
+  {
+    return (*_fev_space)[extractor].value(function_no % n_dofs_space_cell,
+                                          point_no % n_quads_space) *
+           _fev_time->shape_value(function_no / n_dofs_space_cell,
+                                  point_no / n_quads_space);
+  }
 
-    template<int dim>
-    typename dealii::FEValuesViews::Vector<dim>::value_type FEFaceValues<dim>::vector_value (
-        const typename dealii::FEValuesExtractors::Vector &extractor ,
-        unsigned int function_no ,
-        unsigned int point_no )
-    {
-        return ( *_fev_space )[extractor].value ( function_no % n_dofs_space_cell ,
-                                                  point_no % n_quads_space )
-                       * _fev_time->shape_value ( function_no / n_dofs_space_cell ,
-                                                  point_no / n_quads_space );
-    }
+  template <int dim>
+  double
+  FEFaceValues<dim>::time_quadrature_point(unsigned int quadrature_point)
+  {
+    return _fev_time->quadrature_point(quadrature_point / n_quads_space)[0];
+  }
 
-    template<int dim>
-    double FEFaceValues<dim>::time_quadrature_point ( unsigned int quadrature_point )
-    {
-        return _fev_time->quadrature_point ( quadrature_point / n_quads_space )[0];
-    }
+  template <int dim>
+  dealii::Point<dim>
+  FEFaceValues<dim>::space_quadrature_point(unsigned int quadrature_point)
+  {
+    return _fev_space->quadrature_point(quadrature_point % n_quads_space);
+  }
 
-    template<int dim>
-    dealii::Point<dim> FEFaceValues<dim>::space_quadrature_point ( unsigned int quadrature_point )
-    {
-        return _fev_space->quadrature_point ( quadrature_point % n_quads_space );
-    }
+  template <int dim>
+  const dealii::Tensor<1, dim> &
+  FEFaceValues<dim>::space_normal_vector(unsigned int i)
+  {
+    return _fev_space->normal_vector(i % n_quads_space);
+  }
 
-    template<int dim>
-    const dealii::Tensor<1,dim>&
-    FEFaceValues<dim>::space_normal_vector ( unsigned int i )
-    {
-        return _fev_space->normal_vector ( i % n_quads_space );
-    }
+  template <int dim>
+  double
+  FEFaceValues<dim>::JxW(unsigned int quadrature_point)
+  {
+    return _fev_space->JxW(quadrature_point % n_quads_space) *
+           _fev_time->JxW(quadrature_point / n_quads_space);
+  }
 
-    template<int dim>
-    double FEFaceValues<dim>::JxW ( unsigned int quadrature_point )
-    {
-        return _fev_space->JxW ( quadrature_point % n_quads_space ) * _fev_time->JxW (
-                quadrature_point / n_quads_space );
-    }
+  template <int dim>
+  void
+  FEFaceValues<dim>::get_local_dof_indices(
+    std::vector<dealii::types::global_dof_index> &indices)
+  {
+    for (unsigned int i = 0; i < _fe.dofs_per_cell; i++)
+      {
+        indices[i + time_cell_index * _fe.dofs_per_cell] =
+          local_space_dof_index[i % n_dofs_space_cell] +
+          local_time_dof_index[i / n_dofs_space_cell] * n_dofs_space;
+      }
+  }
 
-    template<int dim>
-    void FEFaceValues<dim>::get_local_dof_indices ( std::vector<dealii::types::global_dof_index> &indices )
-    {
-        for ( unsigned int i = 0 ; i < _fe.dofs_per_cell ; i++ )
-        {
+  template <int dim>
+  std::shared_ptr<dealii::FEFaceValues<dim>>
+  FEFaceValues<dim>::spatial()
+  {
+    return _fev_space;
+  }
 
-            indices[i + time_cell_index * _fe.dofs_per_cell] =
-                    local_space_dof_index[i % n_dofs_space_cell]
-                   + local_time_dof_index[i / n_dofs_space_cell] * n_dofs_space;
-        }
-    }
-
-    template<int dim>
-    std::shared_ptr<dealii::FEFaceValues<dim>> FEFaceValues<dim>::spatial ()
-    {
-        return _fev_space;
-    }
-
-    template<int dim>
-    std::shared_ptr<dealii::FEValues<1>> FEFaceValues<dim>::temporal ()
-    {
-        return _fev_time;
-    }
-}
+  template <int dim>
+  std::shared_ptr<dealii::FEValues<1>>
+  FEFaceValues<dim>::temporal()
+  {
+    return _fev_time;
+  }
+} // namespace idealii::spacetime
 
 #include "spacetime_fe_values.inst"
-

--- a/src/fe/spacetime_fe_values.inst
+++ b/src/fe/spacetime_fe_values.inst
@@ -18,92 +18,126 @@
 
 namespace idealii::spacetime
 {
-    template class FEValues<2> ;
-    template class FEValues<3> ;
+  template class FEValues<2>;
+  template class FEValues<3>;
 
 
-    template void FEValues<2>::get_function_values(const dealii::Vector<double>&,
-                                                   std::vector<dealii::Vector<double>>&) const;
+  template void
+  FEValues<2>::get_function_values(const dealii::Vector<double> &,
+                                   std::vector<dealii::Vector<double>> &) const;
 
-    template void FEValues<3>::get_function_values(const dealii::Vector<double> &,
-                                                   std::vector<dealii::Vector<double>> &) const;
+  template void
+  FEValues<3>::get_function_values(const dealii::Vector<double> &,
+                                   std::vector<dealii::Vector<double>> &) const;
 
-    template void FEValues<2>::get_function_dt(const dealii::Vector<double>&,
-                                                   std::vector<dealii::Vector<double>>&) const;
+  template void
+  FEValues<2>::get_function_dt(const dealii::Vector<double> &,
+                               std::vector<dealii::Vector<double>> &) const;
 
-    template void FEValues<3>::get_function_dt(const dealii::Vector<double> &,
-                                                   std::vector<dealii::Vector<double>> &) const;
+  template void
+  FEValues<3>::get_function_dt(const dealii::Vector<double> &,
+                               std::vector<dealii::Vector<double>> &) const;
 
-    template void FEValues<2>::get_function_space_gradients(const dealii::Vector<double>&,
-                                                   std::vector<std::vector<dealii::Tensor<1,2,double>>>&) const;
+  template void
+  FEValues<2>::get_function_space_gradients(
+    const dealii::Vector<double> &,
+    std::vector<std::vector<dealii::Tensor<1, 2, double>>> &) const;
 
-    template void FEValues<3>::get_function_space_gradients(const dealii::Vector<double> &,
-                                                   std::vector<std::vector<dealii::Tensor<1,3,double>>>&) const;
-
-    #ifdef DEAL_II_WITH_TRILINOS
-    #ifdef DEAL_II_WITH_MPI
-    template void FEValues<2>::get_function_values(const dealii::TrilinosWrappers::MPI::Vector&,
-                                                   std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
-
-    template void FEValues<3>::get_function_values(const dealii::TrilinosWrappers::MPI::Vector&,
-                                                   std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
-
-    template void FEValues<2>::get_function_dt(const dealii::TrilinosWrappers::MPI::Vector&,
-                                               std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
-
-    template void FEValues<3>::get_function_dt(const dealii::TrilinosWrappers::MPI::Vector&,
-                                               std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
-
-
-    template void FEValues<2>::get_function_space_gradients(
-        const dealii::TrilinosWrappers::MPI::Vector&,
-        std::vector<std::vector<dealii::Tensor<1,2,dealii::TrilinosScalar>>>&
-    ) const;
-
-    template void FEValues<3>::get_function_space_gradients(
-        const dealii::TrilinosWrappers::MPI::Vector&,
-        std::vector<std::vector<dealii::Tensor<1,3,dealii::TrilinosScalar>>>&
-    ) const;
-
-    #endif
-    #endif
-
-    template class FEJumpValues<2> ;
-    template class FEJumpValues<3> ;
-
-
-    template void FEJumpValues<2>::get_function_values_plus(const dealii::Vector<double>&,
-                                                        std::vector<dealii::Vector<double>>&) const;
-
-    template void FEJumpValues<2>::get_function_values_minus(const dealii::Vector<double>&,
-                                                         std::vector<dealii::Vector<double>>&) const;
-
-    template void FEJumpValues<3>::get_function_values_plus(const dealii::Vector<double> &,
-                                                        std::vector<dealii::Vector<double>> &) const;
-
-    template void FEJumpValues<3>::get_function_values_minus(const dealii::Vector<double> &,
-                                                         std::vector<dealii::Vector<double>> &) const;
+  template void
+  FEValues<3>::get_function_space_gradients(
+    const dealii::Vector<double> &,
+    std::vector<std::vector<dealii::Tensor<1, 3, double>>> &) const;
 
 #ifdef DEAL_II_WITH_TRILINOS
-#ifdef DEAL_II_WITH_MPI
-    template void FEJumpValues<2>::get_function_values_plus(const dealii::TrilinosWrappers::MPI::Vector&,
-                                                        std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+#  ifdef DEAL_II_WITH_MPI
+  template void
+  FEValues<2>::get_function_values(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<dealii::Vector<dealii::TrilinosScalar>> &) const;
 
-    template void FEJumpValues<2>::get_function_values_minus(const dealii::TrilinosWrappers::MPI::Vector&,
-                                                         std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+  template void
+  FEValues<3>::get_function_values(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<dealii::Vector<dealii::TrilinosScalar>> &) const;
 
-    template void FEJumpValues<3>::get_function_values_plus(const dealii::TrilinosWrappers::MPI::Vector&,
-                                                        std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+  template void
+  FEValues<2>::get_function_dt(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<dealii::Vector<dealii::TrilinosScalar>> &) const;
 
-    template void FEJumpValues<3>::get_function_values_minus(const dealii::TrilinosWrappers::MPI::Vector&,
-                                                         std::vector<dealii::Vector<dealii::TrilinosScalar>>&) const;
+  template void
+  FEValues<3>::get_function_dt(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<dealii::Vector<dealii::TrilinosScalar>> &) const;
 
 
+  template void
+  FEValues<2>::get_function_space_gradients(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<std::vector<dealii::Tensor<1, 2, dealii::TrilinosScalar>>> &)
+    const;
+
+  template void
+  FEValues<3>::get_function_space_gradients(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<std::vector<dealii::Tensor<1, 3, dealii::TrilinosScalar>>> &)
+    const;
+
+#  endif
 #endif
+
+  template class FEJumpValues<2>;
+  template class FEJumpValues<3>;
+
+
+  template void
+  FEJumpValues<2>::get_function_values_plus(
+    const dealii::Vector<double> &,
+    std::vector<dealii::Vector<double>> &) const;
+
+  template void
+  FEJumpValues<2>::get_function_values_minus(
+    const dealii::Vector<double> &,
+    std::vector<dealii::Vector<double>> &) const;
+
+  template void
+  FEJumpValues<3>::get_function_values_plus(
+    const dealii::Vector<double> &,
+    std::vector<dealii::Vector<double>> &) const;
+
+  template void
+  FEJumpValues<3>::get_function_values_minus(
+    const dealii::Vector<double> &,
+    std::vector<dealii::Vector<double>> &) const;
+
+#ifdef DEAL_II_WITH_TRILINOS
+#  ifdef DEAL_II_WITH_MPI
+  template void
+  FEJumpValues<2>::get_function_values_plus(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<dealii::Vector<dealii::TrilinosScalar>> &) const;
+
+  template void
+  FEJumpValues<2>::get_function_values_minus(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<dealii::Vector<dealii::TrilinosScalar>> &) const;
+
+  template void
+  FEJumpValues<3>::get_function_values_plus(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<dealii::Vector<dealii::TrilinosScalar>> &) const;
+
+  template void
+  FEJumpValues<3>::get_function_values_minus(
+    const dealii::TrilinosWrappers::MPI::Vector &,
+    std::vector<dealii::Vector<dealii::TrilinosScalar>> &) const;
+
+
+#  endif
 #endif
 
-    template class FEFaceValues<2> ;
-    template class FEFaceValues<3> ;
-}
+  template class FEFaceValues<2>;
+  template class FEFaceValues<3>;
+} // namespace idealii::spacetime
 
 #endif

--- a/src/grid/fixed_tria.cc
+++ b/src/grid/fixed_tria.cc
@@ -17,103 +17,122 @@
 
 namespace idealii::spacetime::fixed
 {
-    template<int dim>
-    Triangulation<dim>::Triangulation (dealii::types::global_cell_index max_N_intervals_per_slab)
-    :
-    spacetime::Triangulation<dim> (max_N_intervals_per_slab)
-    {
-    }
+  template <int dim>
+  Triangulation<dim>::Triangulation(
+    dealii::types::global_cell_index max_N_intervals_per_slab)
+    : spacetime::Triangulation<dim>(max_N_intervals_per_slab)
+  {}
 
-    template<int dim>
-    void Triangulation<dim>::generate (
-        std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
-        unsigned int M ,
-        double t0 ,
-        double T )
-    {
-        Assert( space_tria.use_count () , dealii::ExcNotInitialized () );
-        double t = t0;
-        double k = ( T - t0 ) / M;
-        for ( unsigned int i = 0 ; i < M ; i++ )
-        {
-            this->trias.push_back ( idealii::slab::Triangulation<dim> (
-                                        space_tria ,
-                                        t ,
-                                        t + k ) );
-            t += k;
-        }
-    }
+  template <int dim>
+  void
+  Triangulation<dim>::generate(
+    std::shared_ptr<dealii::Triangulation<dim>> space_tria,
+    unsigned int                                M,
+    double                                      t0,
+    double                                      T)
+  {
+    Assert(space_tria.use_count(), dealii::ExcNotInitialized());
+    double t = t0;
+    double k = (T - t0) / M;
+    for (unsigned int i = 0; i < M; i++)
+      {
+        this->trias.push_back(
+          idealii::slab::Triangulation<dim>(space_tria, t, t + k));
+        t += k;
+      }
+  }
 
-    template<int dim>
-    void Triangulation<dim>::refine_global (
-        const unsigned int times_space ,
-        const unsigned int times_time )
-    {
+  template <int dim>
+  void
+  Triangulation<dim>::refine_global(const unsigned int times_space,
+                                    const unsigned int times_time)
+  {
+    // do refinement
+    slab::TriaIterator<dim> slab_tria = this->begin();
+    slab_tria->spatial()->refine_global(times_space);
+    for (; slab_tria != this->end(); ++slab_tria)
+      {
+        slab_tria->temporal()->refine_global(times_time);
 
-        //do refinement
-        slab::TriaIterator<dim> slab_tria = this->begin ();
-        slab_tria->spatial ()->refine_global ( times_space );
-        for ( ; slab_tria != this->end () ; ++slab_tria )
-        {
-            slab_tria->temporal ()->refine_global ( times_time );
+        // Check if temporal triangulation got too large (unless max_N = 0)
+        if (this->max_N_intervals_per_slab &&
+            slab_tria->temporal()->n_global_active_cells() >
+              this->max_N_intervals_per_slab)
+          {
+            dealii::types::global_cell_index M =
+              slab_tria->temporal()->n_global_active_cells();
+            std::vector<double>              step_sizes(M);
+            dealii::types::global_cell_index i = 0;
+            for (auto &cell : slab_tria->temporal()->active_cell_iterators())
+              {
+                step_sizes[i] = cell->bounding_box().side_length(0);
+                i++;
+              }
 
-            //Check if temporal triangulation got too large (unless max_N = 0)
-            if ( this->max_N_intervals_per_slab &&
-                 slab_tria->temporal()->n_global_active_cells( )> this->max_N_intervals_per_slab)
-            {
-                dealii::types::global_cell_index M = slab_tria->temporal()->n_global_active_cells();
-                std::vector<double> step_sizes(M);
-                dealii::types::global_cell_index i = 0;
-                for (auto &cell : slab_tria->temporal()->active_cell_iterators()){
-                    step_sizes[i] = cell->bounding_box().side_length(0);
-                    i++;
-                }
+            // number of subdivisions needed is at least
+            dealii::types::global_cell_index subdiv =
+              M / this->max_N_intervals_per_slab;
+            // remaining intervals?
+            dealii::types::global_cell_index modulus =
+              M % this->max_N_intervals_per_slab;
 
-                //number of subdivisions needed is at least
-                dealii::types::global_cell_index subdiv = M/this->max_N_intervals_per_slab;
-                //remaining intervals?
-                dealii::types::global_cell_index modulus = M%this->max_N_intervals_per_slab;
-
-                std::vector<std::vector<double>> partial_step_sizes;
-                for ( dealii::types::global_cell_index j = 0 ; j < subdiv ; j++){
-                    partial_step_sizes.push_back(std::vector<double>(this->max_N_intervals_per_slab));
-                }
-                if ( modulus ){
-                    partial_step_sizes.push_back(std::vector<double>(modulus));
-                }
+            std::vector<std::vector<double>> partial_step_sizes;
+            for (dealii::types::global_cell_index j = 0; j < subdiv; j++)
+              {
+                partial_step_sizes.push_back(
+                  std::vector<double>(this->max_N_intervals_per_slab));
+              }
+            if (modulus)
+              {
+                partial_step_sizes.push_back(std::vector<double>(modulus));
+              }
 
 
-                //Distribute step sizes onto subdivisions
-                for ( i = 0 ; i < M ; ++i ){
-                    dealii::types::global_cell_index j = i/this->max_N_intervals_per_slab;
-                    dealii::types::global_cell_index k  = i%this->max_N_intervals_per_slab;
-                    partial_step_sizes[j][k] = step_sizes[i];
-                }
+            // Distribute step sizes onto subdivisions
+            for (i = 0; i < M; ++i)
+              {
+                dealii::types::global_cell_index j =
+                  i / this->max_N_intervals_per_slab;
+                dealii::types::global_cell_index k =
+                  i % this->max_N_intervals_per_slab;
+                partial_step_sizes[j][k] = step_sizes[i];
+              }
 
-                // we need to calculate temporal bounds for the new slabs
-                double end = slab_tria->startpoint();
-                double start = end;
+            // we need to calculate temporal bounds for the new slabs
+            double end   = slab_tria->startpoint();
+            double start = end;
 
-                //The first new slabs will be emplaced before the current one.
-                //Then, they will not invalidate the list iterator going forward
-                for ( i =  0 ; i < partial_step_sizes.size()-1 ; ++i ){
-                    start = end;
-                    for ( dealii::types::global_cell_index j = 0 ; j < partial_step_sizes[i].size() ; ++j ){
-                        end += partial_step_sizes[i][j];
-                    }
-                    this->trias.emplace(slab_tria,slab_tria->spatial(),partial_step_sizes[i],start,end);
-                }
-                //Finally, update the current slab triangulation
+            // The first new slabs will be emplaced before the current one.
+            // Then, they will not invalidate the list iterator going forward
+            for (i = 0; i < partial_step_sizes.size() - 1; ++i)
+              {
                 start = end;
-                for ( dealii::types::global_cell_index j = 0 ; j < partial_step_sizes[i].size() ; ++j ){
+                for (dealii::types::global_cell_index j = 0;
+                     j < partial_step_sizes[i].size();
+                     ++j)
+                  {
                     end += partial_step_sizes[i][j];
-                }
-                slab_tria->update_temporal_triangulation(partial_step_sizes[i],start,end);
-            }
-        }
-
-    }
-}
+                  }
+                this->trias.emplace(slab_tria,
+                                    slab_tria->spatial(),
+                                    partial_step_sizes[i],
+                                    start,
+                                    end);
+              }
+            // Finally, update the current slab triangulation
+            start = end;
+            for (dealii::types::global_cell_index j = 0;
+                 j < partial_step_sizes[i].size();
+                 ++j)
+              {
+                end += partial_step_sizes[i][j];
+              }
+            slab_tria->update_temporal_triangulation(partial_step_sizes[i],
+                                                     start,
+                                                     end);
+          }
+      }
+  }
+} // namespace idealii::spacetime::fixed
 
 #include "fixed_tria.inst"
-

--- a/src/grid/fixed_tria.inst
+++ b/src/grid/fixed_tria.inst
@@ -18,9 +18,9 @@
 
 namespace idealii::spacetime::fixed
 {
-    template class Triangulation<2> ;
-    template class Triangulation<3> ;
+  template class Triangulation<2>;
+  template class Triangulation<3>;
 
-} //namespaces
+} // namespace idealii::spacetime::fixed
 
 #endif

--- a/src/grid/slab_tria.cc
+++ b/src/grid/slab_tria.cc
@@ -20,112 +20,112 @@
 namespace idealii::slab
 {
 
-    template<int dim>
-    Triangulation<dim>::Triangulation (
-        std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
-        double start ,
-        double end )
-        :
-        _startpoint ( start ),
-        _endpoint ( end )
-    {
-        Assert( space_tria.use_count () , dealii::ExcNotInitialized () );
-        _spatial_tria = space_tria;
-        _temporal_tria = std::make_shared<dealii::Triangulation<1>> ();
-        dealii::GridGenerator::hyper_cube ( *_temporal_tria ,
-                                            _startpoint ,
-                                            _endpoint );
-    }
+  template <int dim>
+  Triangulation<dim>::Triangulation(
+    std::shared_ptr<dealii::Triangulation<dim>> space_tria,
+    double                                      start,
+    double                                      end)
+    : _startpoint(start)
+    , _endpoint(end)
+  {
+    Assert(space_tria.use_count(), dealii::ExcNotInitialized());
+    _spatial_tria  = space_tria;
+    _temporal_tria = std::make_shared<dealii::Triangulation<1>>();
+    dealii::GridGenerator::hyper_cube(*_temporal_tria, _startpoint, _endpoint);
+  }
 
-    template<int dim>
-    Triangulation<dim>::Triangulation (
-        std::shared_ptr<dealii::Triangulation<dim>> space_tria ,
-        std::vector<double> step_sizes,
-        double start ,
-        double end )
-        :
-        _startpoint ( start ),
-        _endpoint ( end )
-    {
-        Assert( space_tria.use_count () , dealii::ExcNotInitialized () );
-        #ifdef DEBUG
-            double sum = std::accumulate(step_sizes.begin(),step_sizes.end(),0);
-            Assert ( ( (_startpoint + sum - _endpoint) < 1.0e-12),
-                    dealii::ExcMessage("Mismatch between provided endpoint and temporal step sizes in slab Triangulation."));
-        #endif
-        _spatial_tria = space_tria;
-        _temporal_tria = std::make_shared<dealii::Triangulation<1>> ();
-        //Grid generator needs step sizes for each dimension,
-        //so we need to construct a new vector with on entry.
-        std::vector<std::vector<double>> spacing;
-        spacing.push_back(step_sizes);
-        dealii::Point<1> p1(_startpoint);
-        dealii::Point<1> p2(_endpoint);
-        dealii::GridGenerator::subdivided_hyper_rectangle( *_temporal_tria,
-                                                           spacing,
-                                                           p1,
-                                                           p2
-        );
-    }
+  template <int dim>
+  Triangulation<dim>::Triangulation(
+    std::shared_ptr<dealii::Triangulation<dim>> space_tria,
+    std::vector<double>                         step_sizes,
+    double                                      start,
+    double                                      end)
+    : _startpoint(start)
+    , _endpoint(end)
+  {
+    Assert(space_tria.use_count(), dealii::ExcNotInitialized());
+#ifdef DEBUG
+    double sum = std::accumulate(step_sizes.begin(), step_sizes.end(), 0);
+    Assert(
+      ((_startpoint + sum - _endpoint) < 1.0e-12),
+      dealii::ExcMessage(
+        "Mismatch between provided endpoint and temporal step sizes in slab Triangulation."));
+#endif
+    _spatial_tria  = space_tria;
+    _temporal_tria = std::make_shared<dealii::Triangulation<1>>();
+    // Grid generator needs step sizes for each dimension,
+    // so we need to construct a new vector with on entry.
+    std::vector<std::vector<double>> spacing;
+    spacing.push_back(step_sizes);
+    dealii::Point<1> p1(_startpoint);
+    dealii::Point<1> p2(_endpoint);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*_temporal_tria,
+                                                      spacing,
+                                                      p1,
+                                                      p2);
+  }
 
-    template<int dim>
-        Triangulation<dim>::Triangulation ( const Triangulation &other )
-            :
-            _startpoint ( other._startpoint ),
-            _endpoint ( other._endpoint )
-        {
-            Assert( other._spatial_tria.use_count () , dealii::ExcNotInitialized () );
-            _spatial_tria = other._spatial_tria;
-            Assert( other._temporal_tria.use_count () , dealii::ExcNotInitialized () );
-            _temporal_tria = other._temporal_tria;
-        }
+  template <int dim>
+  Triangulation<dim>::Triangulation(const Triangulation &other)
+    : _startpoint(other._startpoint)
+    , _endpoint(other._endpoint)
+  {
+    Assert(other._spatial_tria.use_count(), dealii::ExcNotInitialized());
+    _spatial_tria = other._spatial_tria;
+    Assert(other._temporal_tria.use_count(), dealii::ExcNotInitialized());
+    _temporal_tria = other._temporal_tria;
+  }
 
-    template<int dim>
-        std::shared_ptr<dealii::Triangulation<dim>> Triangulation<dim>::spatial ()
-        {
-            Assert( _spatial_tria.use_count () , dealii::ExcNotInitialized () );
-            return _spatial_tria;
-        }
+  template <int dim>
+  std::shared_ptr<dealii::Triangulation<dim>>
+  Triangulation<dim>::spatial()
+  {
+    Assert(_spatial_tria.use_count(), dealii::ExcNotInitialized());
+    return _spatial_tria;
+  }
 
-    template<int dim>
-        std::shared_ptr<dealii::Triangulation<1>> Triangulation<dim>::temporal ()
-        {
-            Assert( _temporal_tria.use_count () , dealii::ExcNotInitialized () );
-            return _temporal_tria;
-        }
+  template <int dim>
+  std::shared_ptr<dealii::Triangulation<1>>
+  Triangulation<dim>::temporal()
+  {
+    Assert(_temporal_tria.use_count(), dealii::ExcNotInitialized());
+    return _temporal_tria;
+  }
 
-    template<int dim>
-        double Triangulation<dim>::startpoint ()
-        {
-            return _startpoint;
-        }
+  template <int dim>
+  double
+  Triangulation<dim>::startpoint()
+  {
+    return _startpoint;
+  }
 
-    template<int dim>
-        double Triangulation<dim>::endpoint ()
-        {
-            return _endpoint;
-        }
+  template <int dim>
+  double
+  Triangulation<dim>::endpoint()
+  {
+    return _endpoint;
+  }
 
-    template<int dim>
-    void Triangulation<dim>:: update_temporal_triangulation(
-        std::vector<double> step_sizes,
-        double startpoint,
-        double endpoint){
-        _startpoint = startpoint;
-        _endpoint = endpoint;
-        std::vector<std::vector<double>> spacing;
-        spacing.push_back(step_sizes);
-        //TODO: add an assertion that no subscribers exist
-        _temporal_tria->clear();
-        dealii::Point<1> p1(_startpoint);
-        dealii::Point<1> p2(_endpoint);
-        dealii::GridGenerator::subdivided_hyper_rectangle( *_temporal_tria,
-                                                           spacing,
-                                                           p1,
-                                                           p2
-        );
-    }
-}
+  template <int dim>
+  void
+  Triangulation<dim>::update_temporal_triangulation(
+    std::vector<double> step_sizes,
+    double              startpoint,
+    double              endpoint)
+  {
+    _startpoint = startpoint;
+    _endpoint   = endpoint;
+    std::vector<std::vector<double>> spacing;
+    spacing.push_back(step_sizes);
+    // TODO: add an assertion that no subscribers exist
+    _temporal_tria->clear();
+    dealii::Point<1> p1(_startpoint);
+    dealii::Point<1> p2(_endpoint);
+    dealii::GridGenerator::subdivided_hyper_rectangle(*_temporal_tria,
+                                                      spacing,
+                                                      p1,
+                                                      p2);
+  }
+} // namespace idealii::slab
 
 #include "slab_tria.inst"
-

--- a/src/grid/slab_tria.inst
+++ b/src/grid/slab_tria.inst
@@ -18,8 +18,8 @@
 
 namespace idealii::slab
 {
-    template class Triangulation<2> ;
-    template class Triangulation<3> ;
-} //namespaces
+  template class Triangulation<2>;
+  template class Triangulation<3>;
+} // namespace idealii::slab
 
 #endif

--- a/src/grid/spacetime_tria.cc
+++ b/src/grid/spacetime_tria.cc
@@ -17,32 +17,36 @@
 
 namespace idealii::spacetime
 {
-    template<int dim>
-    Triangulation<dim>::Triangulation (dealii::types::global_cell_index max_N_intervals_per_slab)
-    :max_N_intervals_per_slab(max_N_intervals_per_slab)
-    {
-        trias = std::list<idealii::slab::Triangulation<dim>> ();
-    }
+  template <int dim>
+  Triangulation<dim>::Triangulation(
+    dealii::types::global_cell_index max_N_intervals_per_slab)
+    : max_N_intervals_per_slab(max_N_intervals_per_slab)
+  {
+    trias = std::list<idealii::slab::Triangulation<dim>>();
+  }
 
 
-    template<int dim>
-    unsigned int Triangulation<dim>::M ()
-    {
-        return trias.size ();
-    }
+  template <int dim>
+  unsigned int
+  Triangulation<dim>::M()
+  {
+    return trias.size();
+  }
 
-    template<int dim>
-    slab::TriaIterator<dim> Triangulation<dim>::begin ()
-    {
-        return trias.begin ();
-    }
+  template <int dim>
+  slab::TriaIterator<dim>
+  Triangulation<dim>::begin()
+  {
+    return trias.begin();
+  }
 
-    template<int dim>
-    slab::TriaIterator<dim> Triangulation<dim>::end ()
-    {
-        return trias.end ();
-    }
+  template <int dim>
+  slab::TriaIterator<dim>
+  Triangulation<dim>::end()
+  {
+    return trias.end();
+  }
 
-}
+} // namespace idealii::spacetime
 
 #include "spacetime_tria.inst"

--- a/src/grid/spacetime_tria.inst
+++ b/src/grid/spacetime_tria.inst
@@ -18,8 +18,8 @@
 
 namespace idealii::spacetime
 {
-    template class Triangulation<2> ;
-    template class Triangulation<3> ;
-} //namespaces
+  template class Triangulation<2>;
+  template class Triangulation<3>;
+} // namespace idealii::spacetime
 
 #endif

--- a/src/lac/spacetime_trilinos_vector.cc
+++ b/src/lac/spacetime_trilinos_vector.cc
@@ -16,39 +16,42 @@
 #include <ideal.II/lac/spacetime_trilinos_vector.hh>
 
 #ifdef DEAL_II_WITH_TRILINOS
-#ifdef DEAL_II_WITH_MPI
+#  ifdef DEAL_II_WITH_MPI
 namespace idealii::spacetime
 {
-    TrilinosVector::TrilinosVector ()
-    {
-        _vectors = std::list<dealii::TrilinosWrappers::MPI::Vector> ();
-    }
+  TrilinosVector::TrilinosVector()
+  {
+    _vectors = std::list<dealii::TrilinosWrappers::MPI::Vector>();
+  }
 
-    unsigned int TrilinosVector::M ()
-    {
-        return _vectors.size ();
-    }
+  unsigned int
+  TrilinosVector::M()
+  {
+    return _vectors.size();
+  }
 
-    void TrilinosVector::reinit ( unsigned int M )
-    {
-        this->_vectors.clear ();
-        for ( unsigned int i = 0 ; i < M ; i++ )
-        {
-            this->_vectors.push_back (dealii::TrilinosWrappers::MPI::Vector () );
-        }
-    }
+  void
+  TrilinosVector::reinit(unsigned int M)
+  {
+    this->_vectors.clear();
+    for (unsigned int i = 0; i < M; i++)
+      {
+        this->_vectors.push_back(dealii::TrilinosWrappers::MPI::Vector());
+      }
+  }
 
-    slab::TrilinosVectorIterator TrilinosVector::begin ()
-    {
-        return _vectors.begin ();
-    }
+  slab::TrilinosVectorIterator
+  TrilinosVector::begin()
+  {
+    return _vectors.begin();
+  }
 
-    slab::TrilinosVectorIterator TrilinosVector::end ()
-    {
-        return _vectors.end ();
-    }
-}
+  slab::TrilinosVectorIterator
+  TrilinosVector::end()
+  {
+    return _vectors.end();
+  }
+} // namespace idealii::spacetime
 
+#  endif
 #endif
-#endif
-

--- a/src/lac/spacetime_vector.cc
+++ b/src/lac/spacetime_vector.cc
@@ -17,40 +17,43 @@
 
 namespace idealii::spacetime
 {
-    template<typename Number>
-    Vector<Number>::Vector ()
-    {
-        _vectors = std::list<dealii::Vector<Number>> ();
-    }
+  template <typename Number>
+  Vector<Number>::Vector()
+  {
+    _vectors = std::list<dealii::Vector<Number>>();
+  }
 
-    template<typename Number>
-    unsigned int Vector<Number>::M ()
-    {
-        return _vectors.size ();
-    }
+  template <typename Number>
+  unsigned int
+  Vector<Number>::M()
+  {
+    return _vectors.size();
+  }
 
-    template<typename Number>
-    void Vector<Number>::reinit ( unsigned int M )
-    {
-        this->_vectors.clear ();
-        for ( unsigned int i = 0 ; i < M ; i++ )
-        {
-            this->_vectors.push_back ( dealii::Vector<Number> () );
-        }
-    }
+  template <typename Number>
+  void
+  Vector<Number>::reinit(unsigned int M)
+  {
+    this->_vectors.clear();
+    for (unsigned int i = 0; i < M; i++)
+      {
+        this->_vectors.push_back(dealii::Vector<Number>());
+      }
+  }
 
-    template<typename Number>
-    slab::VectorIterator<Number> Vector<Number>::begin ()
-    {
-        return _vectors.begin ();
-    }
+  template <typename Number>
+  slab::VectorIterator<Number>
+  Vector<Number>::begin()
+  {
+    return _vectors.begin();
+  }
 
-    template<typename Number>
-    slab::VectorIterator<Number> Vector<Number>::end ()
-    {
-        return _vectors.end ();
-    }
-}
+  template <typename Number>
+  slab::VectorIterator<Number>
+  Vector<Number>::end()
+  {
+    return _vectors.end();
+  }
+} // namespace idealii::spacetime
 
 #include "spacetime_vector.inst"
-

--- a/src/lac/spacetime_vector.inst
+++ b/src/lac/spacetime_vector.inst
@@ -18,8 +18,8 @@
 
 namespace idealii::spacetime
 {
-    template class Vector<float> ;
-    template class Vector<double> ;
-}
+  template class Vector<float>;
+  template class Vector<double>;
+} // namespace idealii::spacetime
 
 #endif

--- a/src/numerics/vector_tools.cc
+++ b/src/numerics/vector_tools.cc
@@ -17,208 +17,218 @@
 
 namespace idealii::slab::VectorTools
 {
-    template<int dim,typename Number>
-    void interpolate_boundary_values (
-       idealii::slab::DoFHandler<dim> &dof_handler ,
-       const dealii::types::boundary_id boundary_component ,
-       dealii::Function<dim,Number> &boundary_function ,
-       std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints ,
-       const dealii::ComponentMask &component_mask )
-    {
-        auto space_constraints = std::make_shared<dealii::AffineConstraints<Number>> ();
+  template <int dim, typename Number>
+  void
+  interpolate_boundary_values(
+    idealii::slab::DoFHandler<dim>                    &dof_handler,
+    const dealii::types::boundary_id                   boundary_component,
+    dealii::Function<dim, Number>                     &boundary_function,
+    std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints,
+    const dealii::ComponentMask                       &component_mask)
+  {
+    auto space_constraints =
+      std::make_shared<dealii::AffineConstraints<Number>>();
 
-        dealii::Quadrature<1> quad_time ( dof_handler.temporal ()->get_fe ( 0 ).get_unit_support_points () );
-        dealii::FEValues<1> fev (
-          dof_handler.temporal ()->get_fe ( 0 ) ,
-          quad_time ,
-          dealii::update_quadrature_points
-        );
+    dealii::Quadrature<1> quad_time(
+      dof_handler.temporal()->get_fe(0).get_unit_support_points());
+    dealii::FEValues<1> fev(dof_handler.temporal()->get_fe(0),
+                            quad_time,
+                            dealii::update_quadrature_points);
 
-        unsigned int n_space_dofs = dof_handler.n_dofs_space ();
-        unsigned int time_dof = 0;
-        std::vector<dealii::types::global_dof_index> local_indices ( dof_handler.dofs_per_cell_time () );
-        //loop over time cells instead
-        for ( const auto &cell_time : dof_handler.temporal ()->active_cell_iterators () )
-        {
-            fev.reinit ( cell_time );
+    unsigned int n_space_dofs = dof_handler.n_dofs_space();
+    unsigned int time_dof     = 0;
+    std::vector<dealii::types::global_dof_index> local_indices(
+      dof_handler.dofs_per_cell_time());
+    // loop over time cells instead
+    for (const auto &cell_time :
+         dof_handler.temporal()->active_cell_iterators())
+      {
+        fev.reinit(cell_time);
 
-            cell_time->get_dof_indices ( local_indices );
-            for ( unsigned int q = 0 ; q < quad_time.size () ; q++ )
-            {
-                space_constraints->clear ();
-                time_dof = local_indices[q];
-                boundary_function.set_time (
-                                             fev.quadrature_point ( q )[0] );
-                dealii::VectorTools::interpolate_boundary_values (
-                   *dof_handler.spatial () ,
-                   boundary_component ,
-                   boundary_function ,
-                   *space_constraints ,
-                   component_mask
-                );
+        cell_time->get_dof_indices(local_indices);
+        for (unsigned int q = 0; q < quad_time.size(); q++)
+          {
+            space_constraints->clear();
+            time_dof = local_indices[q];
+            boundary_function.set_time(fev.quadrature_point(q)[0]);
+            dealii::VectorTools::interpolate_boundary_values(
+              *dof_handler.spatial(),
+              boundary_component,
+              boundary_function,
+              *space_constraints,
+              component_mask);
 
-                for ( unsigned int i = 0 ; i < n_space_dofs ; i++ )
-                {
-                    //check if this is a constrained dof
-                    if ( space_constraints->is_constrained ( i ) )
-                    {
-                        const std::vector<std::pair<dealii::types::global_dof_index,double>> *entries
-                            = space_constraints->get_constraint_entries ( i );
+            for (unsigned int i = 0; i < n_space_dofs; i++)
+              {
+                // check if this is a constrained dof
+                if (space_constraints->is_constrained(i))
+                  {
+                    const std::vector<std::pair<dealii::types::global_dof_index,
+                                                double>> *entries =
+                      space_constraints->get_constraint_entries(i);
 
-                        spacetime_constraints->add_line ( i + time_dof * n_space_dofs );
-                        //non Dirichlet constraint
-                        if ( entries->size () > 0 )
-                        {
-                            for ( auto entry : *entries )
-                            {
-                                spacetime_constraints->add_entry ( i + time_dof * n_space_dofs ,
-                                                                   entry.first + time_dof * n_space_dofs ,
-                                                                   entry.second );
-                            }
-                        }
-                        else
-                        {
-                            spacetime_constraints->set_inhomogeneity ( i + time_dof * n_space_dofs ,
-                                                                       space_constraints->get_inhomogeneity ( i ) );
-                        }
-                    }
-                }
-            }
-        }
-    }
+                    spacetime_constraints->add_line(i +
+                                                    time_dof * n_space_dofs);
+                    // non Dirichlet constraint
+                    if (entries->size() > 0)
+                      {
+                        for (auto entry : *entries)
+                          {
+                            spacetime_constraints->add_entry(
+                              i + time_dof * n_space_dofs,
+                              entry.first + time_dof * n_space_dofs,
+                              entry.second);
+                          }
+                      }
+                    else
+                      {
+                        spacetime_constraints->set_inhomogeneity(
+                          i + time_dof * n_space_dofs,
+                          space_constraints->get_inhomogeneity(i));
+                      }
+                  }
+              }
+          }
+      }
+  }
 
-    template<int dim,typename Number>
-    void project_boundary_values_curl_conforming_l2 (
-            idealii::slab::DoFHandler<dim> &dof_handler ,
-            unsigned int first_vector_component ,
-            dealii::Function<dim,Number> &boundary_function ,
-            const dealii::types::boundary_id boundary_component ,
-            std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints )
-    {
-        auto space_constraints = std::make_shared<dealii::AffineConstraints<Number>> ();
+  template <int dim, typename Number>
+  void
+  project_boundary_values_curl_conforming_l2(
+    idealii::slab::DoFHandler<dim>                    &dof_handler,
+    unsigned int                                       first_vector_component,
+    dealii::Function<dim, Number>                     &boundary_function,
+    const dealii::types::boundary_id                   boundary_component,
+    std::shared_ptr<dealii::AffineConstraints<Number>> spacetime_constraints)
+  {
+    auto space_constraints =
+      std::make_shared<dealii::AffineConstraints<Number>>();
 
-        dealii::Quadrature<1> quad_time ( dof_handler.temporal ()->get_fe ( 0 ).get_unit_support_points () );
-        dealii::FEValues<1> fev (
-          dof_handler.temporal ()->get_fe ( 0 ) ,
-          quad_time ,
-          dealii::update_quadrature_points
-        );
+    dealii::Quadrature<1> quad_time(
+      dof_handler.temporal()->get_fe(0).get_unit_support_points());
+    dealii::FEValues<1> fev(dof_handler.temporal()->get_fe(0),
+                            quad_time,
+                            dealii::update_quadrature_points);
 
-        unsigned int n_space_dofs = dof_handler.n_dofs_space ();
-        unsigned int time_dof = 0;
-        std::vector<dealii::types::global_dof_index> local_indices ( dof_handler.dofs_per_cell_time () );
-        //loop over time cells instead
-        for ( const auto &cell_time : dof_handler.temporal ()->active_cell_iterators () )
-        {
-            fev.reinit ( cell_time );
+    unsigned int n_space_dofs = dof_handler.n_dofs_space();
+    unsigned int time_dof     = 0;
+    std::vector<dealii::types::global_dof_index> local_indices(
+      dof_handler.dofs_per_cell_time());
+    // loop over time cells instead
+    for (const auto &cell_time :
+         dof_handler.temporal()->active_cell_iterators())
+      {
+        fev.reinit(cell_time);
 
-            cell_time->get_dof_indices ( local_indices );
-            for ( unsigned int q = 0 ; q < quad_time.size () ; q++ )
-            {
-                space_constraints->clear ();
-                time_dof = local_indices[q];
-                boundary_function.set_time ( fev.quadrature_point ( q )[0] );
-                dealii::VectorTools::project_boundary_values_curl_conforming_l2 (
-                  *dof_handler.spatial () ,
-                  first_vector_component ,
-                  boundary_function ,
-                  boundary_component ,
-                  *space_constraints
-                );
+        cell_time->get_dof_indices(local_indices);
+        for (unsigned int q = 0; q < quad_time.size(); q++)
+          {
+            space_constraints->clear();
+            time_dof = local_indices[q];
+            boundary_function.set_time(fev.quadrature_point(q)[0]);
+            dealii::VectorTools::project_boundary_values_curl_conforming_l2(
+              *dof_handler.spatial(),
+              first_vector_component,
+              boundary_function,
+              boundary_component,
+              *space_constraints);
 
-                for ( unsigned int i = 0 ; i < n_space_dofs ; i++ )
-                {
-                    //check if this is a constrained dof
-                    if ( space_constraints->is_constrained ( i ) )
-                    {
-                        const std::vector<std::pair<dealii::types::global_dof_index,double>> *entries
-                            = space_constraints->get_constraint_entries ( i );
+            for (unsigned int i = 0; i < n_space_dofs; i++)
+              {
+                // check if this is a constrained dof
+                if (space_constraints->is_constrained(i))
+                  {
+                    const std::vector<std::pair<dealii::types::global_dof_index,
+                                                double>> *entries =
+                      space_constraints->get_constraint_entries(i);
 
-                        spacetime_constraints->add_line ( i + time_dof * n_space_dofs );
-                        //non Dirichlet constraint
-                        if ( entries->size () > 0 )
-                        {
-                            for ( auto entry : *entries )
-                            {
-                                spacetime_constraints->add_entry ( i + time_dof * n_space_dofs ,
-                                                                   entry.first + time_dof * n_space_dofs ,
-                                                                   entry.second );
-                            }
-                        }
-                        else
-                        {
-                            spacetime_constraints->set_inhomogeneity ( i + time_dof * n_space_dofs ,
-                                                                       space_constraints->get_inhomogeneity ( i ) );
-                        }
-                    }
-                }
-            }
-        }
-    }
+                    spacetime_constraints->add_line(i +
+                                                    time_dof * n_space_dofs);
+                    // non Dirichlet constraint
+                    if (entries->size() > 0)
+                      {
+                        for (auto entry : *entries)
+                          {
+                            spacetime_constraints->add_entry(
+                              i + time_dof * n_space_dofs,
+                              entry.first + time_dof * n_space_dofs,
+                              entry.second);
+                          }
+                      }
+                    else
+                      {
+                        spacetime_constraints->set_inhomogeneity(
+                          i + time_dof * n_space_dofs,
+                          space_constraints->get_inhomogeneity(i));
+                      }
+                  }
+              }
+          }
+      }
+  }
 
-    template<int dim>
-    double calculate_L2L2_squared_error_on_slab (
-                                                  slab::DoFHandler<dim> &dof_handler ,
-                                                  dealii::Vector<double> &spacetime_vector ,
-                                                  dealii::Function<dim,double> &exact_solution ,
-                                                  spacetime::Quadrature<dim> &quad )
-    {
-        //Note: Possibly not working correctly?
-        double slab_norm_sqr = 0.;
-        dealii::FEValues<1> fev_time ( dof_handler.temporal ()->get_fe () ,
-                                       *quad.temporal () ,
-                                       dealii::update_values |
-                                       dealii::update_JxW_values |
-                                       dealii::update_quadrature_points );
+  template <int dim>
+  double
+  calculate_L2L2_squared_error_on_slab(
+    slab::DoFHandler<dim>         &dof_handler,
+    dealii::Vector<double>        &spacetime_vector,
+    dealii::Function<dim, double> &exact_solution,
+    spacetime::Quadrature<dim>    &quad)
+  {
+    //Note: Possibly not working correctly?
+    double              slab_norm_sqr = 0.;
+    dealii::FEValues<1> fev_time(dof_handler.temporal()->get_fe(),
+                                 *quad.temporal(),
+                                 dealii::update_values |
+                                   dealii::update_JxW_values |
+                                   dealii::update_quadrature_points);
 
-        dealii::Vector<double> space_vec;
-        dealii::Vector<double> difference_per_cell;
-        space_vec.reinit ( dof_handler.n_dofs_space () );
-        difference_per_cell.reinit ( dof_handler.n_dofs_space () );
-        std::vector<dealii::Point<1,double>> q_points;
-        double t = 0;
-        unsigned int offset = 0;
-        unsigned int n_dofs_space = dof_handler.n_dofs_space ();
-        for ( auto cell_time : dof_handler.temporal ()->active_cell_iterators () )
-        {
-            offset = cell_time->index ()
-                   * dof_handler.dofs_per_cell_time ()
-                   * n_dofs_space;
+    dealii::Vector<double> space_vec;
+    dealii::Vector<double> difference_per_cell;
+    space_vec.reinit(dof_handler.n_dofs_space());
+    difference_per_cell.reinit(dof_handler.n_dofs_space());
+    std::vector<dealii::Point<1, double>> q_points;
+    double                                t      = 0;
+    unsigned int                          offset = 0;
+    unsigned int n_dofs_space                    = dof_handler.n_dofs_space();
+    for (auto cell_time : dof_handler.temporal()->active_cell_iterators())
+      {
+        offset =
+          cell_time->index() * dof_handler.dofs_per_cell_time() * n_dofs_space;
 
-            fev_time.reinit ( cell_time );
-            for ( unsigned int q = 0 ;
-                    q < fev_time.n_quadrature_points ; q++ )
-            {
-                t = fev_time.quadrature_point ( q )[0];
-                exact_solution.set_time ( t );
-                //calculate spatial vector at t
-                space_vec = 0;
-                for ( unsigned int ii = 0 ; ii < dof_handler.dofs_per_cell_time () ; ii++ )
-                {
-                    double factor = fev_time.shape_value ( ii , q );
-                    for ( unsigned int i = 0 ; i < n_dofs_space ; i++ )
-                    {
-                        space_vec[i] += spacetime_vector[i + ii * n_dofs_space + offset] * factor;
-                    }
-                }
-                //calculate L2 norm at current temporal QP
-                difference_per_cell = 0;
-                dealii::VectorTools::integrate_difference (
-                    *dof_handler.spatial () ,
-                    space_vec ,
-                    exact_solution ,
-                    difference_per_cell ,
-                    *quad.spatial () ,
-                    dealii::VectorTools::L2_norm );
+        fev_time.reinit(cell_time);
+        for (unsigned int q = 0; q < fev_time.n_quadrature_points; q++)
+          {
+            t = fev_time.quadrature_point(q)[0];
+            exact_solution.set_time(t);
+            // calculate spatial vector at t
+            space_vec = 0;
+            for (unsigned int ii = 0; ii < dof_handler.dofs_per_cell_time();
+                 ii++)
+              {
+                double factor = fev_time.shape_value(ii, q);
+                for (unsigned int i = 0; i < n_dofs_space; i++)
+                  {
+                    space_vec[i] +=
+                      spacetime_vector[i + ii * n_dofs_space + offset] * factor;
+                  }
+              }
+            // calculate L2 norm at current temporal QP
+            difference_per_cell = 0;
+            dealii::VectorTools::integrate_difference(
+              *dof_handler.spatial(),
+              space_vec,
+              exact_solution,
+              difference_per_cell,
+              *quad.spatial(),
+              dealii::VectorTools::L2_norm);
 
-                slab_norm_sqr += difference_per_cell.norm_sqr ()
-                                 * fev_time.JxW ( q );
-            }
-        }
-        return slab_norm_sqr;
-    }
+            slab_norm_sqr += difference_per_cell.norm_sqr() * fev_time.JxW(q);
+          }
+      }
+    return slab_norm_sqr;
+  }
 
-}
+} // namespace idealii::slab::VectorTools
 
 #include "vector_tools.inst"
-

--- a/src/numerics/vector_tools.inst
+++ b/src/numerics/vector_tools.inst
@@ -18,51 +18,51 @@
 
 namespace idealii::slab::VectorTools
 {
-    template void
-    interpolate_boundary_values (
-      idealii::slab::DoFHandler<2> &dof_handler ,
-      const dealii::types::boundary_id boundary_component ,
-      dealii::Function<2,double> &boundary_function ,
-      std::shared_ptr<dealii::AffineConstraints<double>> spacetime_constraints ,
-      const dealii::ComponentMask &component_mask = dealii::ComponentMask () );
+  template void
+  interpolate_boundary_values(
+    idealii::slab::DoFHandler<2>                      &dof_handler,
+    const dealii::types::boundary_id                   boundary_component,
+    dealii::Function<2, double>                       &boundary_function,
+    std::shared_ptr<dealii::AffineConstraints<double>> spacetime_constraints,
+    const dealii::ComponentMask &component_mask = dealii::ComponentMask());
 
-    template void
-    interpolate_boundary_values (
-      idealii::slab::DoFHandler<3> &dof_handler ,
-      const dealii::types::boundary_id boundary_component ,
-      dealii::Function<3,double> &boundary_function ,
-      std::shared_ptr<dealii::AffineConstraints<double>> spacetime_constraints ,
-      const dealii::ComponentMask &component_mask = dealii::ComponentMask () );
+  template void
+  interpolate_boundary_values(
+    idealii::slab::DoFHandler<3>                      &dof_handler,
+    const dealii::types::boundary_id                   boundary_component,
+    dealii::Function<3, double>                       &boundary_function,
+    std::shared_ptr<dealii::AffineConstraints<double>> spacetime_constraints,
+    const dealii::ComponentMask &component_mask = dealii::ComponentMask());
 
-    template void
-    project_boundary_values_curl_conforming_l2 (
-        idealii::slab::DoFHandler<2> &dof_handler ,
-        unsigned int first_vector_component ,
-        dealii::Function<2,double> &boundary_function ,
-        const dealii::types::boundary_id boundary_component ,
-        std::shared_ptr<dealii::AffineConstraints<double>> spacetime_constraints );
+  template void
+  project_boundary_values_curl_conforming_l2(
+    idealii::slab::DoFHandler<2>                      &dof_handler,
+    unsigned int                                       first_vector_component,
+    dealii::Function<2, double>                       &boundary_function,
+    const dealii::types::boundary_id                   boundary_component,
+    std::shared_ptr<dealii::AffineConstraints<double>> spacetime_constraints);
 
-    template void
-    project_boundary_values_curl_conforming_l2 (
-        idealii::slab::DoFHandler<3> &dof_handler ,
-        unsigned int first_vector_component ,
-        dealii::Function<3,double> &boundary_function ,
-        const dealii::types::boundary_id boundary_component ,
-        std::shared_ptr<dealii::AffineConstraints<double>> spacetime_constraints );
+  template void
+  project_boundary_values_curl_conforming_l2(
+    idealii::slab::DoFHandler<3>                      &dof_handler,
+    unsigned int                                       first_vector_component,
+    dealii::Function<3, double>                       &boundary_function,
+    const dealii::types::boundary_id                   boundary_component,
+    std::shared_ptr<dealii::AffineConstraints<double>> spacetime_constraints);
 
-    template double
-    calculate_L2L2_squared_error_on_slab<2> (
-      slab::DoFHandler<2> &dof_handler ,
-      dealii::Vector<double> &spacetime_vector ,
-      dealii::Function<2,double> &exact_solution ,
-      spacetime::Quadrature<2> &quad );
+  template double
+  calculate_L2L2_squared_error_on_slab<2>(
+    slab::DoFHandler<2>         &dof_handler,
+    dealii::Vector<double>      &spacetime_vector,
+    dealii::Function<2, double> &exact_solution,
+    spacetime::Quadrature<2>    &quad);
 
-    template double
-    calculate_L2L2_squared_error_on_slab<3> (
-      slab::DoFHandler<3> &dof_handler ,
-      dealii::Vector<double> &spacetime_vector ,
-      dealii::Function<3,double> &exact_solution ,
-      spacetime::Quadrature<3> &quad );
-}
+  template double
+  calculate_L2L2_squared_error_on_slab<3>(
+    slab::DoFHandler<3>         &dof_handler,
+    dealii::Vector<double>      &spacetime_vector,
+    dealii::Function<3, double> &exact_solution,
+    spacetime::Quadrature<3>    &quad);
+} // namespace idealii::slab::VectorTools
 
 #endif


### PR DESCRIPTION
This adds the `.clang-format` specification file together with an indent GitHub Action to check format misses.
The specification was also applied to all existing C++ source files.