### PR TITLE
Fix type in Triangulation constructors

### DIFF
--- a/include/ideal.II/distributed/fixed_tria.hh
+++ b/include/ideal.II/distributed/fixed_tria.hh
@@ -39,7 +39,8 @@ namespace idealii::spacetime::parallel::distributed::fixed
      * @brief Constructor that initializes the underlying list object.
      * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
      */
-    Triangulation(unsigned int max_N_intervals_per_slab = 0);
+    Triangulation(
+      dealii::types::global_cell_index max_N_intervals_per_slab = 0);
 
     /**
      * @brief Generate a list of M slab triangulations with matching temporal meshes pointing to the same

--- a/include/ideal.II/grid/fixed_tria.hh
+++ b/include/ideal.II/grid/fixed_tria.hh
@@ -37,7 +37,8 @@ namespace idealii::spacetime::fixed
      * @brief Constructor that initializes the underlying list object.
      * @param max_N_intervals_per_slab. When to split a slab into two. (default 0 = never)
      */
-    Triangulation(unsigned int max_N_intervals_per_slab = 0);
+    Triangulation(
+      dealii::types::global_cell_index max_N_intervals_per_slab = 0);
 
     /**
      * @brief Generate a list of M slab triangulations with matching temporal meshes pointing to the same


### PR DESCRIPTION
The type was `dealii::types::global_cell_index` in the declaration but `unsigned int` in the definition
leading to type errors for 64Bit deal.II