### PR TITLE
Fix indentation errors on closing brackets

### DIFF
--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -475,7 +475,8 @@ Step1::assemble_system_on_slab()
                     right_hand_side.value(x_q) * fe_values_spacetime.JxW(q);
 
                 } // dofs i
-            }     // quad
+
+            } // quad
 
           // Jump terms and initial values just have a spatial quadrature loop
           for (unsigned int q = 0; q < n_quad_space; ++q)

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -449,8 +449,10 @@ Step2::assemble_system_on_slab()
                         fe_values_spacetime.JxW(q);
 
                     } // dofs j
-                }     // dofs i
-            }         // quad
+
+                } // dofs i
+
+            } // quad
 
           // Jump terms and initial values just have a spatial loop
           // Only the velocity has a temporal derivative, so we don't need

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -434,7 +434,8 @@ Step3::assemble_system_on_slab()
                         right_hand_side.value(x_q) * fe_values_spacetime.JxW(q);
 
                     } // dofs i
-                }     // quad
+
+                } // quad
 
               // Jump terms and initial values just have a spatial loop
               for (unsigned int q = 0; q < n_quad_space; ++q)

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -543,8 +543,10 @@ Step4::assemble_system_on_slab()
                             fe_values_spacetime.JxW(q);
 
                         } // dofs j
-                    }     // dofs i
-                }         // quad
+
+                    } // dofs i
+
+                } // quad
 
               for (unsigned int q = 0; q < n_quad_space; ++q)
                 {
@@ -576,7 +578,8 @@ Step4::assemble_system_on_slab()
                                 fe_jump_values_spacetime.JxW(q);
                             }
                         } // dofs j
-                    }     // dofs i
+
+                    } // dofs i
                 }
 
             } // cell time
@@ -732,7 +735,8 @@ Step4::assemble_residual_on_slab()
                         div_v * fe_values_spacetime.JxW(q);
 
                     } // dofs i
-                }     // quad
+
+                } // quad
 
               fe_jump_values_spacetime.get_function_values_plus(
                 *slab_its.solution, old_solution_plus);
@@ -765,7 +769,8 @@ Step4::assemble_residual_on_slab()
                         v_minus * fe_jump_values_spacetime.JxW(q);
 
                     } // dofs i
-                }     // quad_space
+
+                } // quad_space
               if (n < N - 1)
                 {
                   fe_jump_values_spacetime.get_function_values_minus(

--- a/include/ideal.II/base/idealii.hh
+++ b/include/ideal.II/base/idealii.hh
@@ -108,7 +108,10 @@ namespace idealii
         namespace fixed
         {}
       } // namespace distributed
-    }   // namespace parallel
-  }     // namespace spacetime
+
+    } // namespace parallel
+
+  } // namespace spacetime
+
 } // namespace idealii
 #endif /* INCLUDE_IDEAL_II_BASE_IDEALII1_HH_ */


### PR DESCRIPTION
Behaviour for clang-format for examples like

```
  }  //dofs
}  // quad
``` 
is ill defined and produces 
```
  } //dofs
}   //quad
```
on some machines.

An additional empty line fixes this.