### PR TITLE
[CI] build documentation on PR

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,9 @@ name: Documentation
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
     
 permissions:
   contents: read
@@ -36,6 +39,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --target sphinx
 
     - name: Deploy to GitHub Pages
+      if: ${{ github.event_name == 'push' }}
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This makes the documentation build on pull requests as well, but only deploys the documentation itself on pushes to main